### PR TITLE
Add support for UDP trailer mode to frame receiver

### DIFF
--- a/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -39,9 +39,11 @@ public:
   const size_t get_packet_header_size(void) const { return static_cast<const size_t>(0); };
   void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr) { };
 
+  inline const bool trailer_mode(void) const { return false; };
+
   void* get_next_payload_buffer(void) const { return static_cast<void *>(0); };
   size_t get_next_payload_size(void) const { return static_cast<const size_t>(0); };
-  FrameDecoder::FrameReceiveState process_packet(size_t bytes_received);
+  FrameDecoder::FrameReceiveState process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr);
 
   void monitor_buffers(void) { };
   void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);

--- a/frameReceiver/include/FrameDecoderUDP.h
+++ b/frameReceiver/include/FrameDecoderUDP.h
@@ -40,12 +40,6 @@ public:
 
   virtual const bool requires_header_peek(void) const = 0;
 
-//-----
-
-  virtual const bool trailer_mode(void) const = 0;
-
-//-----
-
   virtual const size_t get_packet_header_size(void) const = 0;
   virtual void* get_packet_header_buffer(void) = 0;
   virtual void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr) = 0;

--- a/frameReceiver/include/FrameDecoderUDP.h
+++ b/frameReceiver/include/FrameDecoderUDP.h
@@ -40,13 +40,19 @@ public:
 
   virtual const bool requires_header_peek(void) const = 0;
 
+//-----
+
+  virtual const bool trailer_mode(void) const = 0;
+
+//-----
+
   virtual const size_t get_packet_header_size(void) const = 0;
   virtual void* get_packet_header_buffer(void) = 0;
   virtual void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr) = 0;
 
   virtual void* get_next_payload_buffer(void) const = 0;
   virtual size_t get_next_payload_size(void) const = 0;
-  virtual FrameReceiveState process_packet(size_t bytes_received) = 0;
+  virtual FrameReceiveState process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr) = 0;
 };
 
 inline FrameDecoderUDP::~FrameDecoderUDP() {};

--- a/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -34,7 +34,7 @@ void DummyUDPFrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& config_
   LOG4CXX_TRACE(logger_, "DummyFrameDecoderUDP init called");
 }
 
-FrameDecoder::FrameReceiveState DummyUDPFrameDecoder::process_packet(size_t bytes_received)
+FrameDecoder::FrameReceiveState DummyUDPFrameDecoder::process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr)
 {
   LOG4CXX_TRACE(logger_, "DummyFrameDecoderUDP process_packet called");
   return FrameDecoder::FrameReceiveStateComplete;


### PR DESCRIPTION
This PR adds support for UDP 'trailer mode' to the frame receiver, where the packet level metadata is appended to the payload. This is required for some STFC-supported detector systems. The primary change is to the logic of building the `io_vec`list for receiving UDP packets and a change to the `process_packet` argument list to allow that method to identify the source of incoming packets. **NB** this requires a modification to the process_packet method in **all** UDP frame decoders (e.g. PERCIVAL, EXCALIBUR).

This change has been validated with a modified EXCALIBUR decoder plugin.