### PR TITLE
Add pthread library to CMake config for binaries.

### DIFF
--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -30,6 +30,12 @@ message(STATUS "HDF5 libs:           " ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES})
 message(STATUS "HDF5 defs:           " ${HDF5_DEFINITIONS})
 
 target_link_libraries(frameProcessor ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
+if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
+    find_library(PTHREAD_LIBRARY
+             NAMES pthread)
+    target_link_libraries(frameProcessor ${PTHREAD_LIBRARY} )
+endif()
+
 install(TARGETS frameProcessor RUNTIME DESTINATION bin)
 
 # Add library for dummy plugin

--- a/frameProcessor/test/CMakeLists.txt
+++ b/frameProcessor/test/CMakeLists.txt
@@ -25,5 +25,8 @@ if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
   # librt required for timing functions
   find_library(REALTIME_LIBRARY
                NAMES rt)
-  target_link_libraries( frameProcessorTest ${REALTIME_LIBRARY} )
+  target_link_libraries(frameProcessorTest ${REALTIME_LIBRARY} )
+  find_library(PTHREAD_LIBRARY
+	       NAMES pthread)
+  target_link_libraries(frameProcessorTest ${PTHREAD_LIBRARY} )
 endif()

--- a/frameReceiver/src/CMakeLists.txt
+++ b/frameReceiver/src/CMakeLists.txt
@@ -21,6 +21,12 @@ add_executable(frameReceiver ${APP_SOURCES})
 
 target_link_libraries(frameReceiver ${LIB_RECEIVER} ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 
+if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
+    find_library(PTHREAD_LIBRARY
+             NAMES pthread)
+    target_link_libraries(frameReceiver ${PTHREAD_LIBRARY} )
+endif()
+
 install(TARGETS frameReceiver RUNTIME DESTINATION bin)
 
 add_library(DummyUDPFrameDecoder SHARED DummyUDPFrameDecoder.cpp DummyUDPFrameDecoderLib.cpp)

--- a/frameReceiver/test/CMakeLists.txt
+++ b/frameReceiver/test/CMakeLists.txt
@@ -20,6 +20,9 @@ if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
     find_library(REALTIME_LIBRARY
                  NAMES rt)
     target_link_libraries( frameReceiverTest ${REALTIME_LIBRARY} )
+    find_library(PTHREAD_LIBRARY
+             NAMES pthread)
+    target_link_libraries(frameReceiverTest ${PTHREAD_LIBRARY} )
 endif()
 
 # Define libraries to link against


### PR DESCRIPTION
Updated boost version (1.67.0) needed for error-free compilation on EL7 variants now requires libpthread to be linked into binaries using the boost thread library. Added this to the CMake config for
each of the frameReceiver/Processor main and test binaries.

N.B. This is required for non-DLS projects using later OS versions. Has been verified to have no side-effect on EL6 variants, compiled with either the latest boost version or the earlier default (e.g. 1.48) used on DLS builds.