### PR TITLE
Fix python 2/3 import of JSONDecodeError in FR client

### DIFF
--- a/tools/python/odin_data/frame_receiver/client.py
+++ b/tools/python/odin_data/frame_receiver/client.py
@@ -11,7 +11,11 @@ import os
 import json
 import zmq
 from struct import Struct
-from json.decoder import JSONDecodeError
+
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError 
 
 class FrameReceiverClient(object):
     
@@ -84,6 +88,7 @@ class FrameReceiverClient(object):
             config_msg = IpcMessage('cmd', 'configure')
             for param, value in config_params.items():
                 config_msg.set_param(param, value)
+
                 
             self.logger.info("Sending configure command to frame receiver with specified parameters")
             self.ctrl_channel.send(config_msg.encode())

--- a/tools/python/odin_data/frame_receiver/client.py
+++ b/tools/python/odin_data/frame_receiver/client.py
@@ -88,7 +88,6 @@ class FrameReceiverClient(object):
             config_msg = IpcMessage('cmd', 'configure')
             for param, value in config_params.items():
                 config_msg.set_param(param, value)
-
                 
             self.logger.info("Sending configure command to frame receiver with specified parameters")
             self.ctrl_channel.send(config_msg.encode())


### PR DESCRIPTION
This PR is a trivial fix that allows the test FR client script to correctly handle JSON decode errors in both python 2 and 3, where the exception type raised when a JSON string cannot be decoded differs.