### PR TITLE
Updated FileWriterPlugin to be able to write single 1D datasets.

### DIFF
--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -127,6 +127,9 @@ public:
   void clearHdfErrors();
   std::string getCreateMetaHeader();
   std::string getMetaHeader();
+  void stopAcquisition();
+  void startCloseFileTimeout();
+  void runCloseFileTimeout();
 
 private:
   /** Configuration constant for process related items */
@@ -168,6 +171,10 @@ private:
   static const std::string CONFIG_OFFSET_ADJUSTMENT;
   /** Configuration constant for the acquisition id */
   static const std::string ACQUISITION_ID;
+  /** Configuration constant for the close file timeout */
+  static const std::string CLOSE_TIMEOUT_PERIOD;
+  /** Configuration constant for starting the close file timeout */
+  static const std::string START_CLOSE_TIMEOUT;
 
   /** Filter definition to write datasets with LZ4 compressed data */
   static const H5Z_filter_t LZ4_FILTER = (H5Z_filter_t)32004;
@@ -198,6 +205,8 @@ private:
   bool writing_;
   /** Number of frames that have been written to file */
   size_t framesWritten_;
+  /** Number of frames that have been processed */
+  size_t framesProcessed_;
   /** Number of concurrent file writers executing */
   size_t concurrent_processes_;
   /** Rank of this file writer */
@@ -216,6 +225,22 @@ private:
   Acquisition currentAcquisition_;
   /** Details of the next acquisition to be written */
   Acquisition nextAcquisition_;
+  /** Timeout for closing the file after receiving no data */
+  size_t timeoutPeriod;
+  /** Mutex used to make starting the close file timeout thread safe */
+  boost::mutex m_startTimeoutMutex;
+  /** Mutex used to make running the close file timeout thread safe */
+  boost::mutex m_closeFileMutex;
+  /** Condition variable used to start the close file timeout */
+  boost::condition_variable m_startCondition;
+  /** Condition variable used to run the close file timeout */
+  boost::condition_variable m_timeoutCondition;
+  /** Close file timeout active switch */
+  bool timeoutActive;
+  /** Close file timeout thread running */
+  bool timeoutThreadRunning;
+  /** The close file timeout thread */
+  boost::thread timeoutThread;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -37,6 +37,7 @@ public:
 
   void connectMetaChannel();
   void publishMeta(const std::string& item, int32_t value, const std::string& header = "");
+  void publishMeta(const std::string& item, uint64_t value, const std::string &header = "");
   void publishMeta(const std::string& item, double value, const std::string& header = "");
   void publishMeta(const std::string& item, const std::string& value, const std::string& header = "");
   void publishMeta(const std::string& item, const void *pValue, size_t length, const std::string& header = "");

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -895,9 +895,9 @@ void FileWriterPlugin::configureDataset(OdinData::IpcMessage& config, OdinData::
         }
         dset_def.frame_dimensions = dims;
       } else {
-    	  // This is a single dimensioned dataset so store dimensions as NULL
-          dimensions_t dims(0);
-    	  dset_def.frame_dimensions = dims;
+        // This is a single dimensioned dataset so store dimensions as NULL
+        dimensions_t dims(0);
+        dset_def.frame_dimensions = dims;
       }
 
       // There might be chunking dimensions present for the dataset, this is not required

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -272,13 +272,11 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
   std::vector<hsize_t> dset_dims(1,1);
   dset_dims.insert(dset_dims.end(), frame_dims.begin(), frame_dims.end());
 
-  // If chunking has not been defined it defaults to a single full frame
-  std::vector<hsize_t> chunk_dims(1, 1);
-  if (definition.chunks.size() != dset_dims.size()) {
-    chunk_dims = dset_dims;
-  } else {
-    chunk_dims = definition.chunks;
+  // If chunking has not been defined then throw an error
+  if (definition.chunks.size() != dset_dims.size()){
+    throw std::runtime_error("Dataset chunk size not defined correctly");
   }
+  std::vector<hsize_t> chunk_dims = definition.chunks;
 
   std::vector<hsize_t> max_dims = dset_dims;
   max_dims[0] = H5S_UNLIMITED;

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -106,6 +106,8 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
            "Set the number of frames to write into dataset")
         ("acqid",         po::value<std::string>()->default_value(""),
            "Set the Acquisition Id of the acquisition")
+        ("timeout",       po::value<size_t>()->default_value(0),
+           "Set the timeout period for closing the file (milliseconds)")
     ;
 
     // Group the variables for parsing at the command line and/or from the configuration file
