### PR TITLE
Reset frame receiver statistics

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -92,6 +92,7 @@ public:
     MsgValCmdRequestConfiguration,   //!< Request configuration command message
     MsgValCmdBufferConfigRequest,    //!< Buffer configuration request
     MsgValCmdBufferPrechargeRequest, //!< Buffer precharge request
+    MsgValCmdResetStatistics,        //!< Reset statistics command
     MsgValCmdShutdown,               //!< Process shutdown request
     MsgValNotifyIdentity,            //!< Identity notification message
     MsgValNotifyFrameReady,          //!< Frame ready notification message

--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -55,6 +55,9 @@ private:
 } // namespace OdinData
 
 // Override rapidsjon assertion mechanism before including appropriate headers
+#ifdef RAPIDJSON_ASSERT
+#undef RAPIDJSON_ASSERT
+#endif
 #define RAPIDJSON_ASSERT(x) if (!(x)) throw OdinData::IpcMessageException("rapidjson assertion thrown");
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -495,6 +495,7 @@ void IpcMessage::msg_val_map_init()
   msg_val_map_.insert(MsgValMapEntry("request_configuration",    MsgValCmdRequestConfiguration));
   msg_val_map_.insert(MsgValMapEntry("request_buffer_config",    MsgValCmdBufferConfigRequest));
   msg_val_map_.insert(MsgValMapEntry("request_buffer_precharge", MsgValCmdBufferPrechargeRequest));
+  msg_val_map_.insert(MsgValMapEntry("reset_statistics",         MsgValCmdResetStatistics));
   msg_val_map_.insert(MsgValMapEntry("shutdown",                 MsgValCmdShutdown));
   msg_val_map_.insert(MsgValMapEntry("identity",                 MsgValNotifyIdentity));
   msg_val_map_.insert(MsgValMapEntry("frame_ready",              MsgValNotifyFrameReady));

--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -43,6 +43,7 @@ public:
   void provideStatus(OdinData::IpcMessage& reply);
   void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void requestConfiguration(OdinData::IpcMessage& reply);
+  void resetStatistics(OdinData::IpcMessage& reply);
   void configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void loadPlugin(const std::string& index, const std::string& name, const std::string& library);
   void connectPlugin(const std::string& index, const std::string& connectTo);

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -33,6 +33,7 @@ public:
   std::string get_name();
   void set_error(const std::string& msg);
   void clear_errors();
+  virtual bool reset_statistics();
   std::vector<std::string> get_errors();
   virtual void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   virtual void requestConfiguration(OdinData::IpcMessage& reply);

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -82,6 +82,16 @@ void FrameProcessorPlugin::clear_errors()
   error_messages_.clear();
 }
 
+/** Reset any statistics.
+ *
+ * Any counters in the plugin should be reset by this method
+ */
+bool FrameProcessorPlugin::reset_statistics()
+{
+  // Default method does nothing
+  return true;
+}
+
 /** Return the current error message.
  *
  */

--- a/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -45,12 +45,14 @@ public:
 
   void monitor_buffers(void) { };
   void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);
+  void reset_statistics(void);
 
   void* get_packet_header_buffer(void){ return reinterpret_cast<void *>(0); };
 
 private:
 
   unsigned int udp_packets_per_frame_;
+  unsigned int status_get_count_;
 
 };
 

--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -76,6 +76,7 @@ public:
   const unsigned int get_num_frames_timedout(void) const;
   virtual void monitor_buffers(void) = 0;
   virtual void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) = 0;
+  virtual void reset_statistics(void);
 
 protected:
   LoggerPtr logger_;  //!< Pointer to the logging facility

--- a/frameReceiver/include/FrameReceiverController.h
+++ b/frameReceiver/include/FrameReceiverController.h
@@ -81,6 +81,7 @@ namespace FrameReceiver
     void notify_buffer_config(const bool deferred=false);
     void store_rx_thread_status(OdinData::IpcMessage& rx_status_msg);
     void get_status(OdinData::IpcMessage& status_reply);
+    void reset_statistics(OdinData::IpcMessage& reset_reply);
     void request_configuration(OdinData::IpcMessage& config_reply);
 
 #ifdef FR_CONTROLLER_TICK_TIMER

--- a/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -11,7 +11,8 @@ using namespace FrameReceiver;
 
 DummyUDPFrameDecoder::DummyUDPFrameDecoder() :
     FrameDecoderUDP(),
-    udp_packets_per_frame_(DummyUdpFrameDecoderDefaults::default_udp_packets_per_frame)
+    udp_packets_per_frame_(DummyUdpFrameDecoderDefaults::default_udp_packets_per_frame),
+    status_get_count_(0)
 {
 
 }
