### PR TITLE
Improve FrameProcessor error handling

### DIFF
--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -35,6 +35,7 @@ public:
   ProcessFrameStatus process_frame(boost::shared_ptr<Frame> frame);
   void create_file(size_t file_number=0);
   void close_file(boost::shared_ptr<HDF5File> file);
+  void validate_dataset_definition(DatasetDefinition definition);
   bool start_acquisition(
       size_t concurrent_rank,
       size_t concurrent_processes,

--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -49,6 +49,7 @@ public:
   void disconnectPlugin(const std::string& index, const std::string& disconnectFrom);
   void run();
   void waitForShutdown();
+  void shutdown();
 private:
   /** Configuration constant for the meta-data Rx interface **/
   static const std::string META_RX_INTERFACE;
@@ -129,7 +130,9 @@ private:
   /** Did an error occur during the thread initialisation */
   bool                                                            threadInitError_;
   /** Have we sent sent the shutdown command to the plugins */
-  bool                                                            pluginShutdownSent;
+  bool                                                            pluginShutdownSent_;
+  /** Have we successfully shutdown */
+  bool                                                            shutdown_;
   /** Main thread used for control message handling */
   boost::thread                                                   ctrlThread_;
   /** Store for any messages occurring during thread initialisation */

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -255,6 +255,7 @@ void Acquisition::create_file(size_t file_number) {
       }
     }
 
+    validate_dataset_definition(dset_def);
     current_file->create_dataset(dset_def, low_index, high_index);
   }
 
@@ -275,6 +276,29 @@ void Acquisition::close_file(boost::shared_ptr<HDF5File> file) {
     file->close_file();
     // Send meta data message to notify of file close
     publish_meta(META_NAME, META_CLOSE_ITEM, file->get_filename(), get_meta_header());
+  }
+}
+
+/**
+ * Validate dataset definition
+ *
+ * Perform checks on the given dataset definition to ensure it is valid before creation
+ *
+ * \param[in] definition - The DatasetDefinition to validate
+ */
+void Acquisition::validate_dataset_definition(DatasetDefinition definition) {
+  // Check image dimensions
+  std::vector<long long unsigned int>::iterator iter;
+  for (iter = definition.frame_dimensions.begin(); iter != definition.frame_dimensions.end(); ++iter) {
+    if (*iter == 0) {
+      throw std::runtime_error("Image dimensions must be non-zero");
+    }
+  }
+  // Check chunk dimensions
+  for (iter = definition.chunks.begin(); iter != definition.chunks.end(); ++iter) {
+    if (*iter == 0) {
+      throw std::runtime_error("Chunk dimensions must be non-zero");
+    }
   }
 }
 

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -647,12 +647,15 @@ bool FileWriterPlugin::frame_in_acquisition(boost::shared_ptr<Frame> frame) {
     }
 
     if (frame->get_acquisition_id() == next_acquisition_->acquisition_id_) {
-      LOG4CXX_DEBUG(logger_, "Acquisition ID sent in frame matches next acquisition ID. Closing current file and starting next");
+      LOG4CXX_DEBUG(logger_, "Acquisition ID sent in frame matches next acquisition ID. "
+                             "Closing current file and starting next");
       stop_writing();
       start_writing();
     } else {
-      LOG4CXX_WARN(logger_, "Unexpected acquisition ID on frame [" << frame->get_acquisition_id() << "] for frame " << frame->get_frame_number());
-      // TODO set status? (There's currently no mechanism to report this in the status message)
+      std::stringstream ss;
+      ss << "Unexpected acquisition ID on frame [" << frame->get_acquisition_id() << "] "
+            "for frame " << frame->get_frame_number();
+      set_error(ss.str());
       return false;
     }
   }

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -131,7 +131,7 @@ void FileWriterPlugin::process_frame(boost::shared_ptr<Frame> frame)
         LOG4CXX_INFO(logger_, "Starting close file timeout as received last frame but missing some frames");
         start_close_file_timeout();
       } else if (status == status_invalid) {
-        LOG4CXX_WARN(logger_, "Frame invalid");
+        this->set_error("Frame invalid");
         this->set_error(current_acquisition_->get_last_error());
       }
 
