### PR TITLE
Fix buffer precharge

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -94,6 +94,7 @@ public:
     MsgValNotifyFrameReady,          //!< Frame ready notification message
     MsgValNotifyFrameRelease,        //!< Frame release notification message
     MsgValNotifyBufferConfig,        //!< Buffer configuration notification
+    MsgValNotifyBufferPrecharge,     //!< Buffer precharge notification
     MsgValNotifyStatus,              //!< Status notification 
   };
 

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -500,6 +500,7 @@ void IpcMessage::msg_val_map_init()
   msg_val_map_.insert(MsgValMapEntry("frame_ready",              MsgValNotifyFrameReady));
   msg_val_map_.insert(MsgValMapEntry("frame_release",            MsgValNotifyFrameRelease));
   msg_val_map_.insert(MsgValMapEntry("buffer_config",            MsgValNotifyBufferConfig));
+  msg_val_map_.insert(MsgValMapEntry("buffer_precharge",         MsgValNotifyBufferPrecharge));
   msg_val_map_.insert(MsgValMapEntry("notify_status",            MsgValNotifyStatus));
 }
 

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -942,8 +942,8 @@ void FrameReceiverController::handle_frame_release_channel(void)
 //!
 //! This method precharges all the buffers available in the shared buffer manager onto the
 //! empty buffer queue in the receiver thread. This allows the receiver thread to obtain a pool
-//! of empty buffers at startup, and is done by sending frame release notificaitons for all buffers
-//! over the RX thread channel.
+//! of empty buffers at startup, and is done by sending a buffer precharge notification over the
+//! RX thread channel.
 //!
 void FrameReceiverController::precharge_buffers(void)
 {
@@ -951,14 +951,10 @@ void FrameReceiverController::precharge_buffers(void)
   // Only pre-charge buffers if a buffer manager and RX thread are configured
   if (buffer_manager_ && rx_thread_)
   {
-
-    // Loop over all buffers in the buffer manager and send a frame release notification for each
-    for (int buf = 0; buf < buffer_manager_->get_num_buffers(); buf++)
-    {
-      IpcMessage buf_msg(IpcMessage::MsgTypeNotify, IpcMessage::MsgValNotifyFrameRelease);
-      buf_msg.set_param<int>("buffer_id", buf);
-      rx_channel_.send(buf_msg.encode(), 0, rx_thread_identity_);
-    }
+    IpcMessage precharge_msg(IpcMessage::MsgTypeNotify, IpcMessage::MsgValNotifyBufferPrecharge);
+    precharge_msg.set_param<int>("start_buffer_id", 0);
+    precharge_msg.set_param<int>("num_buffers", buffer_manager_->get_num_buffers());
+    rx_channel_.send(precharge_msg.encode(), 0, rx_thread_identity_);
   }
   else
   {

--- a/frameReceiver/src/FrameReceiverRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverRxThread.cpp
@@ -267,6 +267,27 @@ void FrameReceiverRxThread::handle_rx_channel(void)
 
         switch (msg_val)
         {
+        case IpcMessage::MsgValNotifyBufferPrecharge:
+          {
+            int start_buffer_id = rx_msg.get_param<int>("start_buffer_id", -1);
+            int num_buffers = rx_msg.get_param<int>("num_buffers", -1);
+
+            if ((start_buffer_id == -1) || (num_buffers == -1))
+            {
+              LOG4CXX_ERROR(logger_, "RX thread received precharge notification with missing buffer parameters");
+            }
+            else
+            {
+              for (int buffer_id = start_buffer_id; buffer_id < start_buffer_id + num_buffers; buffer_id++)
+              {
+                frame_decoder_->push_empty_buffer(buffer_id);
+              }
+              LOG4CXX_DEBUG_LEVEL(1, logger_, "Precharged " << num_buffers << " empty buffers onto queue, "
+                << "length is now " << frame_decoder_->get_num_empty_buffers());
+            }
+          }
+          break;
+
         case IpcMessage::MsgValNotifyFrameRelease:
           {
             


### PR DESCRIPTION
Fixes issue reported in #131 and [BC-684](https://jira.diamond.ac.uk/browse/BC-684) where frame receivers with large shared buffers inconsistently precharge buffers onto the RX thread empty queue, depending on run-time performance caused by e.g. debug level. Individual buffer precharge messages are replaced with a single precharge notification for a range of buffers, which the RX thread then pushes itself onto the queue.

**NB** This does not fix the other part of BC-684 concerning inconsistent buffer reporting when the FP has died and needs restarting.