### PR TITLE
Add command line option for specifying a JSON configuration file.

### DIFF
--- a/config/fp_test_config.json
+++ b/config/fp_test_config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "fr_setup": {
+      "fr_ready_cnxn": "tcp://127.0.0.1:5001",
+      "fr_release_cnxn": "tcp://127.0.0.1:5002"
+    }
+  },
+  {
+    "plugin": {
+      "load": {
+        "index": "hdf",
+        "name": "FileWriterPlugin",
+        "library": "../lib/libHdf5Plugin.so"
+      }
+    }
+  },
+  {
+    "plugin": {
+      "connect": {
+        "index": "hdf",
+        "connection": "frame_receiver"
+      }
+    }
+  },
+  {
+    "hdf": {
+      "dataset": "data"
+    }
+  }
+]

--- a/config/fr_excalibur1.json
+++ b/config/fr_excalibur1.json
@@ -1,0 +1,13 @@
+{
+  "max_buffer_mem": 10000000,
+  "decoder_type": "Excalibur",
+  "decoder_path": "/dls_sw/prod/tools/RHEL6-x86_64/excalibur-detector/0-2-0/prefix/lib",
+  "rx_ports": "61649,61650",
+  "decoder_config": {
+    "enable_packet_logging": false,
+    "frame_timeout_ms": 1000,
+    "fem_port_map": "61649:0,61650:1",
+    "bitdepth": "12-bit"
+  }
+}
+

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -118,6 +118,8 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
            "Set the hdf5 alignment threshold. Default is 1 (no alignment)")
         ("alignment-value",       po::value<size_t>()->default_value(1),
            "Set the hdf5 alignment value. Default is 1 (no alignment)")
+        ("json_file,j",  po::value<std::string>()->default_value(""),
+         "Path to a JSON configuration file to submit to the application")
     ;
 
     // Group the variables for parsing at the command line and/or from the configuration file
@@ -495,6 +497,44 @@ int main(int argc, char** argv)
         LOG4CXX_DEBUG(logger, "Adding configuration options to work without a client");
         configurePlugins(fwc, vm);
         configureFileWriter(fwc, vm);
+      }
+    }
+
+    if (vm["json_file"].as<std::string>() != "")
+    {
+      std::string json_config_file = vm["json_file"].as<std::string>();
+      // Attempt to open the file specified and read in the string as a JSON parameter set
+      std::ifstream t(json_config_file.c_str());
+      std::string json((std::istreambuf_iterator<char>(t)),
+                       std::istreambuf_iterator<char>());
+
+      // Check for empty JSON and throw an exception.
+      if (json == ""){
+        throw OdinData::OdinDataException("Incorrect or empty JSON configuration file specified");
+      }
+
+      // Parse the JSON file
+      rapidjson::Document param_doc;
+      param_doc.Parse(json.c_str());
+      // Check if the top level object is an array
+      if (param_doc.IsArray()) {
+        // Loop over the array submitting the child objects in order
+        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i){
+          // Create a configuration message
+          OdinData::IpcMessage json_config_msg(param_doc[i],
+                                               OdinData::IpcMessage::MsgTypeCmd,
+                                               OdinData::IpcMessage::MsgValCmdConfigure);
+          // Now submit the config to the controller
+          fwc->configure(json_config_msg, reply);
+        }
+      } else {
+        // Single level JSON object
+        // Create a configuration message
+        OdinData::IpcMessage json_config_msg(param_doc,
+                                             OdinData::IpcMessage::MsgTypeCmd,
+                                             OdinData::IpcMessage::MsgValCmdConfigure);
+        // Now submit the config to the controller
+        fwc->configure(json_config_msg, reply);
       }
     }
 

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -500,8 +500,7 @@ int main(int argc, char** argv)
       }
     }
 
