### PR TITLE
Add ability to specify number of ZMQ io_threads in frame receiver and processor

### DIFF
--- a/common/include/IpcChannel.h
+++ b/common/include/IpcChannel.h
@@ -21,11 +21,11 @@ namespace OdinData
 class IpcContext
 {
 public:
-  static IpcContext& Instance(void);
+  static IpcContext& Instance(unsigned int io_threads=1);
   zmq::context_t& get(void);
 
 private:
-  IpcContext(int io_threads=1);
+  IpcContext(unsigned int io_threads=1);
   IpcContext(const IpcContext&);
   IpcContext& operator=(const IpcContext&);
 

--- a/common/src/IpcChannel.cpp
+++ b/common/src/IpcChannel.cpp
@@ -17,10 +17,11 @@ using namespace OdinData;
 //! This static method retrieves the singleton IpcContext instance used
 //! by call IpcChannels in an application.
 //!
-IpcContext& IpcContext::Instance(void)
+IpcContext& IpcContext::Instance(unsigned int io_threads)
 {
-  static IpcContext ipcContext;
-  return ipcContext;
+  static IpcContext ipc_context(io_threads);
+
+  return ipc_context;
 }
 
 //! Retrieve the underlying ZeroMQ context from the IpcContext instance
@@ -42,7 +43,7 @@ zmq::context_t& IpcContext::get(void)
 //!
 //! \param[in] io_threads - number of IO threads to create.
 //!
-IpcContext::IpcContext(int io_threads) :
+IpcContext::IpcContext(unsigned int io_threads) :
     zmq_context_(io_threads)
 {
 }

--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -36,7 +36,7 @@ class FrameProcessorController : public IFrameCallback,
                                  public boost::enable_shared_from_this<FrameProcessorController>
 {
 public:
-  FrameProcessorController();
+  FrameProcessorController(unsigned int num_io_threads=1);
   virtual ~FrameProcessorController();
   void handleCtrlChannel();
   void handleMetaRxChannel();
@@ -141,6 +141,8 @@ private:
   boost::shared_ptr<OdinData::IpcReactor>                         reactor_;
   /** End point for control messages */
   std::string                                                     ctrlChannelEndpoint_;
+  /** ZMQ context for IPC channels */
+  OdinData::IpcContext& ipc_context_;
   /** IpcChannel for control messages */
   OdinData::IpcChannel                                            ctrlChannel_;
   /** IpcChannel for meta-data messages */

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -66,6 +66,8 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
            "Set the debug level")
         ("logconfig,l",   po::value<string>(),
            "Set the log4cxx logging configuration file")
+        ("iothreads",     po::value<unsigned int>()->default_value(1),
+           "Set number of IPC channel IO threads")
         ("ctrl",          po::value<std::string>()->default_value("tcp://0.0.0.0:5004"),
            "Set the control endpoint")
         ("ready",         po::value<std::string>()->default_value("tcp://127.0.0.1:5001"),
@@ -182,6 +184,11 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
     {
       set_debug_level(vm["debug-level"].as<unsigned int>());
       LOG4CXX_DEBUG_LEVEL(1, logger, "Debug level set to  " << debug_level);
+    }
+
+    if (vm.count("iothreads"))
+    {
+      LOG4CXX_DEBUG_LEVEL(1, logger, "Setting number of IO threads to " << vm["iothreads"].as<unsigned int>());
     }
 
     bool no_client = vm["no-client"].as<bool>();
@@ -493,8 +500,9 @@ int main(int argc, char** argv)
     po::variables_map vm;
     parse_arguments(argc, argv, vm, logger);
 
+    unsigned int num_io_threads = vm["iothreads"].as<unsigned int>();
     boost::shared_ptr<FrameProcessorController> fwc;
-    fwc = boost::shared_ptr<FrameProcessorController>(new FrameProcessorController());
+    fwc = boost::shared_ptr<FrameProcessorController>(new FrameProcessorController(num_io_threads));
 
     // Configure the control channel for the FrameProcessor
     OdinData::IpcMessage cfg;

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -42,13 +42,14 @@ const int FrameProcessorController::META_TX_HWM = 10000;
  * The constructor sets up logging used within the class, and starts the
  * IpcReactor thread.
  */
-FrameProcessorController::FrameProcessorController() :
+FrameProcessorController::FrameProcessorController(unsigned int num_io_threads) :
     logger_(log4cxx::Logger::getLogger("FP.FrameProcessorController")),
     runThread_(true),
     threadRunning_(false),
     threadInitError_(false),
     pluginShutdownSent_(false),
     shutdown_(false),
+    ipc_context_(OdinData::IpcContext::Instance(num_io_threads)),
     ctrlThread_(boost::bind(&FrameProcessorController::runIpcService, this)),
     ctrlChannelEndpoint_(""),
     ctrlChannel_(ZMQ_ROUTER),

--- a/frameReceiver/include/FrameReceiverConfig.h
+++ b/frameReceiver/include/FrameReceiverConfig.h
@@ -50,6 +50,7 @@ class FrameReceiverConfig
 public:
 
   FrameReceiverConfig() :
+  
       max_buffer_mem_(Defaults::default_max_buffer_mem),
       decoder_path_(Defaults::default_decoder_path),
       decoder_type_(Defaults::default_decoder_type),
@@ -57,6 +58,7 @@ public:
       rx_type_(Defaults::default_rx_type),
       rx_address_(Defaults::default_rx_address),
       rx_recv_buffer_size_(Defaults::default_rx_recv_buffer_size),
+      io_threads_(Defaults::default_io_threads),
       rx_channel_endpoint_(Defaults::default_rx_chan_endpoint),
       ctrl_channel_endpoint_(Defaults::default_ctrl_chan_endpoint),
       frame_ready_endpoint_(Defaults::default_frame_ready_endpoint),
@@ -187,6 +189,7 @@ private:
   std::vector<uint16_t> rx_ports_;               //!< Port(s) to receive frame data on
   std::string           rx_address_;             //!< IP address to receive frame data on
   int                   rx_recv_buffer_size_;    //!< Receive socket buffer size
+  unsigned int          io_threads_;             //!< Number of IO threads for IPC channels
   std::string           rx_channel_endpoint_;    //!< IPC channel endpoint for RX thread communication
   std::string           ctrl_channel_endpoint_;  //!< IPC channel endpoint for control communication with other processes
   std::string           frame_ready_endpoint_;   //!< IPC channel endpoint for transmitting frame ready notifications to other processes

--- a/frameReceiver/include/FrameReceiverController.h
+++ b/frameReceiver/include/FrameReceiverController.h
@@ -106,6 +106,7 @@ namespace FrameReceiver
     bool rx_thread_configured_;           //!< Indicates that the RX thread is configured
     bool configuration_complete_;         //!< Indicates that all components are configured
     
+    IpcContext& ipc_context_;             //!< ZMQ context for IPC channels
     IpcChannel rx_channel_;               //!< Channel for communication with receiver thread
     IpcChannel ctrl_channel_;             //!< Channel for communication with  control clients
     IpcChannel frame_ready_channel_;      //!< Channel for signalling to downstream processes

--- a/frameReceiver/include/FrameReceiverDefaults.h
+++ b/frameReceiver/include/FrameReceiverDefaults.h
@@ -28,6 +28,7 @@ enum RxType
 };
 
 const int          default_node                   = 1;
+const unsigned int default_io_threads             = 1;
 const std::size_t  default_max_buffer_mem         = 1048576;
 const std::string  default_decoder_path           = std::string(BUILD_DIR) + "/lib/";
 const std::string  default_decoder_type           = "unknown";

--- a/frameReceiver/src/FrameReceiverApp.cpp
+++ b/frameReceiver/src/FrameReceiverApp.cpp
@@ -40,11 +40,6 @@ FrameReceiverApp::FrameReceiverApp(void) : json_config_file_("")
   OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   logger_ = Logger::getLogger("FR.App");
 
-  // Instantiate a controller
-  controller_ = boost::shared_ptr<FrameReceiverController>(
-      new FrameReceiverController(config_)
-  );
-
 }
 
 //! Destructor for FrameReceiverApp class