@@ -266,6 +268,11 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
       LOG4CXX_DEBUG(logger, "Setting acquisition ID to " << vm["acqid"].as<string>());
     }
 
+    if (no_client && vm.count("timeout"))
+    {
+      LOG4CXX_DEBUG(logger, "Setting close file timeout period to " << vm["timeout"].as<size_t>());
+    }
+
   }
   catch (po::unknown_option &e)
   {
@@ -392,6 +399,7 @@ void configureFileWriter(boost::shared_ptr<FrameProcessorController> fwc, po::va
   cfg.set_param<string>("hdf/file/path", vm["output-dir"].as<string>());
   cfg.set_param<unsigned int>("hdf/frames", vm["frames"].as<unsigned int>());
   cfg.set_param<string>("hdf/acquisition_id", vm["acqid"].as<string>());
+  cfg.set_param<size_t>("hdf/timeout_timer_period", vm["timeout"].as<size_t>());
   cfg.set_param<bool>("hdf/write", true);
 
   fwc->configure(cfg, reply);

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -171,6 +171,16 @@ void FrameProcessorPlugin::publishMeta(const std::string& item, int32_t value, c
   metaChannel_.send(sizeof(uintptr_t), &addr, ZMQ_DONTWAIT);
 }
 
+void FrameProcessorPlugin::publishMeta(const std::string& item, uint64_t value, const std::string &header)
+{
+  // Create a new MetaMessage object and send to the consumer
+  FrameProcessor::MetaMessage *meta = new FrameProcessor::MetaMessage(name_, item, "uint64", header, sizeof(uint64_t), &value);
+  // We need the pointer to the object cast to be able to pass it through ZMQ
+  uintptr_t addr = reinterpret_cast<uintptr_t>(&(*meta));
+  // Send the pointer value to the listener
+  metaChannel_.send(sizeof(uintptr_t), &addr, ZMQ_DONTWAIT);
+}
+
 void FrameProcessorPlugin::publishMeta(const std::string& item, double value, const std::string& header)
 {
   // Create a new MetaMessage object and send to the consumer

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -151,6 +151,7 @@ public:
                                 5, 6, 7, 8,
                                 9,10,11,12 };
     dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
+    dimensions_t chunk_dims(3); chunk_dims[0] = 1; chunk_dims[1] = 3; chunk_dims[2] = 4;
     //PercivalEmulator::FrameHeader img_header;
     //img_header.frame_number = 7;
 
@@ -160,6 +161,7 @@ public:
     dset_def.frame_dimensions = dimensions_t(2);
     dset_def.frame_dimensions[0] = 3;
     dset_def.frame_dimensions[1] = 4;
+    dset_def.chunks = chunk_dims;
 
     frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame("data"));
     frame->set_frame_number(7);

--- a/tools/python/odin_data/ipc_client.py
+++ b/tools/python/odin_data/ipc_client.py
@@ -20,7 +20,7 @@ class IpcClient(object):
         self.ctrl_endpoint = self.ENDPOINT_TEMPLATE.format(
             IP=ip_address, PORT=port)
         self.logger.debug("Connecting to client at %s", self.ctrl_endpoint)
-        self.ctrl_channel = IpcChannel(IpcChannel.CHANNEL_TYPE_REQ)
+        self.ctrl_channel = IpcChannel(IpcChannel.CHANNEL_TYPE_DEALER)
         self.ctrl_channel.connect(self.ctrl_endpoint)
 
         self._lock = RLock()

--- a/tools/python/odin_data/logconfig.py
+++ b/tools/python/odin_data/logconfig.py
@@ -20,7 +20,7 @@ default_config = {
             "format": "%(message)s"
         },
         "extended": {
-            "format": "%(asctime)s - %(name)20s - %(levelname)6s - %(message)s"
+            "format": "%(asctime)s - %(name)20s - %(levelname)7s - %(message)s"
         },
         "json": {
             "format": "name: %(name)s, level: %(levelname)s, time: %(asctime)s, message: %(message)s"
@@ -31,7 +31,7 @@ default_config = {
         "console": {
             "class": "logging.StreamHandler",
             "level": "DEBUG",
-            "formatter": "simple",
+            "formatter": "extended",
             "stream": "ext://sys.stdout"
         }
     },


### PR DESCRIPTION
Specifically:
1) Dataset is extended by the outer chunk dimension instead of 1.
2) Offset is calculated taking into account the outer chunk dimension.
3) Dataset dimensions do not need to be defined, this will now not throw.
4) If no dataset dimensions are defined then this is a 1D dataset.
5) Updated some log messages that were expecting 3D datasets.