### PR TITLE
Add low and high index attributes to dataset when in block write mode

### DIFF
--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -55,7 +55,7 @@ public:
   void handle_h5_error(std::string message, std::string function, std::string filename, int line) const;
   void create_file(std::string file_name, size_t file_index, bool use_earliest_version, size_t alignment_threshold, size_t alignment_value);
   void close_file();
-  void create_dataset(const DatasetDefinition& definition);
+  void create_dataset(const DatasetDefinition& definition, int low_index, int high_index);
   void write_frame(const Frame& frame, hsize_t frame_offset, uint64_t outer_chunk_dimension);
   size_t get_dataset_frames(const std::string dset_name);
   void start_swmr();

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -206,7 +206,22 @@ void Acquisition::create_file(size_t file_number) {
   for (iter = dataset_defs_.begin(); iter != dataset_defs_.end(); ++iter) {
     DatasetDefinition dset_def = iter->second;
     dset_def.num_frames = frames_to_write_;
-    current_file->create_dataset(dset_def);
+
+    // Calculate low and high index for this dataset - needed to be able to open datasets in Albula
+    int low_index = -1;
+    int high_index = -1;
+
+    if (frames_per_block_ > 1)
+    {
+      low_index = file_number * frames_per_block_ + 1;
+      high_index = low_index + frames_per_block_ - 1;
+      if (blocks_per_file_ == 0 || high_index > total_frames_)
+      {
+        high_index = total_frames_;
+      }
+    }
+
+    current_file->create_dataset(dset_def, low_index, high_index);
   }
 
   current_file->start_swmr();

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -200,7 +200,7 @@ BOOST_FIXTURE_TEST_SUITE(HDF5FileUnitTest, FileWriterPluginTestFixture);
 BOOST_AUTO_TEST_CASE( HDF5FileTest )
 {
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah.h5", 0, false, 1, 1));
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
   BOOST_REQUIRE_EQUAL(dset_def.name, frame->get_dataset_name());
 
   BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
@@ -212,12 +212,12 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultiDatasetTest )
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multidataset.h5", 0, false, 1, 1));
 
   // Create the first dataset "data"
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
   BOOST_CHECK_EQUAL(dset_def.name, frame->get_dataset_name());
 
   // Create the second dataset "stuff"
   dset_def.name = "stuff";
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   // Write first frame to "data"
   BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileBadFileTest )
 BOOST_AUTO_TEST_CASE( FileWriterPluginDatasetWithoutOpenFileTest )
 {
   // Check for an error when a dataset is created without a file open
-  BOOST_CHECK_THROW(hdf5f.create_dataset(dset_def), std::runtime_error);
+  BOOST_CHECK_THROW(hdf5f.create_dataset(dset_def, -1, -1), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
 BOOST_AUTO_TEST_CASE( HDF5FileInvalidDatasetTest )
 {
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0, false, 1, 1));
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
   BOOST_REQUIRE_NO_THROW(frame->set_dataset_name("non_existing_dataset_name"));
 
   BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1), std::runtime_error);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileInvalidDatasetTest )
 BOOST_AUTO_TEST_CASE( FileWriterPluginMultipleFramesTest )
 {
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple.h5", 0, false, 1, 1));
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   std::vector<boost::shared_ptr<FrameProcessor::Frame> >::iterator it;
   for (it = frames.begin(); it != frames.end(); ++it) {
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
   // Just reverse through the list of frames and write them out.
   // The frames should still appear in the file in the original order...
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple_reverse.h5", 0, false, 1, 1));
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   // The first frame to write is used as an offset - so must be the lowest
   // frame number. Frames received later with a smaller number would result
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
 BOOST_AUTO_TEST_CASE( HDF5FileAdjustHugeOffset )
 {
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_huge_offset.h5", 0, false, 1, 1));
-  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def));
+  BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   hsize_t huge_offset = 100000;
   BOOST_REQUIRE_NO_THROW(fw.set_frame_offset_adjustment(huge_offset));


### PR DESCRIPTION
Albula needs the low and high index to be set on the dataset to be able
to read it properly
BC-682