@@ -43,5 +44,14 @@ FrameDecoder::FrameReceiveState DummyUDPFrameDecoder::process_packet(size_t byte
 void DummyUDPFrameDecoder::get_status(const std::string param_prefix,
     OdinData::IpcMessage& status_msg)
 {
+  status_get_count_++;
   status_msg.set_param(param_prefix + "name", std::string("DummyUDPFrameDecoder"));
+  status_msg.set_param(param_prefix + "status_get_count", status_get_count_);
+}
+
+void DummyUDPFrameDecoder::reset_statistics()
+{
+  FrameDecoderUDP::reset_statistics();
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "DummyUDPFrameDecoder resetting statistics");
+  status_get_count_ = 0;
 }

--- a/frameReceiver/src/FrameDecoder.cpp
+++ b/frameReceiver/src/FrameDecoder.cpp
@@ -174,3 +174,15 @@ void FrameDecoder::drop_all_buffers(void)
   }
 }
 
+//! Reset frame decoder statistics.
+//!
+//! This method resets the frame decoder statistics. In this base class this
+//! is limited to setting the timed-out frames count to zero. Dervied decoder classes
+//! which override this method should ensure the base class version is explicitly called.
+//!
+void FrameDecoder::reset_statistics(void)
+{
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Resetting frame decoder statistics");
+    frames_timedout_ = 0;
+}
+

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -763,6 +763,12 @@ void FrameReceiverController::handle_ctrl_channel(void)
               this->get_status(ctrl_reply);
               break;
 
+          case IpcMessage::MsgValCmdResetStatistics:
+              LOG4CXX_DEBUG_LEVEL(3, logger_,
+                "Got reset statistics request from client " << client_identity);
+              this->reset_statistics(ctrl_reply);
+              break;
+
           case IpcMessage::MsgValCmdShutdown:
               LOG4CXX_DEBUG_LEVEL(3, logger_,
                 "Got shutdown command request from client " << client_identity);
@@ -1101,6 +1107,26 @@ void FrameReceiverController::request_configuration(OdinData::IpcMessage& config
   // Add frame count to reply parameters
   config_reply.set_param(CONFIG_FRAME_COUNT, config_.frame_count_);
 
+}
+
+//! Reset the frame receiver statistics.
+//!
+//! This method resets the frame receiver statistics present in status responses.
+//! If a frame decoder is configured, its reset method is called to clear any
+//! decoder specific values.
+//!
+//! \param[in,out] reset_reply - IpcMessage reply to reset request
+//!
+void FrameReceiverController::reset_statistics(OdinData::IpcMessage& reset_reply)
+{
+
+  // Set the reply type to acknowledge
+  reset_reply.set_msg_type(IpcMessage::MsgTypeAck);
+
+  // If a decoder is configured, calls its reset method
+  if (frame_decoder_) {
+    frame_decoder_->reset_statistics();
+  }
 }
 
 #ifdef FR_CONTROLLER_TICK_TIMER

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -1123,10 +1123,15 @@ void FrameReceiverController::reset_statistics(OdinData::IpcMessage& reset_reply
   // Set the reply type to acknowledge
   reset_reply.set_msg_type(IpcMessage::MsgTypeAck);
 
-  // If a decoder is configured, calls its reset method
+  // If a decoder is configured, call its reset method
   if (frame_decoder_) {
     frame_decoder_->reset_statistics();
   }
+
+  // Reset frames recevied and released counters
+  frames_received_ = 0;
+  frames_released_ = 0;
+
 }
 
 #ifdef FR_CONTROLLER_TICK_TIMER

--- a/tools/python/odin_data/odin_data_adapter.py
+++ b/tools/python/odin_data/odin_data_adapter.py
@@ -376,25 +376,19 @@ class OdinDataAdapter(ApiAdapter):
     def send_command_to_clients(self, command, client_index=-1):
         status_code = 200
         response = {}
-        if client_index == -1:
-            # We are sending the value to all clients
-            for client in self._clients:
-                try:
+        try:
+            if client_index == -1:
+                # We are sending the value to all clients
+                for client in self._clients:
                     client.send_request(command)
-                except Exception as err:
-                    logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
-                    logging.error("Error: %s", err)
-                    status_code = 503
-                    response = {'error': OdinDataAdapter.ERROR_FAILED_TO_SEND}
-        else:
-            # A client index has been specified
-            try:
+            else:
+                # A client index has been specified
                 self._clients[client_index].send_request(command)