-    if (vm["json_file"].as<std::string>() != "")
-    {
+    if (vm["json_file"].as<std::string>() != "") {
       std::string json_config_file = vm["json_file"].as<std::string>();
       // Attempt to open the file specified and read in the string as a JSON parameter set
       std::ifstream t(json_config_file.c_str());
@@ -509,7 +508,7 @@ int main(int argc, char** argv)
                        std::istreambuf_iterator<char>());
 
       // Check for empty JSON and throw an exception.
-      if (json == ""){
+      if (json == "") {
         throw OdinData::OdinDataException("Incorrect or empty JSON configuration file specified");
       }
 
@@ -519,7 +518,7 @@ int main(int argc, char** argv)
       // Check if the top level object is an array
       if (param_doc.IsArray()) {
         // Loop over the array submitting the child objects in order
-        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i){
+        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i) {
           // Create a configuration message
           OdinData::IpcMessage json_config_msg(param_doc[i],
                                                OdinData::IpcMessage::MsgTypeCmd,

--- a/frameReceiver/include/FrameReceiverApp.h
+++ b/frameReceiver/include/FrameReceiverApp.h
@@ -54,6 +54,7 @@ private:
 
   LoggerPtr logger_;                    //!< Log4CXX logger instance pointer
   FrameReceiverConfig config_;          //!< Configuration storage object
+  std::string json_config_file_;        //!< Full path to JSON configuration file
   static boost::shared_ptr<FrameReceiverController> controller_; //!< FrameReceiver controller object
 
 };

--- a/frameReceiver/include/FrameReceiverDefaults.h
+++ b/frameReceiver/include/FrameReceiverDefaults.h
@@ -43,6 +43,7 @@ const std::string  default_rx_chan_endpoint       = "inproc://rx_channel";
 const std::string  default_ctrl_chan_endpoint     = "tcp://*:5000";
 const std::string  default_frame_ready_endpoint   = "tcp://*:5001";
 const std::string  default_frame_release_endpoint = "tcp://*:5002";
+const std::string  default_json_config_file       = "";
 const std::string  default_shared_buffer_name     = "FrameReceiverBuffer";
 const unsigned int default_frame_timeout_ms       = 1000;
 const unsigned int default_frame_count            = 0;

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -290,7 +290,7 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
     if (vm.count("json_file"))
     {
       json_config_file_ = vm["json_file"].as<std::string>();
-      LOG4CXX_DEBUG_LEVEL(1, logger_, "Loading JSON configuration file " << config_.frame_release_endpoint_);
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "Loading JSON configuration file " << json_config_file_);
     }
 
   }

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -334,14 +334,14 @@ void FrameReceiverApp::run(void)
     controller_->configure(config_msg, config_reply);
 
     // Check for a JSON configuration file option
-    if (json_config_file_ != ""){
+    if (json_config_file_ != "") {
       // Attempt to open the file specified and read in the string as a JSON parameter set
       std::ifstream t(json_config_file_.c_str());
       std::string json((std::istreambuf_iterator<char>(t)),
                        std::istreambuf_iterator<char>());
 
       // Check for empty JSON and throw an exception.
-      if (json == ""){
+      if (json == "") {
         throw OdinData::OdinDataException("Incorrect or empty JSON configuration file specified");
       }
 
@@ -351,7 +351,7 @@ void FrameReceiverApp::run(void)
       // Check if the top level object is an array
       if (param_doc.IsArray()) {
         // Loop over the array submitting the child objects in order
-        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i){
+        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i) {
           // Create a configuration message
           OdinData::IpcMessage json_config_msg(param_doc[i],
                                                OdinData::IpcMessage::MsgTypeCmd,

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -7,7 +7,9 @@
 
 #include <signal.h>
 #include <iostream>
+#include <string>
 #include <fstream>
+#include <streambuf>
 using namespace std;
 
 #include <boost/foreach.hpp>
@@ -33,7 +35,7 @@ static bool has_suffix(const std::string &str, const std::string &suffix)
 //!
 //! This constructor initialises the FrameReceiverApp instance
 
-FrameReceiverApp::FrameReceiverApp(void)
+FrameReceiverApp::FrameReceiverApp(void) : json_config_file_("")
 {
 
   // Retrieve a logger instance
@@ -124,6 +126,8 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
          "Set the frame ready channel endpoint")
         ("release",      po::value<std::string>()->default_value(FrameReceiver::Defaults::default_frame_release_endpoint),
          "Set the frame release channel endpoint")
+        ("json_file,j",  po::value<std::string>()->default_value(FrameReceiver::Defaults::default_json_config_file),
+         "Path to a JSON configuration file to submit to the application")
         ;
 
     // Group the variables for parsing at the command line and/or from the configuration file
@@ -283,6 +287,12 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
       LOG4CXX_DEBUG_LEVEL(1, logger_, "Setting frame release channel endpoint to " << config_.frame_release_endpoint_);
     }
 
+    if (vm.count("json_file"))
+    {
+      json_config_file_ = vm["json_file"].as<std::string>();
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "Loading JSON configuration file " << config_.frame_release_endpoint_);
+    }
+
   }
   catch (Exception &e)
   {
@@ -322,6 +332,43 @@ void FrameReceiverApp::run(void)
     config_msg.set_param<bool>(CONFIG_FORCE_RECONFIG, true);
 
     controller_->configure(config_msg, config_reply);
+
+    // Check for a JSON configuration file option
+    if (json_config_file_ != ""){
+      // Attempt to open the file specified and read in the string as a JSON parameter set
+      std::ifstream t(json_config_file_.c_str());
+      std::string json((std::istreambuf_iterator<char>(t)),
+                       std::istreambuf_iterator<char>());
+
+      // Check for empty JSON and throw an exception.
+      if (json == ""){
+        throw OdinData::OdinDataException("Incorrect or empty JSON configuration file specified");
+      }
+
+      // Parse the JSON file
+      rapidjson::Document param_doc;
+      param_doc.Parse(json.c_str());
+      // Check if the top level object is an array
+      if (param_doc.IsArray()) {
+        // Loop over the array submitting the child objects in order
+        for (rapidjson::SizeType i = 0; i < param_doc.Size(); ++i){
+          // Create a configuration message
+          OdinData::IpcMessage json_config_msg(param_doc[i],
+                                               OdinData::IpcMessage::MsgTypeCmd,
+                                               OdinData::IpcMessage::MsgValCmdConfigure);
+          // Now submit the config to the controller
+          controller_->configure(json_config_msg, config_reply);
+        }
+      } else {
+        // Single level JSON object
+        // Create a configuration message
+        OdinData::IpcMessage json_config_msg(param_doc,
+                                             OdinData::IpcMessage::MsgTypeCmd,
+                                             OdinData::IpcMessage::MsgValCmdConfigure);
+        // Now submit the config to the controller
+        controller_->configure(json_config_msg, config_reply);
+      }
+    }
 
     controller_->run();
 


### PR DESCRIPTION
Added this for both FP and FR.
Parsing the JSON directly in the App classes because the JSON configuration file could contain an array of configuration objects, and each one must be submitted as a new IpcMessage in order.  This means that the parsing to JSON must take place outside of the IpcMessage class itself.