### PR TITLE
Generic updates (part 2)

### DIFF
--- a/common/include/CMakeLists.txt
+++ b/common/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Install header files into installation prefix
 
-SET(HEADERS ClassLoader.h gettime.h IpcChannel.h IpcMessage.h IpcReactor.h OdinDataException.h SharedBufferManager.h)
+SET(HEADERS ClassLoader.h gettime.h IpcChannel.h IpcMessage.h IpcReactor.h logging.h OdinDataException.h SharedBufferManager.h)
 SET(RAPIDJSON_INCLUDE_DIR rapidjson)
 SET(ZMQ_INCLUDE_DIR zmq)
 

--- a/common/include/logging.h
+++ b/common/include/logging.h
@@ -1,0 +1,20 @@
+#ifndef ODINDATA_LOGGING_H
+#define ODINDATA_LOGGING_H
+
+#include <string>
+
+namespace OdinData
+{
+
+extern std::string app_path;
+
+/** Configure logging constants
+ *
+ * Call this only once per thread context.
+ *
+ * @param app_path Path to executable (use argv[0])
+ */
+void configure_logging_mdc(const char* app_path);
+
+}
+#endif //ODINDATA_LOGGING_H

--- a/common/src/CMakeLists.txt
+++ b/common/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Add library for odin-data shared functionality
-include_directories(${Boost_INCLUDE_DIRS} ${ZEROMQ_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS} ${ZEROMQ_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/..)
 
 file(GLOB LIB_SOURCES *.cpp)
 

--- a/common/src/logging.cpp
+++ b/common/src/logging.cpp
@@ -3,6 +3,7 @@
 
 #include <pwd.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <log4cxx/basicconfigurator.h>
 #include <log4cxx/propertyconfigurator.h>

--- a/common/src/logging.cpp
+++ b/common/src/logging.cpp
@@ -1,0 +1,59 @@
+#ifndef ODINDATA_LOGGING_H
+#define ODINDATA_LOGGING_H
+
+#include <pwd.h>
+#include <string.h>
+
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+#include <log4cxx/xml/domconfigurator.h>
+#include <log4cxx/mdc.h>
+
+#include "logging.h"
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+namespace OdinData {
+
+std::string app_path = "";
+
+/** Configure logging constants
+ *
+ * Call this only once per thread context.
+ *
+ * @param app_path Path to executable (use argv[0])
+ */
+void configure_logging_mdc(const char *app_path) {
+  char hostname[HOST_NAME_MAX];
+  ::gethostname(hostname, HOST_NAME_MAX);
+  hostname[HOST_NAME_MAX - 1] = '\0';
+  MDC::put("host", hostname);
+
+  std::stringstream ss;
+  ss << ::getpid();
+  MDC::put("pid", ss.str());
+
+  const char *app_name = strrchr(app_path, static_cast<int>('/'));
+  if (app_name != NULL) {
+    MDC::put("app", app_name + 1);
+  } else {
+    MDC::put("app", app_path);
+  }
+
+  char thread_name[256];
+  thread_name[0] = '\0';
+  thread_name[256 - 1] = '\0';
+  ::pthread_getname_np(::pthread_self(), thread_name, 256);
+  MDC::put("thread", thread_name);
+
+  uid_t uid = ::geteuid();
+  struct passwd *pw = ::getpwuid(uid);
+  if (pw) {
+    MDC::put("user", pw->pw_name);
+  }
+}
+
+}
+#endif //ODINDATA_LOGGING_H

--- a/config/fr_log4cxx.xml
+++ b/config/fr_log4cxx.xml
@@ -37,7 +37,7 @@
  <logger name="FR">
   <priority value="all" />
  </logger>
- <logger name="FR.APP">
+ <logger name="FR.App">
   <appender-ref ref="FrameReceiverAppender" />
  </logger>
  <logger name="FR.PacketLogger" additivity="false">

--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -11,6 +11,7 @@
 #include <boost/shared_ptr.hpp>
 #include <log4cxx/logger.h>
 
+#include "logging.h"
 #include "IpcReactor.h"
 #include "IpcChannel.h"
 #include "SharedMemoryController.h"

--- a/frameProcessor/src/DataBlock.cpp
+++ b/frameProcessor/src/DataBlock.cpp
@@ -18,7 +18,7 @@ int DataBlock::indexCounter_ = 0;
  * \param[in] nbytes - number of bytes to allocate.
  */
 DataBlock::DataBlock(size_t nbytes) :
-    logger_(log4cxx::Logger::getLogger("FW.DataBlock")),
+    logger_(log4cxx::Logger::getLogger("FP.DataBlock")),
     allocatedBytes_(nbytes)
 {
   LOG4CXX_DEBUG(logger_, "Constructing DataBlock, allocating " << nbytes << " bytes");

--- a/frameProcessor/src/DataBlockPool.cpp
+++ b/frameProcessor/src/DataBlockPool.cpp
@@ -133,7 +133,7 @@ DataBlockPool::DataBlockPool() :
     usedBlocks_(0),
     totalBlocks_(0),
     memoryAllocated_(0),
-    logger_(log4cxx::Logger::getLogger("FW.DataBlockPool"))
+    logger_(log4cxx::Logger::getLogger("FP.DataBlockPool"))
 {
 }
 

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -65,7 +65,7 @@ FileWriterPlugin::FileWriterPlugin() :
     hdf5ErrorFlag_(false),
     frame_offset_adjustment_(0)
 {
-  this->logger_ = Logger::getLogger("FW.FileWriterPlugin");
+  this->logger_ = Logger::getLogger("FP.FileWriterPlugin");
   this->logger_->setLevel(Level::getTrace());
   LOG4CXX_TRACE(logger_, "FileWriterPlugin constructor.");
 

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -277,7 +277,7 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
   ensureH5result(dataspace, "H5Screate_simple failed to create the dataspace");
 
   /* Enable chunking  */
-  LOG4CXX_DEBUG(logger_, "Chunking=" << chunk_dims[0] << ","
+  LOG4CXX_INFO(logger_, "Chunking=" << chunk_dims[0] << ","
                                      << chunk_dims[1] << ","
                                      << chunk_dims[2]);
   prop = H5Pcreate(H5P_DATASET_CREATE);
@@ -285,10 +285,10 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
 
   /* Enable defined compression mode */
   if (definition.compression == no_compression) {
-    LOG4CXX_DEBUG(logger_, "Compression type: None");
+    LOG4CXX_INFO(logger_, "Compression type: None");
   }
   else if (definition.compression == lz4){
-    LOG4CXX_DEBUG(logger_, "Compression type: LZ4");
+    LOG4CXX_INFO(logger_, "Compression type: LZ4");
     // Create cd_values for filter to set the LZ4 compression level
     unsigned int cd_values = 3;
     size_t cd_values_length = 1;
@@ -296,7 +296,7 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
                            cd_values_length, &cd_values), "H5Pset_filter failed to set the LZ4 filter");
   }
   else if (definition.compression == bslz4) {
-    LOG4CXX_DEBUG(logger_, "Compression type: BSLZ4");
+    LOG4CXX_INFO(logger_, "Compression type: BSLZ4");
     // Create cd_values for filter to set default block size and to enable LZ4
     unsigned int cd_values[2] = {0, 2};
     size_t cd_values_length = 2;
@@ -313,7 +313,7 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
   ensureH5result(dapl, "H5Pcreate failed to create the dataset access property list");
 
   /* Create dataset  */
-  LOG4CXX_DEBUG(logger_, "Creating dataset: " << definition.name);
+  LOG4CXX_INFO(logger_, "Creating dataset: " << definition.name);
   FileWriterPlugin::HDF5Dataset_t dset;
   dset.datasetid = H5Dcreate2(this->hdf5_fileid_, definition.name.c_str(),
                               dtype, dataspace,
@@ -340,7 +340,7 @@ void FileWriterPlugin::createDataset(const FileWriterPlugin::DatasetDefinition& 
  * Close the currently open HDF5 file.
  */
 void FileWriterPlugin::closeFile() {
-  LOG4CXX_TRACE(logger_, "Closing file " << this->currentAcquisition_.filePath_ << "/" << this->currentAcquisition_.fileName_);
+  LOG4CXX_INFO(logger_, "Closing file " << this->currentAcquisition_.filePath_ << "/" << this->currentAcquisition_.fileName_);
   if (this->hdf5_fileid_ >= 0) {
     ensureH5result(H5Fclose(this->hdf5_fileid_), "H5Fclose failed to close the file");
     this->hdf5_fileid_ = 0;
@@ -686,7 +686,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
   // Protect this method
   boost::lock_guard<boost::recursive_mutex> lock(mutex_);
 
-  LOG4CXX_DEBUG(logger_, config.encode());
+  LOG4CXX_INFO(logger_, config.encode());
 
   // Check to see if we are configuring the process number and rank
   if (config.has_param(FileWriterPlugin::CONFIG_PROCESS)) {
@@ -714,7 +714,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
     if (totalFrames % this->concurrent_processes_ > this->concurrent_rank_) {
       nextAcquisition_.framesToWrite_++;
     }
-    LOG4CXX_DEBUG(logger_, "Expecting " << nextAcquisition_.framesToWrite_ << " frames "
+    LOG4CXX_INFO(logger_, "Expecting " << nextAcquisition_.framesToWrite_ << " frames "
                            "(total " << totalFrames << ")");
   }
 
@@ -725,7 +725,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
 
   // Check if we are setting the frame offset adjustment
   if (config.has_param(FileWriterPlugin::CONFIG_OFFSET_ADJUSTMENT)) {
-    LOG4CXX_DEBUG(logger_, "Setting frame offset adjustment to "
+    LOG4CXX_INFO(logger_, "Setting frame offset adjustment to "
                            << config.get_param<int>(FileWriterPlugin::CONFIG_OFFSET_ADJUSTMENT));
     frame_offset_adjustment_ = (size_t)config.get_param<int>(FileWriterPlugin::CONFIG_OFFSET_ADJUSTMENT);
   }
@@ -733,7 +733,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
   // Check to see if the acquisition id is being set
   if (config.has_param(FileWriterPlugin::ACQUISITION_ID)) {
     nextAcquisition_.acquisitionID_ = config.get_param<std::string>(FileWriterPlugin::ACQUISITION_ID);
-	LOG4CXX_DEBUG(logger_, "Setting next Acquisition ID to " << nextAcquisition_.acquisitionID_);
+	LOG4CXX_INFO(logger_, "Setting next Acquisition ID to " << nextAcquisition_.acquisitionID_);
   }
 
   // Final check is to start or stop writing
@@ -902,13 +902,13 @@ void FileWriterPlugin::configureDataset(OdinData::IpcMessage& config, OdinData::
       // Check if compression has been specified for the raw data
       if (config.has_param(FileWriterPlugin::CONFIG_DATASET_COMPRESSION)) {
         dset_def.compression = (FileWriterPlugin::CompressionType)config.get_param<int>(FileWriterPlugin::CONFIG_DATASET_COMPRESSION);
-        LOG4CXX_DEBUG(logger_, "Enabling compression: " << dset_def.compression);
+        LOG4CXX_INFO(logger_, "Enabling compression: " << dset_def.compression);
       }
       else {
         dset_def.compression = no_compression;
       }
 
-      LOG4CXX_DEBUG(logger_, "Creating dataset [" << dset_def.name << "] (" << dset_def.frame_dimensions[0] << ", " << dset_def.frame_dimensions[1] << ")");
+      LOG4CXX_INFO(logger_, "Creating dataset [" << dset_def.name << "] (" << dset_def.frame_dimensions[0] << ", " << dset_def.frame_dimensions[1] << ")");
       // Add the dataset definition to the store
       this->nextAcquisition_.dataset_defs_[dset_def.name] = dset_def;
     }

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -31,6 +31,7 @@ namespace po = boost::program_options;
 #include "rapidjson/prettywriter.h"
 using namespace rapidjson;
 
+#include "logging.h"
 #include "FrameProcessorController.h"
 
 using namespace FrameProcessor;
@@ -420,12 +421,12 @@ void checkNoClientArgs(po::variables_map vm) {
 
 int main(int argc, char** argv)
 {
-  LoggerPtr logger(Logger::getLogger("FW.App"));
+  setlocale(LC_CTYPE, "UTF-8");
+  OdinData::app_path = argv[0];
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+  LoggerPtr logger(Logger::getLogger("FP.App"));
 
   try {
-
-    // Create a default basic logger configuration, which can be overridden by command-line option later
-    BasicConfigurator::configure();
 
     po::variables_map vm;
     parse_arguments(argc, argv, vm, logger);

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -155,6 +155,8 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
         PropertyConfigurator::configure(logconf_fname);
       }
       LOG4CXX_DEBUG(logger, "log4cxx config file is set to " << vm["logconfig"].as<string>());
+    } else {
+      BasicConfigurator::configure();
     }
 
     bool no_client = vm["no-client"].as<bool>();

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -39,7 +39,7 @@ const int FrameProcessorController::META_TX_HWM = 10000;
  * IpcReactor thread.
  */
 FrameProcessorController::FrameProcessorController() :
-    logger_(log4cxx::Logger::getLogger("FW.FrameProcessorController")),
+    logger_(log4cxx::Logger::getLogger("FP.FrameProcessorController")),
     runThread_(true),
     threadRunning_(false),
     threadInitError_(false),
@@ -49,6 +49,7 @@ FrameProcessorController::FrameProcessorController() :
     metaRxChannel_(ZMQ_PULL),
     metaTxChannel_(ZMQ_PUB)
 {
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   LOG4CXX_DEBUG(logger_, "Constructing FrameProcessorController");
 
   totalFrames = 0;

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -49,7 +49,6 @@ FrameProcessorController::FrameProcessorController() :
     metaRxChannel_(ZMQ_PULL),
     metaTxChannel_(ZMQ_PUB)
 {
-  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   LOG4CXX_DEBUG(logger_, "Constructing FrameProcessorController");
 
   totalFrames = 0;
@@ -657,6 +656,9 @@ void FrameProcessorController::closeMetaTxInterface()
  */
 void FrameProcessorController::runIpcService(void)
 {
+  // Configure logging for this thread
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+
   LOG4CXX_DEBUG(logger_, "Running IPC thread service");
 
   // Create the reactor

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -5,6 +5,7 @@
  *      Author: gnx91527
  */
 
+#include "logging.h"
 #include "FrameProcessorPlugin.h"
 
 namespace FrameProcessor
@@ -18,7 +19,8 @@ FrameProcessorPlugin::FrameProcessorPlugin() :
     name_(""),
     metaChannel_(ZMQ_PUSH)
 {
-  logger_ = log4cxx::Logger::getLogger("FW.FrameProcessorPlugin");
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+  logger_ = log4cxx::Logger::getLogger("FP.FrameProcessorPlugin");
 }
 
 /**

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -5,7 +5,6 @@
  *      Author: gnx91527
  */
 
-#include "logging.h"
 #include "FrameProcessorPlugin.h"
 
 namespace FrameProcessor
@@ -19,7 +18,6 @@ FrameProcessorPlugin::FrameProcessorPlugin() :
     name_(""),
     metaChannel_(ZMQ_PUSH)
 {
-  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   logger_ = log4cxx::Logger::getLogger("FP.FrameProcessorPlugin");
 }
 

--- a/frameProcessor/src/IFrameCallback.cpp
+++ b/frameProcessor/src/IFrameCallback.cpp
@@ -5,6 +5,7 @@
  *      Author: gnx91527
  */
 
+#include "logging.h"
 #include <IFrameCallback.h>
 
 namespace FrameProcessor
@@ -112,6 +113,9 @@ void IFrameCallback::confirmRemoval(const std::string& name)
  */
 void IFrameCallback::workerTask()
 {
+  // Configure logging for this thread
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+
   // Main worker task of this callback
   // Check the queue for messages
   while (working_) {

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -191,6 +191,8 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
         PropertyConfigurator::configure(logconf_fname);
       }
       LOG4CXX_DEBUG_LEVEL(1, logger_, "log4cxx config file is set to " << logconf_fname);
+    } else {
+      BasicConfigurator::configure();
     }
 
     if (vm.count("maxmem"))

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -12,6 +12,7 @@ using namespace std;
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
+#include "logging.h"
 #include "FrameReceiverApp.h"
 
 using namespace FrameReceiver;
@@ -44,7 +45,8 @@ FrameReceiverApp::FrameReceiverApp(void) :
 {
 
   // Retrieve a logger instance
-  logger_ = Logger::getLogger("FR.APP");
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+  logger_ = Logger::getLogger("FR.App");
 
 }
 

--- a/frameReceiver/src/appMain.cpp
+++ b/frameReceiver/src/appMain.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "FrameReceiverApp.h"
+#include "logging.h"
 #include <signal.h>
 #include <iostream>
 
@@ -25,8 +26,9 @@ int main (int argc, char** argv)
   signal (SIGINT, intHandler);
   signal (SIGTERM, intHandler);
 
-  // Create a default basic logger configuration, which can be overridden by command-line option later
-  BasicConfigurator::configure ();
+  // Set the application path and locale for logging
+  setlocale(LC_CTYPE, "UTF-8");
+  OdinData::app_path = argv[0];
 
   // Create a FrameReceiverApp instance
   FrameReceiver::FrameReceiverApp fr_instance;

--- a/tools/python/odin_data/ipc_client.py
+++ b/tools/python/odin_data/ipc_client.py
@@ -6,7 +6,7 @@ from ipc_channel import IpcChannel
 from ipc_message import IpcMessage, IpcMessageException
 
 
-class ZMQClient(object):
+class IpcClient(object):
 
     ENDPOINT_TEMPLATE = "tcp://{IP}:{PORT}"
 

--- a/tools/python/odin_data/zmqclient.py
+++ b/tools/python/odin_data/zmqclient.py
@@ -2,8 +2,8 @@ import logging
 
 import zmq
 from threading import RLock
-from odin_data.ipc_channel import IpcChannel
-from odin_data.ipc_message import IpcMessage, IpcMessageException
+from ipc_channel import IpcChannel
+from ipc_message import IpcMessage, IpcMessageException
 
 
 class ZMQClient(object):

--- a/tools/python/odin_data/zmqclient.py
+++ b/tools/python/odin_data/zmqclient.py
@@ -1,0 +1,90 @@
+import logging
+
+import zmq
+from threading import RLock
+from odin_data.ipc_channel import IpcChannel
+from odin_data.ipc_message import IpcMessage, IpcMessageException
+
+
+class ZMQClient(object):
+
+    ENDPOINT_TEMPLATE = "tcp://{IP}:{PORT}"
+
+    def __init__(self, ip_address, port):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self._ip_address = ip_address
+        self._port = port
+
+        self.ctrl_endpoint = self.ENDPOINT_TEMPLATE.format(IP=ip_address, PORT=port)
+        self.logger.debug("Connecting to client at %s", self.ctrl_endpoint)
+        self.ctrl_channel = IpcChannel(IpcChannel.CHANNEL_TYPE_REQ)
+        self.ctrl_channel.connect(self.ctrl_endpoint)
+
+        self._lock = RLock()
+
+    def _send_message(self, msg, timeout=1000):
+        self.logger.debug("Sending control message:\n%s", msg.encode())
+        with self._lock:
+            self.ctrl_channel.send(msg.encode())
+            pollevts = self.ctrl_channel.poll(timeout)
+
+        if pollevts == zmq.POLLIN:
+            reply = IpcMessage(from_str=self.ctrl_channel.recv())
+            if reply.is_valid() \
+               and reply.get_msg_type() == IpcMessage.ACK:
+                self.logger.debug("Request successful")
+                return True, reply.attrs
+            else:
+                self.logger.debug("Request unsuccessful")
+                return False, reply.attrs
+        else:
+            self.logger.warning("Received no response")
+            return False, None
+
+    @staticmethod
+    def _raise_reply_error(msg, reply):
+        if reply is not None:
+            raise IpcMessageException(
+                "Request\n%s\nunsuccessful."
+                " Got invalid response: %s" % (msg, reply))
+        else:
+            raise IpcMessageException(
+                "Request\n%s\nunsuccessful."
+                " Got no response." % msg)
+
+    def send_request(self, value):
+        msg = IpcMessage("cmd", value)
+        success, reply = self._send_message(msg)
+        if success:
+            return reply
+        else:
+            self._raise_reply_error(msg, reply)
+
+    def send_configuration(self, target, content, valid_error=None):
+        msg = IpcMessage("cmd", "configure")
+        if not target:
+            for key in content:
+                msg.set_param(key, content[key])
+        else:
+            msg.set_param(target, content)
+        success, reply = self._send_message(msg)
+        if not success and None not in [reply, valid_error]:
+            if reply["params"]["error"] != valid_error:
+                self._raise_reply_error(msg, reply)
+            else:
+                self.logger.debug("Got valid error for request %s: %s",
+                                  msg, reply)
+        return success, reply
+
+    def send_configuration_dict(self, **kwargs):
+        msg = IpcMessage("cmd", "configure")
+        for key, value in kwargs.items():
+            msg.set_param(key, value)
+        return self._send_message(msg)
+
+    def _read_message(self, timeout):
+        pollevts = self.ctrl_channel.poll(timeout)
+        if pollevts == zmq.POLLIN:
+            reply = IpcMessage(from_str=self.ctrl_channel.recv())
+            return reply


### PR DESCRIPTION
This PR contains further generic updates to odin-data concerned with logging and some additional helper python classes for use with ZeroMQ.  Specifically:

- Logging updated to work with Graylog.  Default settings should still be the same as before, only if Graylog is specified in the config file will it be used.
- Minor logging typo fixes and updates to logging levels.
- Added ZeroMQ helper python class for communicating with frameProcessor or frameReceiver (will be used by adapters).

Most of these changes were originally made by @GDYendell and @MattTaylorDLS.