### PR TITLE
Generic updates - Part definitely the last one for sure this time

### DIFF
--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -176,8 +176,7 @@ void FrameProcessorController::handleMetaRxChannel()
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   doc.Accept(writer);
 
-  LOG4CXX_DEBUG(logger_, "Meta RX thread called: " << buffer.GetString());
-
+  LOG4CXX_TRACE(logger_, "Meta RX thread called: " << buffer.GetString());
 
   metaTxChannel_.send(buffer.GetString(), ZMQ_SNDMORE);
   metaTxChannel_.send(rPtr->getSize(), rPtr->getDataPtr());

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -49,6 +49,7 @@ FrameProcessorController::FrameProcessorController() :
     metaRxChannel_(ZMQ_PULL),
     metaTxChannel_(ZMQ_PUB)
 {
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   LOG4CXX_DEBUG(logger_, "Constructing FrameProcessorController");
 
   totalFrames = 0;

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -5,6 +5,7 @@
  *      Author: gnx91527
  */
 
+#include "logging.h"
 #include "FrameProcessorPlugin.h"
 
 namespace FrameProcessor
@@ -18,6 +19,7 @@ FrameProcessorPlugin::FrameProcessorPlugin() :
     name_(""),
     metaChannel_(ZMQ_PUSH)
 {
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   logger_ = log4cxx::Logger::getLogger("FP.FrameProcessorPlugin");
 }
 

--- a/tools/python/odin_data/ipc_client.py
+++ b/tools/python/odin_data/ipc_client.py
@@ -1,7 +1,8 @@
 import logging
+from threading import RLock
 
 import zmq
-from threading import RLock
+
 from ipc_channel import IpcChannel
 from ipc_message import IpcMessage, IpcMessageException
 
@@ -16,7 +17,8 @@ class IpcClient(object):
         self._ip_address = ip_address
         self._port = port
 
-        self.ctrl_endpoint = self.ENDPOINT_TEMPLATE.format(IP=ip_address, PORT=port)
+        self.ctrl_endpoint = self.ENDPOINT_TEMPLATE.format(
+            IP=ip_address, PORT=port)
         self.logger.debug("Connecting to client at %s", self.ctrl_endpoint)
         self.ctrl_channel = IpcChannel(IpcChannel.CHANNEL_TYPE_REQ)
         self.ctrl_channel.connect(self.ctrl_endpoint)
@@ -31,8 +33,7 @@ class IpcClient(object):
 
         if pollevts == zmq.POLLIN:
             reply = IpcMessage(from_str=self.ctrl_channel.recv())
-            if reply.is_valid() \
-               and reply.get_msg_type() == IpcMessage.ACK:
+            if reply.is_valid() and reply.get_msg_type() == IpcMessage.ACK:
                 self.logger.debug("Request successful")
                 return True, reply.attrs
             else:

--- a/tools/python/odin_data/ipc_client.py
+++ b/tools/python/odin_data/ipc_client.py
@@ -61,13 +61,15 @@ class IpcClient(object):
         else:
             self._raise_reply_error(msg, reply)
 
-    def send_configuration(self, target, content, valid_error=None):
+    def send_configuration(self, content, target=None, valid_error=None):
         msg = IpcMessage("cmd", "configure")
-        if not target:
-            for key in content:
-                msg.set_param(key, content[key])
-        else:
+
+        if target is not None:
             msg.set_param(target, content)
+        else:
+            for parameter, value in content.items():
+                msg.set_param(parameter, value)
+
         success, reply = self._send_message(msg)
         if not success and None not in [reply, valid_error]:
             if reply["params"]["error"] != valid_error:
@@ -76,12 +78,6 @@ class IpcClient(object):
                 self.logger.debug("Got valid error for request %s: %s",
                                   msg, reply)
         return success, reply
-
-    def send_configuration_dict(self, **kwargs):
-        msg = IpcMessage("cmd", "configure")
-        for key, value in kwargs.items():
-            msg.set_param(key, value)
-        return self._send_message(msg)
 
     def _read_message(self, timeout):
         pollevts = self.ctrl_channel.poll(timeout)


### PR DESCRIPTION
This contains a breaking change for the frameprocessorclient that has been temporarily moved to the eiger repository. send_configuration_dict(config) should be changed to send_configuration(config) where target now defaults to None to provide the behaviour of send_configuration_dict.