### PR TITLE
Do not shut down the reactor when SharedMemoryController is destroyed.

### DIFF
--- a/frameProcessor/src/SharedMemoryController.cpp
+++ b/frameProcessor/src/SharedMemoryController.cpp
@@ -79,8 +79,6 @@ SharedMemoryController::~SharedMemoryController()
   reactor_->remove_channel(rxChannel_);
   txChannel_.close();
   rxChannel_.close();
-  // Stop the SharedMemoryController reactor
-  reactor_->stop();
 }
 
 /** setSharedBufferManager


### PR DESCRIPTION
This stops the application from being reconfigured for a new buffer setup.