@@ -316,9 +316,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
   }
   catch (std::runtime_error& e)
   {
-    std::stringstream ss;
-    ss << "Bad ctrl msg: " << e.what();
-    this->set_error(ss.str());
+    this->set_error(e.what());
     throw;
   }
 }
@@ -393,8 +391,9 @@ void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData:
     if (this->concurrent_processes_ != processes) {
       // If we are writing a file then we cannot change concurrent processes
       if (this->writing_) {
-        LOG4CXX_ERROR(logger_, "Cannot change concurrent processes whilst writing");
-        throw std::runtime_error("Cannot change concurrent processes whilst writing");
+        std::string message = "Cannot change concurrent processes whilst writing";
+        set_error(message);
+        throw std::runtime_error(message);
       }
       this->concurrent_processes_ = processes;
       LOG4CXX_DEBUG(logger_, "Concurrent processes changed to " << this->concurrent_processes_);
@@ -409,8 +408,9 @@ void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData:
     if (this->concurrent_rank_ != rank) {
       // If we are writing a file then we cannot change concurrent rank
       if (this->writing_) {
-        LOG4CXX_ERROR(logger_, "Cannot change process rank whilst writing");
-        throw std::runtime_error("Cannot change process rank whilst writing");
+        std::string message = "Cannot change process rank whilst writing";
+        set_error(message);
+        throw std::runtime_error(message);
       }
       this->concurrent_rank_ = rank;
       LOG4CXX_DEBUG(logger_, "Process rank changed to " << this->concurrent_rank_);
@@ -425,13 +425,15 @@ void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData:
     size_t block_size = config.get_param<size_t>(FileWriterPlugin::CONFIG_PROCESS_BLOCKSIZE);
     if (this->frames_per_block_ != block_size) {
       if (block_size < 1) {
-        LOG4CXX_ERROR(logger_, "Must have at least one frame per block");
-        throw std::runtime_error("Must have at least one frame per block");
+        std::string message = "Must have at least one frame per block";
+        set_error(message);
+        throw std::runtime_error(message);
       }
       // If we are writing a file then we cannot change block size
       if (this->writing_) {
-        LOG4CXX_ERROR(logger_, "Cannot change block size whilst writing");
-        throw std::runtime_error("Cannot change block size whilst writing");
+        std::string message = "Cannot change block size whilst writing";
+        set_error(message);
+        throw std::runtime_error(message);
       }
       this->frames_per_block_ = block_size;
       LOG4CXX_INFO(logger_, "Setting number of frames per block to " << frames_per_block_);
@@ -447,8 +449,9 @@ void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData:
     if (this->blocks_per_file_ != blocks_per_file) {
       // If we are writing a file then we cannot change block size
       if (this->writing_) {
-        LOG4CXX_ERROR(logger_, "Cannot change blocks per file whilst writing");
-        throw std::runtime_error("Cannot change blocks per file whilst writing");
+        std::string message = "Cannot change blocks per file whilst writing";
+        set_error(message);
+        throw std::runtime_error(message);
       }
       this->blocks_per_file_ = blocks_per_file;
       LOG4CXX_INFO(logger_, "Setting number of blocks per file to " << blocks_per_file_);

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -557,7 +557,7 @@ int main(int argc, char** argv)
 
   } catch (const std::exception& e) {
     LOG4CXX_ERROR(logger, e.what());
-    // Nothing to do, terminate gracefully(?)
+    throw;
   }
   return 0;
 }

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -556,7 +556,7 @@ int main(int argc, char** argv)
     LOG4CXX_DEBUG_LEVEL(1, logger, "FrameProcessorController run finished. Stopping app.");
 
   } catch (const std::exception& e) {
-    LOG4CXX_ERROR(logger, e.what());
+    LOG4CXX_ERROR(logger, "Caught unhandled exception in FrameProcessor, application will terminate: " << e.what());
     throw;
   }
   return 0;

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -721,7 +721,7 @@ void FrameProcessorController::closeMetaRxInterface()
 void FrameProcessorController::setupMetaTxInterface(const std::string& metaEndpointString)
 {
   try {
-    LOG4CXX_DEBUG(logger_, "Connecting meta TX channel to endpoint: " << metaEndpointString);
+    LOG4CXX_INFO(logger_, "Connecting meta TX channel to endpoint: " << metaEndpointString);
     int sndHwmSet = META_TX_HWM;
     metaTxChannel_.setsockopt(ZMQ_SNDHWM, &sndHwmSet, sizeof (sndHwmSet));
     metaTxChannel_.bind(metaEndpointString.c_str());

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -70,6 +70,7 @@ void FrameProcessorPlugin::set_error(const std::string& msg)
   }
   if (!found_error){
     error_messages_.push_back(msg);
+    LOG4CXX_ERROR(logger_, msg);
   }
 }
 

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -465,8 +465,9 @@ HDF5File::HDF5Dataset_t& HDF5File::get_hdf5_dataset(const std::string dset_name)
   if (this->hdf5_datasets_.find(dset_name) == this->hdf5_datasets_.end())
   {
     // no dataset of this name exist
-    LOG4CXX_ERROR(logger_, "Attempted to access non-existent dataset: \"" << dset_name << "\"\n");
-    throw std::runtime_error("Attempted to access non-existent dataset");
+    std::stringstream message;
+    message << "Attempted to access non-existent dataset: \"" << dset_name << "\"\n";
+    throw std::runtime_error(message.str());
   }
   return this->hdf5_datasets_.at(dset_name);
 }

