### PR TITLE
Changed initialisation of DECODE_BYTES

### DIFF
--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -3,6 +3,7 @@ import datetime
 import sys
 
 # Check the python version at runtime. DECODE_BYTES is True when running on python 3.0 - 3.5
+DECODE_BYTES = False
 if sys.version_info[0] == 3:
     if sys.version_info[1] <= 5:
         DECODE_BYTES = True


### PR DESCRIPTION
Initialised DECODE_BYTES prior to the python version checking to ensure that DECODE_BYTES is defined when operating on python versions below 3 and above 3.5.