### PR TITLE
Add status reporting to frame decoders.

### DIFF
--- a/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -44,6 +44,7 @@ public:
   FrameDecoder::FrameReceiveState process_packet(size_t bytes_received);
 
   void monitor_buffers(void) { };
+  void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);
 
   void* get_packet_header_buffer(void){ return reinterpret_cast<void *>(0); };
 

--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -75,6 +75,7 @@ public:
   const unsigned int get_frame_timeout_ms(void) const;
   const unsigned int get_num_frames_timedout(void) const;
   virtual void monitor_buffers(void) = 0;
+  virtual void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) = 0;
 
 protected:
   LoggerPtr logger_;  //!< Pointer to the logging facility

--- a/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -39,3 +39,9 @@ FrameDecoder::FrameReceiveState DummyUDPFrameDecoder::process_packet(size_t byte
   LOG4CXX_TRACE(logger_, "DummyFrameDecoderUDP process_packet called");
   return FrameDecoder::FrameReceiveStateComplete;
 }
+
+void DummyUDPFrameDecoder::get_status(const std::string param_prefix,
+    OdinData::IpcMessage& status_msg)
+{
+  status_msg.set_param(param_prefix + "name", std::string("DummyUDPFrameDecoder"));
+}

--- a/frameReceiver/src/FrameReceiverRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverRxThread.cpp
@@ -339,6 +339,7 @@ void FrameReceiverRxThread::buffer_monitor_timer(void)
   // Send status notification to main thread
   IpcMessage status_msg(IpcMessage::MsgTypeNotify, IpcMessage::MsgValNotifyStatus);
   this->fill_status_params(status_msg);
+
   rx_channel_.send(status_msg.encode());
 }
 
@@ -354,7 +355,11 @@ void FrameReceiverRxThread::fill_status_params(IpcMessage& status_msg)
 {
   status_msg.set_param("rx_thread/empty_buffers", frame_decoder_->get_num_empty_buffers());
   status_msg.set_param("rx_thread/mapped_buffers", frame_decoder_->get_num_mapped_buffers());
-  status_msg.set_param("rx_thread/frames_timedout", frame_decoder_->get_num_frames_timedout());  
+  status_msg.set_param("rx_thread/frames_timedout", frame_decoder_->get_num_frames_timedout());
+
+  // Get the specific frame decoder instance to fill its own status into message
+  frame_decoder_->get_status(std::string("decoder/"), status_msg);
+
 }
 
 //! Signal that a frame is ready for processing.


### PR DESCRIPTION
Decoder-specific status reporting is now integrated into the frame
receiver. This requires each decoder plugin to implement the
get_status() method to allow the controller to request and integrate
specific status parameters into its response.