-            except Exception as err:
-                logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
-                logging.error("Error: %s", err)
-                status_code = 503
-                response = {'error': OdinDataAdapter.ERROR_FAILED_TO_SEND}
+        except Exception as err:
+            logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
+            logging.error("Error: %s", err)
+            status_code = 503
+            response = {'error': OdinDataAdapter.ERROR_FAILED_TO_SEND}
         return response, status_code
 
     def send_to_clients(self, request_command, parameters, client_index=-1):

--- a/tools/python/odin_data/odin_data_adapter.py
+++ b/tools/python/odin_data/odin_data_adapter.py
@@ -24,6 +24,8 @@ class OdinDataAdapter(ApiAdapter):
     ERROR_FAILED_GET = "Unable to successfully complete the GET request"
     ERROR_PUT_MISMATCH = "The size of parameter array does not match the number of clients"
 
+    SUPPORTED_COMMANDS = ['reset_statistics']
+    
     def __init__(self, **kwargs):
         """
         Initialise the OdinDataAdapter object
@@ -183,7 +185,7 @@ class OdinDataAdapter(ApiAdapter):
         request_command = path.strip('/')
 
         try:
-            # Request should start with config/
+            # Request should start with either config/ or command/
             if request_command.startswith("config/"):
                 request_command = remove_prefix(request_command, "config/")  # Take the rest of the URI
 
@@ -207,11 +209,50 @@ class OdinDataAdapter(ApiAdapter):
                         self._config_params[request_command] = parameters
                     logging.debug("Stored config items: %s", self._config_params)
                 response, status_code = self.process_configuration(request_command, parameters)
+
+            elif request_command.startswith("command/"):
+                request_command = remove_prefix(request_command, "command/")  # Take the rest of the URI
+
+                client_index, uri_items = self.parse_uri(request_command)
+                # Check that the command is supported
+                # For a command the uri_items object should always be length 1, the command
+                if len(uri_items) > 1:
+                    logging.debug(OdinDataAdapter.ERROR_FAILED_PUT)
+                    status_code = 503
+                    response['error'] = 'Invalid URI for command: {}'.format(request_command)
+                else:
+                    command = uri_items[0]
+                    if command in self.SUPPORTED_COMMANDS:
+                        # Create the IPC message and send to all clients
+                        response, status_code = self.send_command_to_clients(command, client_index)
+                    else:
+                        logging.debug(OdinDataAdapter.ERROR_FAILED_PUT)
+                        status_code = 503
+                        response['error'] = 'Invalid command requested: {}'.format(command)
+
         except Exception as ex:
             self.set_error(str(ex))
             raise
 
         return ApiAdapterResponse(response, status_code=status_code)
+
+    def parse_uri(self, request_command):
+        # Split the request_command into a list
+        uri_items = request_command.split('/')
+
+        client_index = -1
+        # Check to see if the URI finishes with an index
+        try:
+            index = int(uri_items[-1])
+            if index >= 0:
+                # This is a valid index so remove the value from the URI
+                uri_items = uri_items[:-1]
+                # Set the client index for submitting config to
+                client_index = index
+        except ValueError:
+            # This is OK, there is simply no index provided
+            pass
+        return client_index, uri_items
 
     def process_configuration(self, request_command, parameters):
         status_code = 200
@@ -331,6 +372,30 @@ class OdinDataAdapter(ApiAdapter):
         logging.debug(response)
 
         return ApiAdapterResponse(response, status_code=status_code)
+
+    def send_command_to_clients(self, command, client_index=-1):
+        status_code = 200
+        response = {}
+        if client_index == -1:
+            # We are sending the value to all clients
+            for client in self._clients:
+                try:
+                    client.send_request(command)
+                except Exception as err:
+                    logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
+                    logging.error("Error: %s", err)
+                    status_code = 503
+                    response = {'error': OdinDataAdapter.ERROR_FAILED_TO_SEND}
+        else:
+            # A client index has been specified
+            try:
+                self._clients[client_index].send_request(command)
+            except Exception as err:
+                logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
+                logging.error("Error: %s", err)
+                status_code = 503
+                response = {'error': OdinDataAdapter.ERROR_FAILED_TO_SEND}
+        return response, status_code
 
     def send_to_clients(self, request_command, parameters, client_index=-1):
         status_code = 200


### PR DESCRIPTION
This PR addresses #125 and JIRA ticket [BC-769](https://jira.diamond.ac.uk/browse/BC-769). A `reset_statistics` command is implemented in `IpcMessage` and causes the FR and its loaded decoder plugin to reset any frame and packet level statistics. Derived decoder classes should implement a `reset_statistics` method to implement this.

@ajgdls will review this for implementation in the frame processor + migration of `clear_errors` from config parameter to command. Suggest that implementation is added to this branch and PR?