@@ -118,6 +113,8 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
         "Enable logging of packet diagnostics to file")
         ("rxbuffer",     po::value<unsigned int>()->default_value(FrameReceiver::Defaults::default_rx_recv_buffer_size),
         "Set UDP receive buffer size")
+        ("iothreads",    po::value<unsigned int>()->default_value(FrameReceiver::Defaults::default_io_threads),
+        "Set number of IPC channel IO threads")
         ("ctrl",         po::value<std::string>()->default_value(FrameReceiver::Defaults::default_ctrl_chan_endpoint),
         "Set the control channel endpoint")
         ("ready",        po::value<std::string>()->default_value(FrameReceiver::Defaults::default_frame_ready_endpoint),
@@ -267,6 +264,12 @@ int FrameReceiverApp::parse_arguments(int argc, char** argv)
       LOG4CXX_DEBUG_LEVEL(1, logger_, "RX receive buffer size is " << config_.rx_recv_buffer_size_);
     }
 
+    if (vm.count("iothreads"))
+    {
+      config_.io_threads_ = vm["iothreads"].as<unsigned int>();
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "Setting number of IO threads to " << config_.io_threads_);
+    }
+
     if (vm.count("ctrl"))
     {
       config_.ctrl_channel_endpoint_ = vm["ctrl"].as<std::string>();
@@ -322,6 +325,11 @@ void FrameReceiverApp::run(void)
 {
 
   LOG4CXX_INFO(logger_,  "Running frame receiver");
+
+    // Instantiate a controller
+  controller_ = boost::shared_ptr<FrameReceiverController>(
+      new FrameReceiverController(config_)
+  );
 
   try {
 

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -34,6 +34,7 @@ FrameReceiverController::FrameReceiverController (FrameReceiverConfig& config) :
     buffer_manager_configured_(false),
     rx_thread_configured_(false),
     configuration_complete_(false),
+    ipc_context_(IpcContext::Instance(config.io_threads_)),
     rx_channel_(ZMQ_ROUTER),
     ctrl_channel_(ZMQ_ROUTER),
     frame_ready_channel_(ZMQ_PUB),


### PR DESCRIPTION
This PR adds the ability to set the number of IO threads assigned to the underlying IPC/ZeroMQ context in the frameReceiver and frameProcessor applications. This can be configured by:

- setting the command-line argument `--iothreads`
- setting `iothreads=<n>` in the configuration files of the FR or FP.

The default value is 1.

Note that the number of IO threads **cannot** be changed via client configuration messages, as this would require all `IpcChannels` to be torn down to allow a new `IpcContext` to be created.

Closes #134 