### PR TITLE
Implemented option to use earlier version of hdf5 library to write

### DIFF
--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -56,6 +56,8 @@ public:
   std::string file_path_;
   /** Name of the file to write to */
   std::string filename_;
+  /** Use the earliest version of hdf5 */
+  bool use_earliest_hdf5_;
   /** Identifier for the acquisition - value sent from a detector/control to be used to
    * identify frames, config or anything else to this acquisition. Used to name the file */
   std::string acquisition_id_;

--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -72,6 +72,8 @@ private:
   static const std::string CONFIG_FILE_NAME;
   /** Configuration constant for file path */
   static const std::string CONFIG_FILE_PATH;
+  /** Configuration constant for using earliest file version */
+  static const std::string CONFIG_FILE_EARLIEST_VERSION;
 
   /** Configuration constant for dataset related items */
   static const std::string CONFIG_DATASET;

--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -53,7 +53,7 @@ public:
   std::vector<std::string> read_hdf_errors();
   void clear_hdf_errors();
   void handle_h5_error(std::string message, std::string function, std::string filename, int line) const;
-  void create_file(std::string file_name, size_t file_index, size_t chunk_align=1024 * 1024);
+  void create_file(std::string file_name, size_t file_index, bool use_earliest_version, size_t chunk_align=1024 * 1024);
   void close_file();
   void create_dataset(const DatasetDefinition& definition);
   void write_frame(const Frame& frame, hsize_t frame_offset, uint64_t outer_chunk_dimension);
@@ -86,6 +86,8 @@ private:
   size_t file_index_;
   /** Full name and path of the file to write to */
   std::string filename_;
+  /** Whether to use the earliest version of the hdf5 library */
+  bool use_earliest_version_;
   /** Mutex used to make this class thread safe */
   boost::recursive_mutex mutex_;
 };

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -38,7 +38,8 @@ Acquisition::Acquisition() :
         frames_written_(0),
         frames_processed_(0),
         total_frames_(0),
