### PR TITLE
Allow IPCMessages to be decoded correctly on python 3.5

### DIFF
--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -2,10 +2,10 @@ import json
 import datetime
 import sys
 
-'''Check the python version at runtime. VER_FLAG is True when running on python 3.0 - 3.5'''
+'''Check the python version at runtime. DECODE_BYTES is True when running on python 3.0 - 3.5'''
 if sys.version_info[0] == 3:
     if sys.version_info[1] <= 5:
-        VER_FLAG = True
+        DECODE_BYTES = True
 
 class IpcMessageException(Exception):
     def __init__(self, msg, errno=None):
@@ -32,7 +32,7 @@ class IpcMessage(object):
         else:
             try:
                 '''Manually decode bytes when operating in python versions 3.0 - 3.5 inclusive'''
-                if VER_FLAG:
+                if DECODE_BYTES:
                     from_str = from_str.decode("utf-8")
                 self.attrs = json.loads(from_str)
             except ValueError as e:

--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -1,6 +1,11 @@
 import json
 import datetime
+import sys
 
+'''Check the python version at runtime. VER_FLAG is True when running on python 3.5 only'''
+if sys.version_info[0] == 3:
+    if sys.version_info[1] == 5:
+        VER_FLAG = True
 
 class IpcMessageException(Exception):
     def __init__(self, msg, errno=None):
@@ -26,6 +31,9 @@ class IpcMessage(object):
             self.attrs['params'] = {}
         else:
             try:
+                '''Manually decode bytes when operating in python version 3.5'''
+                if VER_FLAG:
+                    from_str = from_str.decode("utf-8")
                 self.attrs = json.loads(from_str)
             except ValueError as e:
                 raise IpcMessageException(

--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -4,7 +4,7 @@ import sys
 
 '''Check the python version at runtime. VER_FLAG is True when running on python 3.5 only'''
 if sys.version_info[0] == 3:
-    if sys.version_info[1] == 5:
+    if sys.version_info[1] <= 5:
         VER_FLAG = True
 
 class IpcMessageException(Exception):
@@ -31,7 +31,7 @@ class IpcMessage(object):
             self.attrs['params'] = {}
         else:
             try:
-                '''Manually decode bytes when operating in python version 3.5'''
+                '''Manually decode bytes when operating in python versions 3.0 - 3.5 inclusive'''
                 if VER_FLAG:
                     from_str = from_str.decode("utf-8")
                 self.attrs = json.loads(from_str)

--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -2,7 +2,7 @@ import json
 import datetime
 import sys
 
-'''Check the python version at runtime. VER_FLAG is True when running on python 3.5 only'''
+'''Check the python version at runtime. VER_FLAG is True when running on python 3.0 - 3.5'''
 if sys.version_info[0] == 3:
     if sys.version_info[1] <= 5:
         VER_FLAG = True


### PR DESCRIPTION
Using odin-data on python3.5 (e.g. on embedded system) causes issues decoding IPCMessages received over e.g. ZMQ sockets, since the json library in that version only decodes strings and not bytes or bytearrays.