--- a/frameProcessor/src/OffsetAdjustmentPlugin.cpp
+++ b/frameProcessor/src/OffsetAdjustmentPlugin.cpp
@@ -78,7 +78,6 @@ void OffsetAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::I
   {
     std::stringstream ss;
     ss << "Bad ctrl msg: " << e.what();
-    LOG4CXX_WARN(logger_, ss);
     this->set_error(ss.str());
     throw;
   }

--- a/tools/python/odin_data/odin_data_adapter.py
+++ b/tools/python/odin_data/odin_data_adapter.py
@@ -463,5 +463,16 @@ class OdinDataAdapter(ApiAdapter):
 
             index += 1
 
+            self.process_updates()
+
         # Schedule the update loop to run in the IOLoop instance again after appropriate interval
         IOLoop.instance().call_later(self._update_interval, self.update_loop)
+
+    def process_updates(self):
+        """Handle additional background update loop tasks
+
+        Child classes can implement logic here to take any action based on the
+        latest parameter tree, before the next update is scheduled.
+
+        """
+        pass

--- a/tools/python/odin_data/odin_data_adapter.py
+++ b/tools/python/odin_data/odin_data_adapter.py
@@ -452,17 +452,16 @@ class OdinDataAdapter(ApiAdapter):
             except Exception as e:
                 # Exception caught, log the error but do not stop the update loop
                 logging.error("Unhandled exception: %s", e)
-            try:
-                # Request a configuration update
-                client.send_request('request_configuration')
-                # Now request a status update
-                client.send_request('status')
-            except Exception as e:
-                # Exception caught, log the error but do not stop the update loop
-                logging.error("Unhandled exception: %s", e)
+
+            # Request parameter updates
+            for parameter_tree in ["status", "request_configuration"]:
+                try:
+                    client.send_request(parameter_tree)
+                except Exception as e:
+                    # Log the error, but do not stop the update loop
+                    logging.error("Unhandled exception: %s", e)
 
             index += 1
 
         # Schedule the update loop to run in the IOLoop instance again after appropriate interval
         IOLoop.instance().call_later(self._update_interval, self.update_loop)
-


### PR DESCRIPTION
Handle errors and expose them to the client more consistently.
Stop the swallowing of exceptions at the top of the FrameProcessorApp.
Implement a process_updates method in the odin_data_adapter update_loop
  to allow child classes to perform some extra logic after a parameter tree update.