### PR TITLE
Fix unsigned current_frame_seen variable in frame decoders

### DIFF
--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -109,7 +109,7 @@ protected:
   FrameReadyCallback   ready_callback_;
 
   std::queue<int>    empty_buffer_queue_;
-  std::map<uint32_t, int> frame_buffer_map_;
+  std::map<int, int> frame_buffer_map_;
 
   unsigned int frame_timeout_ms_;
   unsigned int frames_timedout_;


### PR DESCRIPTION
Provides underlying compatibility with issue [BC-319](BC-319-current-frame-seen). 

N.B. FrameDecoder plugins copying the pattern used in PERCIVAL and EXCALIBUR decoders will need changes to their associated member variables (current_frame_seen_) and buffer map iterators used in monitor_buffers.