### PR TITLE
Remove named dimensions

### DIFF
--- a/frameProcessor/include/Frame.h
+++ b/frameProcessor/include/Frame.h
@@ -113,8 +113,8 @@ public:
    */
   void set_acquisition_id(const std::string& acquisitionID) { this->acquisitionID_ = acquisitionID; }
 
-  void set_dimensions(const std::string& type, const std::vector<unsigned long long>& dimensions);
-  dimensions_t get_dimensions(const std::string& type) const;
+  void set_dimensions(const std::vector<unsigned long long>& dimensions);
+  dimensions_t get_dimensions() const;
   int get_compression() const;
   int get_data_type() const;
   void set_parameter(const std::string& index, size_t parameter);
@@ -141,7 +141,7 @@ private:
   /** Frame number */
   unsigned long long frameNumber_;
   /** Map of dimensions, indexed by name */
-  std::map<std::string, dimensions_t> dimensions_;
+  dimensions_t dimensions_;
   /** Compression type of raw data */
   int compression_;
   /** Data type of raw data */

--- a/frameProcessor/include/Frame.h
+++ b/frameProcessor/include/Frame.h
@@ -140,7 +140,7 @@ private:
   size_t bytes_per_pixel;
   /** Frame number */
   unsigned long long frameNumber_;
-  /** Map of dimensions, indexed by name */
+  /** Vector of dimensions */
   dimensions_t dimensions_;
   /** Compression type of raw data */
   int compression_;

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -355,8 +355,8 @@ bool Acquisition::check_frame_valid(boost::shared_ptr<Frame> frame)
     LOG4CXX_ERROR(logger_, last_error_);
     invalid = true;
   }
-  if (frame->get_dimensions(frame->get_dataset_name()) != dataset.frame_dimensions) {
-    std::vector<unsigned long long> dimensions = frame->get_dimensions(frame->get_dataset_name());
+  if (frame->get_dimensions() != dataset.frame_dimensions) {
+    std::vector<unsigned long long> dimensions = frame->get_dimensions();
     if (dimensions.size() >= 2 && dataset.frame_dimensions.size() >= 2) {
       std::stringstream ss;
       ss << "Invalid frame: Frame has dimensions [" << dimensions[0] << ", " << dimensions[1] <<

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -153,32 +153,24 @@ size_t Frame::get_data_size() const
 
 /** Sets a particular set of dimension values.
  *
- * This method sets the dimensions of the frame. The dimensions are
- * stored in a map indexed by a string, which allows several sets of
- * dimensions to be stored (for example, the overall dimensions plus
- * chunked or subframe dimensions).
+ * This method sets the dimensions of the frame.
  *
- * \param[in] type - the string index under which to store these dimensions.
  * \param[in] dimensions - array of dimensions to store.
  */
-void Frame::set_dimensions(const std::string& type, const std::vector<unsigned long long>& dimensions)
+void Frame::set_dimensions(const std::vector<unsigned long long>& dimensions)
 {
-  dimensions_[type] = dimensions;
+  dimensions_ = dimensions;
 }
 
 /** Retrieves a particular set of dimension values.
  *
- * This method gets the dimensions of the frame. The dimensions are
- * stored in a map indexed by a string, which allows several sets of
- * dimensions to be stored (for example, the overall dimensions plus
- * chunked or subframe dimensions).
+ * This method gets the dimensions of the frame.
  *
- * \param[in] type - the string index of dimensions to return.
  * \return array of dimensions.
  */
-dimensions_t Frame::get_dimensions(const std::string& type) const
+dimensions_t Frame::get_dimensions() const
 {
-  return dimensions_.find(type)->second;
+  return dimensions_;
 }
 
 /** Retrieves the compression type of the raw data.

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -132,12 +132,12 @@ BOOST_AUTO_TEST_CASE( FrameTest )
   dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
 
   FrameProcessor::Frame frame("raw");
-  frame.set_dimensions("frame", img_dims);
+  frame.set_dimensions(img_dims);
   frame.set_frame_number(7);
   BOOST_CHECK_NO_THROW(frame.copy_data(static_cast<void*>(img), 24));
   BOOST_REQUIRE_EQUAL(frame.get_data_size(), 24);
-  BOOST_REQUIRE_EQUAL(frame.get_dimensions("frame")[0], 3);
-  BOOST_REQUIRE_EQUAL(frame.get_dimensions("frame")[1], 4);
+  BOOST_REQUIRE_EQUAL(frame.get_dimensions()[0], 3);
+  BOOST_REQUIRE_EQUAL(frame.get_dimensions()[1], 4);
   BOOST_CHECK_EQUAL(frame.get_frame_number(), 7);
   const unsigned short *img_copy = static_cast<const unsigned short*>(frame.get_data());
   BOOST_CHECK_EQUAL(img_copy[0], img[0]);


### PR DESCRIPTION
This PR completes JIRA ticket BC610.  There is no need to have named dimensions for a frame.  This PR removes the name from the getter/setters and removes the internal map.

This is an API change and will break detector processor code.