### PR TITLE
Bug fix for top level parameter arrays.

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -214,16 +214,16 @@ public:
 
     // Pointer to the rapidjson value
     rapidjson::Value *next;
+    // Check for array notation
+    std::string array_end = "[]";
+    if (0 == tl_param_name.compare(tl_param_name.length() - array_end.length(), array_end.length(), array_end)){
+      found_array = true;
+    }
+    if (found_array){
+      tl_param_name = tl_param_name.substr(0, tl_param_name.size()-2);
+    }
     // Does the param exist
     if (!this->has_param(tl_param_name)){
-      // Check for array notation
-      std::string array_end = "[]";
-      if (0 == tl_param_name.compare(tl_param_name.length() - array_end.length(), array_end.length(), array_end)){
-        found_array = true;
-      }
-      if (found_array){
-        tl_param_name = tl_param_name.substr(0, tl_param_name.size()-2);
-      }
       this->internal_set_param(tl_param_name, rapidjson::Value().SetObject());
     }
     // Get the reference to the parameter


### PR DESCRIPTION
Problem with top level param arrays.  The name was tested to see if parameter existed but the [] was not removed before the test and so the test would always fail.  This would result in single item arrays only for top level parameters.