### PR TITLE
Speed up travis CI jobs by caching pip-installed packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ install:
 - make install
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py
 - pip install --user -r $PYTHONPATH/requirements-travis.txt
-- ls -l $HOME/.cache/pip
-- ls -l $HOME/.local/lib/python2.7/site-packages
 script:
 - bin/frameReceiverTest --log_level=all
 - bin/frameProcessorTest --log_level=all

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     cache:
       directories:
       - "$HOME/hdf5-1.8.16"
+      - "$HOME/.cache/pip"
 install:
 - mkdir -p build
 - mkdir -p $INSTALL_PREFIX

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 - make install
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py
 - pip install --user -r $PYTHONPATH/requirements-travis.txt
+- ls -l $HOME/.cache/pip
 script:
 - bin/frameReceiverTest --log_level=all
 - bin/frameProcessorTest --log_level=all

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       directories:
       - "$HOME/hdf5-1.8.16"
       - "$HOME/.cache/pip"
+      - "$HOME/.local/lib"
 install:
 - mkdir -p build
 - mkdir -p $INSTALL_PREFIX
@@ -33,6 +34,7 @@ install:
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py
 - pip install --user -r $PYTHONPATH/requirements-travis.txt
 - ls -l $HOME/.cache/pip
+- ls -l $HOME/.local/lib/python2.7/site-packages
 script:
 - bin/frameReceiverTest --log_level=all
 - bin/frameProcessorTest --log_level=all


### PR DESCRIPTION
Travis jobs for this repo currently take on average 16 minutes to complete. This is dominated by the time taken to build and install various pip packages (notably h5py and numpy). These are NOT needed for the core tests, but only for ancillary python scripts used to run e.g. integration tests. This PR explicitly adds $HOME/.cache/pip and $HOME/.local/lib to the travis build cache to allow the pip step to be avoided when the cached package versions are valid and match the specified requirements file. This reduces the build time to O(2 mins). Since the package versions are explicit, over-aggressive caching of old package versions is unlikely to be an issue and could be managed by manually deleting the travis cache from the web UI.

Closes #34 