### PR TITLE
Fix implementation of debug level logging

### DIFF
--- a/common/include/DebugLevelLogger.h
+++ b/common/include/DebugLevelLogger.h
@@ -15,13 +15,10 @@ using namespace log4cxx::helpers;
 typedef unsigned int DebugLevel;
 
 extern DebugLevel debug_level;
+void set_debug_level(DebugLevel level);
 
 #define LOG4CXX_DEBUG_LEVEL(level, logger, message) { \
   if (LOG4CXX_UNLIKELY(level <= debug_level)) {\
     LOG4CXX_DEBUG(logger, message); }}
-
-#define IMPLEMENT_DEBUG_LEVEL \
-  DebugLevel debug_level = 0; \
-  void set_debug_level(DebugLevel level) { debug_level = level; }
 
 #endif /* INCLUDE_DEBUGLEVELLOGGER_H_ */

--- a/common/src/DebugLevelLogger.cpp
+++ b/common/src/DebugLevelLogger.cpp
@@ -1,0 +1,8 @@
+#include "DebugLevelLogger.h"
+
+DebugLevel debug_level = 0;
+
+void set_debug_level(DebugLevel level)
+{
+  debug_level = level;
+}

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -37,8 +37,6 @@ using namespace rapidjson;
 
 using namespace FrameProcessor;
 
-IMPLEMENT_DEBUG_LEVEL;
-
 static bool has_suffix(const std::string &str, const std::string &suffix)
 {
   return str.size() >= suffix.size() &&

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -12,7 +12,6 @@
 
 namespace FrameProcessor
 {
-IMPLEMENT_DEBUG_LEVEL;
 
 const std::string FrameProcessorController::META_RX_INTERFACE        = "inproc://meta_rx";
 

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -3,7 +3,6 @@
  *
  */
 #include "DebugLevelLogger.h"
-IMPLEMENT_DEBUG_LEVEL;
 
 #define BOOST_TEST_MODULE "FrameProcessorUnitTests"
 #define BOOST_TEST_MAIN

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -23,8 +23,6 @@ using namespace FrameReceiver;
 
 boost::shared_ptr<FrameReceiverController> FrameReceiverApp::controller_;
 
-IMPLEMENT_DEBUG_LEVEL;
-
 static bool has_suffix(const std::string &str, const std::string &suffix)
 {
   return str.size() >= suffix.size() &&

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -15,10 +15,6 @@ using namespace FrameReceiver;
 #define SHARED_LIBRARY_SUFFIX ".so"
 #endif
 
-namespace FrameReceiver {
-  IMPLEMENT_DEBUG_LEVEL;
-}
-
 //! Constructor for the FrameReceiverController class.
 //!
 //! This constructor initialises the logger, IPC channels and state

--- a/frameReceiver/test/FrameReceiverUnitTestMain.cpp
+++ b/frameReceiver/test/FrameReceiverUnitTestMain.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "DebugLevelLogger.h"
-IMPLEMENT_DEBUG_LEVEL;
 
 #define BOOST_TEST_MODULE "FrameReceiverUnitTests"
 #define BOOST_TEST_MAIN


### PR DESCRIPTION
The recent change to make debug level logging available more widely across odin-data has exposed a flaw in the old mechanism of using `IMPLEMENT_DEBUG_LEVEL` to define (vs declare) the global `debug_level` variable and the `set_debug_level` function. 

Both the FR and FP need to call `set_debug_level` in both the main app (when parsing command-line or config file options) and in their respective controller, when modifying the debug level in response to a configuration request. This led to multiple references to IMPLEMENT_DEBUG_LEVEL in different namespaces, causing there to be multiple debug levels per application 😬 .

This PR solves this problem **and** that raised by @hir12111's recent [EXCALIBUR PR](https://github.com/dls-controls/excalibur-detector/pull/24) by putting the concrete definition of the debug level into a source file in the core odin-data library, which all applications link to. This avoids any need for `IMPLEMENT_DEBUG_LEVEL` - code can make use debug levels simply by including `DebugLevelLogger.h`.

Downstream plugins will need to remove references to `IMPLEMENT_DEBUG_LEVEL` once this is merged. Has been tested on excalibur-detector.