### PR TITLE
Separate FrameDecoder out into shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,10 @@ set(COMMON_LIBRARY ${PROJECT_NAME})
 
 # Set the name of the frameProcessor library
 if (NOT APPLE)
+    set(LIB_RECEIVER FrameReceiver)
     set(LIB_PROCESSOR FrameProcessor)
 else(NOT APPLE)
+    set(LIB_RECEIVER OdinFrameReceiver)
     set(LIB_PROCESSOR OdinFrameProcessor)
 endif(NOT APPLE)
 

--- a/frameReceiver/src/CMakeLists.txt
+++ b/frameReceiver/src/CMakeLists.txt
@@ -4,19 +4,25 @@ ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 
 include_directories(${FRAMERECEIVER_DIR}/include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
+file(GLOB LIB_SOURCES FrameDecoder.cpp)
+
+# Add library for common plugin code
+add_library(${LIB_RECEIVER} SHARED ${LIB_SOURCES})
+target_link_libraries(${LIB_RECEIVER} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
+install(TARGETS ${LIB_RECEIVER} DESTINATION lib)
+
 file(GLOB APP_SOURCES FrameReceiverApp.cpp
                       FrameReceiverController.cpp
                       FrameReceiverRxThread.cpp
                       FrameReceiverUDPRxThread.cpp
-                      FrameReceiverZMQRxThread.cpp
-                      FrameDecoder.cpp)
+                      FrameReceiverZMQRxThread.cpp )
 
 add_executable(frameReceiver ${APP_SOURCES})
 
-target_link_libraries(frameReceiver ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
+target_link_libraries(frameReceiver ${LIB_RECEIVER} ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 
 install(TARGETS frameReceiver RUNTIME DESTINATION bin)
 
 add_library(DummyUDPFrameDecoder SHARED DummyUDPFrameDecoder.cpp DummyUDPFrameDecoderLib.cpp)
-target_link_libraries(DummyUDPFrameDecoder ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
+target_link_libraries(DummyUDPFrameDecoder ${LIB_RECEIVER} ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 install(TARGETS DummyUDPFrameDecoder DESTINATION lib)

--- a/frameReceiver/test/CMakeLists.txt
+++ b/frameReceiver/test/CMakeLists.txt
@@ -23,7 +23,9 @@ if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
 endif()
 
 # Define libraries to link against
-target_link_libraries(frameReceiverTest ${COMMON_LIBRARY}
-                                        ${Boost_LIBRARIES}
-                                        ${LOG4CXX_LIBRARIES}
-                                        ${ZEROMQ_LIBRARIES})
+target_link_libraries(frameReceiverTest 
+        ${LIB_RECEIVER}
+        ${COMMON_LIBRARY}
+        ${Boost_LIBRARIES}
+        ${LOG4CXX_LIBRARIES}
+        ${ZEROMQ_LIBRARIES})


### PR DESCRIPTION
Fixes problem with detector-specific decoder test apps having to
have access to main frameReceiver source.