### PR TITLE
Add status reporting to SharedMemoryController

### DIFF
--- a/frameProcessor/include/SharedMemoryController.h
+++ b/frameProcessor/include/SharedMemoryController.h
@@ -46,6 +46,7 @@ public:
   void registerCallback(const std::string& name, boost::shared_ptr<IFrameCallback> cb);
   void removeCallback(const std::string& name);
   void handleRxChannel();
+  void status(OdinData::IpcMessage& status);
 
 private:
   /** Pointer to logger */
@@ -60,6 +61,11 @@ private:
   OdinData::IpcChannel             rxChannel_;
   /** IpcChannel for sending notifications of frame release */
   OdinData::IpcChannel             txChannel_;
+  /** Shared buffer configured status flag */
+  bool sharedBufferConfigured_;
+
+  /** Name of class used in status messages */
+  static const std::string SHARED_MEMORY_CONTROLLER_NAME;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -233,10 +233,24 @@ void FrameProcessorController::callback(boost::shared_ptr<Frame> frame) {
   }
 }
 
+/** Provide status information to requesting clients.
+ *
+ * This is called in response to a status request from a connected client. The reply to the
+ * request is populated with status information from the shared memory controller and all the
+ * plugins currently loaded, and with any error messages currently stored.
+ *
+ * @param[in,out] reply - response IPC message to be populated with status parameters
+ */
 void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply)
 {
   // Error messages
   std::vector<std::string> error_messages;
+
+  // Request status information from the shared memory controller
+  if (sharedMemController_) {
+    sharedMemController_->status(reply);
+  }
+
   // Loop over plugins, list names and request status from each
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> >::iterator iter;
   for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {

--- a/frameProcessor/src/SharedMemoryController.cpp
+++ b/frameProcessor/src/SharedMemoryController.cpp
@@ -11,6 +11,8 @@
 namespace FrameProcessor
 {
 
+const std::string SharedMemoryController::SHARED_MEMORY_CONTROLLER_NAME = "shared_memory";
+
 /** Constructor.
  *
  * The constructor sets up logging used within the class. It also creates the
@@ -29,7 +31,8 @@ SharedMemoryController::SharedMemoryController(boost::shared_ptr<OdinData::IpcRe
                                                const std::string& txEndPoint) :
     reactor_(reactor),
     rxChannel_(ZMQ_SUB),
-    txChannel_(ZMQ_PUB)
+    txChannel_(ZMQ_PUB),
+    sharedBufferConfigured_(false)
 {
   // Setup logging for the class
   logger_ = Logger::getLogger("FW.SharedMemoryController");
@@ -98,6 +101,8 @@ void SharedMemoryController::setSharedBufferManager(const std::string& shared_bu
   sbm_ =  boost::shared_ptr<OdinData::SharedBufferManager>(
       new OdinData::SharedBufferManager(shared_buffer_name)
   );
+
+  sharedBufferConfigured_ = true;
 
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Initialised shared buffer manager for buffer " << shared_buffer_name);
 }
@@ -248,6 +253,20 @@ void SharedMemoryController::removeCallback(const std::string& name)
     // Confirm removal
     cb->confirmRemoval("frame_receiver");
   }
+}
+
+/**
+ * Collate status information for the plugin. The status is added to the status IpcMessage object.
+ *
+ * \param[out] status - Reference to an IpcMessage value to store the status.
+ */
+void SharedMemoryController::status(OdinData::IpcMessage& status)
+{
+  // Set status parameters in the status message
+  status.set_param(
+      SharedMemoryController::SHARED_MEMORY_CONTROLLER_NAME + "/configured",
+      sharedBufferConfigured_);
+
 }
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/SharedMemoryController.cpp
+++ b/frameProcessor/src/SharedMemoryController.cpp
@@ -92,6 +92,10 @@ SharedMemoryController::~SharedMemoryController()
  */
 void SharedMemoryController::setSharedBufferManager(const std::string& shared_buffer_name)
 {
+
+  // Set configured status to false until the new shared buffer manager is initialised
+  sharedBufferConfigured_ = false;
+
   // Reset the shared buffer manager if already existing
   if (sbm_) {
     sbm_.reset();
@@ -102,6 +106,7 @@ void SharedMemoryController::setSharedBufferManager(const std::string& shared_bu
       new OdinData::SharedBufferManager(shared_buffer_name)
   );
 
+  // Set configured status to true
   sharedBufferConfigured_ = true;
 
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Initialised shared buffer manager for buffer " << shared_buffer_name);


### PR DESCRIPTION
This PR is to address an issue identified on detector projects where the FR/FP are configured immediately prior to the start of the run. The FP, when configuring its SharedMemoryController instance, requests shared buffer configuration info from the FR asynchronously once the ZMQ channels are connected. There is currently no way to interrogate the FP to determine if has completed. If data starts arriving prior to this completion, frames are lost from the data path. The FP status reporting is therefore modified to include a shared_memory/configured flag which a controlling client can poll prior to starting data acquisition.