-        frames_to_write_(0)
+        frames_to_write_(0),
+        use_earliest_hdf5_(false)
 {
   this->logger_ = Logger::getLogger("FP.Acquisition");
   this->logger_->setLevel(Level::getTrace());
@@ -193,7 +194,7 @@ void Acquisition::create_file(size_t file_number) {
 
   // Create the file
   boost::filesystem::path full_path = boost::filesystem::path(file_path_) / boost::filesystem::path(filename_);
-  current_file->create_file(full_path.string(), file_number);
+  current_file->create_file(full_path.string(), file_number, use_earliest_hdf5_);
 
   // Send meta data message to notify of file creation
   publish_meta(META_NAME, META_CREATE_ITEM, full_path.string(), get_create_meta_header());

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -23,25 +23,26 @@ const std::string FileWriterPlugin::CONFIG_PROCESS_RANK            = "rank";
 const std::string FileWriterPlugin::CONFIG_PROCESS_BLOCKSIZE       = "frames_per_block";
 const std::string FileWriterPlugin::CONFIG_PROCESS_BLOCKS_PER_FILE = "blocks_per_file";
 
-const std::string FileWriterPlugin::CONFIG_FILE                = "file";
-const std::string FileWriterPlugin::CONFIG_FILE_NAME           = "name";
-const std::string FileWriterPlugin::CONFIG_FILE_PATH           = "path";
+const std::string FileWriterPlugin::CONFIG_FILE                    = "file";
+const std::string FileWriterPlugin::CONFIG_FILE_NAME               = "name";
+const std::string FileWriterPlugin::CONFIG_FILE_PATH               = "path";
+const std::string FileWriterPlugin::CONFIG_FILE_EARLIEST_VERSION   = "earliest_version";
 
-const std::string FileWriterPlugin::CONFIG_DATASET             = "dataset";
-const std::string FileWriterPlugin::CONFIG_DATASET_CMD         = "cmd";
-const std::string FileWriterPlugin::CONFIG_DATASET_NAME        = "name";
-const std::string FileWriterPlugin::CONFIG_DATASET_TYPE        = "datatype";
-const std::string FileWriterPlugin::CONFIG_DATASET_DIMS        = "dims";
-const std::string FileWriterPlugin::CONFIG_DATASET_CHUNKS      = "chunks";
-const std::string FileWriterPlugin::CONFIG_DATASET_COMPRESSION = "compression";
+const std::string FileWriterPlugin::CONFIG_DATASET                 = "dataset";
+const std::string FileWriterPlugin::CONFIG_DATASET_CMD             = "cmd";
+const std::string FileWriterPlugin::CONFIG_DATASET_NAME            = "name";
+const std::string FileWriterPlugin::CONFIG_DATASET_TYPE            = "datatype";
+const std::string FileWriterPlugin::CONFIG_DATASET_DIMS            = "dims";
+const std::string FileWriterPlugin::CONFIG_DATASET_CHUNKS          = "chunks";
+const std::string FileWriterPlugin::CONFIG_DATASET_COMPRESSION     = "compression";
 
-const std::string FileWriterPlugin::CONFIG_FRAMES              = "frames";
-const std::string FileWriterPlugin::CONFIG_MASTER_DATASET      = "master";
-const std::string FileWriterPlugin::CONFIG_OFFSET_ADJUSTMENT   = "offset";
-const std::string FileWriterPlugin::CONFIG_WRITE               = "write";
-const std::string FileWriterPlugin::ACQUISITION_ID             = "acquisition_id";
-const std::string FileWriterPlugin::CLOSE_TIMEOUT_PERIOD       = "timeout_timer_period";
-const std::string FileWriterPlugin::START_CLOSE_TIMEOUT        = "start_timeout_timer";
+const std::string FileWriterPlugin::CONFIG_FRAMES                  = "frames";
+const std::string FileWriterPlugin::CONFIG_MASTER_DATASET          = "master";
+const std::string FileWriterPlugin::CONFIG_OFFSET_ADJUSTMENT       = "offset";
+const std::string FileWriterPlugin::CONFIG_WRITE                   = "write";
+const std::string FileWriterPlugin::ACQUISITION_ID                 = "acquisition_id";
+const std::string FileWriterPlugin::CLOSE_TIMEOUT_PERIOD           = "timeout_timer_period";
+const std::string FileWriterPlugin::START_CLOSE_TIMEOUT            = "start_timeout_timer";
 
 
 
@@ -390,6 +391,10 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
   if (config.has_param(FileWriterPlugin::CONFIG_FILE_NAME)) {
     this->next_acquisition_->filename_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_NAME);
     LOG4CXX_DEBUG(logger_, "Next file name changed to " << this->next_acquisition_->filename_);
+  }
+  if (config.has_param(FileWriterPlugin::CONFIG_FILE_EARLIEST_VERSION)) {
+    this->next_acquisition_->use_earliest_hdf5_ = config.get_param<bool>(FileWriterPlugin::CONFIG_FILE_EARLIEST_VERSION);
+    LOG4CXX_DEBUG(logger_, "Use earliest version of HDF5 library to write file set to " << this->next_acquisition_->use_earliest_hdf5_);
   }
 }
 

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_SUITE(HDF5FileUnitTest, FileWriterPluginTestFixture);
 
 BOOST_AUTO_TEST_CASE( HDF5FileTest )
 {
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah.h5", 0, false));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
   BOOST_REQUIRE_EQUAL(dset_def.name, frame->get_dataset_name());
 
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileTest )
 
 BOOST_AUTO_TEST_CASE( HDF5FileMultiDatasetTest )
 {
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multidataset.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multidataset.h5", 0, false));
 
   // Create the first dataset "data"
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultiDatasetTest )
 BOOST_AUTO_TEST_CASE( HDF5FileBadFileTest )
 {
   // Check for an error when a bad file path is provided
-  BOOST_CHECK_THROW(hdf5f.create_file("/non/existent/path/blah_throw.h5", 0), std::runtime_error);
+  BOOST_CHECK_THROW(hdf5f.create_file("/non/existent/path/blah_throw.h5", 0, false), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginDatasetWithoutOpenFileTest )
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginDatasetWithoutOpenFileTest )
 BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
 {
   // Create a file ready for writing
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0, false));
 
   // Write a frame without first creating the dataset
   BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1), std::runtime_error);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
 
 BOOST_AUTO_TEST_CASE( HDF5FileInvalidDatasetTest )
 {
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0, false));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
   BOOST_REQUIRE_NO_THROW(frame->set_dataset_name("non_existing_dataset_name"));
 
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileInvalidDatasetTest )
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginMultipleFramesTest )
 {
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple.h5", 0, false));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
 
   std::vector<boost::shared_ptr<FrameProcessor::Frame> >::iterator it;
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
 {
   // Just reverse through the list of frames and write them out.
   // The frames should still appear in the file in the original order...
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple_reverse.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple_reverse.h5", 0, false));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
 
   // The first frame to write is used as an offset - so must be the lowest
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
 
 BOOST_AUTO_TEST_CASE( HDF5FileAdjustHugeOffset )
 {
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_huge_offset.h5", 0));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_huge_offset.h5", 0, false));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
 
   hsize_t huge_offset = 100000;


### PR DESCRIPTION
Note that the default behavior is to use the latest. I.e. it is backwards compatible, you have to specify to use the earliest version