### PR TITLE
Live view test fix

### DIFF
--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -11,7 +11,7 @@
 namespace FrameProcessor
 {
 /* Default Config*/
-const int32_t     LiveViewPlugin::DEFAULT_FRAME_FREQ = 2;
+const int32_t     LiveViewPlugin::DEFAULT_FRAME_FREQ = 1;
 const int32_t     LiveViewPlugin::DEFAULT_PER_SECOND = 0;
 const std::string LiveViewPlugin::DEFAULT_IMAGE_VIEW_SOCKET_ADDR = "tcp://127.0.0.1:5020";
 const std::string LiveViewPlugin::DEFAULT_DATASET_NAME = "";

--- a/frameProcessor/test/LiveViewUnitTest.cpp
+++ b/frameProcessor/test/LiveViewUnitTest.cpp
@@ -78,6 +78,9 @@ public:
   }
   ~LiveViewPluginTestFixture() {
     BOOST_TEST_MESSAGE("Live View Fixture Teardown");
+    uint32_t linger_option = 0;
+    recv_socket.setsockopt(ZMQ_LINGER, &linger_option, sizeof(linger_option));
+    recv_socket_other.setsockopt(ZMQ_LINGER, &linger_option, sizeof(linger_option));
     recv_socket.close();
     recv_socket_other.close();
   }


### PR DESCRIPTION
Fix the issue https://github.com/odin-detector/odin-data/issues/124 by incrementing the port number for the plugin's ZMQ socket by one for each test. This avoids the "same address" errors that were being produced by the socket not closing correctly.