### PR TITLE
Add dropped frames count to FrameReceiver

### DIFF
--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -75,6 +75,7 @@ public:
   void drop_all_buffers(void);
   const unsigned int get_frame_timeout_ms(void) const;
   const unsigned int get_num_frames_timedout(void) const;
+  const unsigned int get_num_frames_dropped(void) const;
   virtual void monitor_buffers(void) = 0;
   virtual void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) = 0;
   void version(const std::string param_prefix, OdinData::IpcMessage& status);
@@ -94,6 +95,7 @@ protected:
 
   unsigned int frame_timeout_ms_; //!< Incomplete frame timeout in ms
   unsigned int frames_timedout_;  //!< Number of frames timed out in decoder
+  unsigned int frames_dropped_;   //!< Number of frames dropped due to lack of buffers
 };
 
 inline FrameDecoder::~FrameDecoder() {};

--- a/frameReceiver/src/FrameDecoder.cpp
+++ b/frameReceiver/src/FrameDecoder.cpp
@@ -19,7 +19,8 @@ FrameDecoder::FrameDecoder() :
      logger_(0),
      enable_packet_logging_(FrameReceiver::Defaults::default_enable_packet_logging),
      frame_timeout_ms_(FrameReceiver::Defaults::default_frame_timeout_ms),
-     frames_timedout_(0)
+     frames_timedout_(0),
+     frames_dropped_(0)
  {
  };
 
@@ -148,6 +149,18 @@ const unsigned int FrameDecoder::get_num_frames_timedout(void) const
     return frames_timedout_;
 }
 
+//! Get the number of frames dropped in the decoder
+//!
+//! This method returns the number of frames that have been dropped by the frame decoder.
+//! This is typically determined by specialised decoders subclassed from this class.
+//!
+//! \return - number of frames dropped
+//!
+const unsigned int FrameDecoder::get_num_frames_dropped(void) const
+{
+    return frames_dropped_;
+}
+
 //! Drop all buffers currently held by the decoder.
 //!
 //! This method forces the decoder to drop all buffers currently held either in the empty
@@ -199,4 +212,5 @@ void FrameDecoder::reset_statistics(void)
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Resetting frame decoder statistics");
     frames_timedout_ = 0;
+    frames_dropped_ = 0;
 }

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -1044,11 +1044,14 @@ void FrameReceiverController::get_status(OdinData::IpcMessage& status_reply)
   unsigned int empty_buffers = 0;
   unsigned int mapped_buffers = 0;
   unsigned int frames_timedout = 0;
+  unsigned int frames_dropped = 0;
+
   if (rx_thread_status_) 
   {
     empty_buffers = rx_thread_status_->get_param<unsigned int>("rx_thread/empty_buffers");
     mapped_buffers = rx_thread_status_->get_param<unsigned int>("rx_thread/mapped_buffers");
     frames_timedout = rx_thread_status_->get_param<unsigned int>("rx_thread/frames_timedout");
+    frames_dropped = rx_thread_status_->get_param<unsigned int>("rx_thread/frames_dropped");
 
     // If there is decoder status info present, also copy that into the reply
     if (rx_thread_status_->has_param("decoder"))
@@ -1064,6 +1067,7 @@ void FrameReceiverController::get_status(OdinData::IpcMessage& status_reply)
   status_reply.set_param("frames/timedout", frames_timedout);
   status_reply.set_param("frames/received", frames_received_);
   status_reply.set_param("frames/released", frames_released_);
+  status_reply.set_param("frames/dropped", frames_dropped);
 
 }
 

--- a/frameReceiver/src/FrameReceiverRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverRxThread.cpp
@@ -377,6 +377,7 @@ void FrameReceiverRxThread::fill_status_params(IpcMessage& status_msg)
   status_msg.set_param("rx_thread/empty_buffers", frame_decoder_->get_num_empty_buffers());
   status_msg.set_param("rx_thread/mapped_buffers", frame_decoder_->get_num_mapped_buffers());
   status_msg.set_param("rx_thread/frames_timedout", frame_decoder_->get_num_frames_timedout());
+  status_msg.set_param("rx_thread/frames_dropped", frame_decoder_->get_num_frames_dropped());
 
   // Get the specific frame decoder instance to fill its own status into message
   frame_decoder_->get_status(std::string("decoder/"), status_msg);


### PR DESCRIPTION
This PR address #150, adding a dropped frames count to the `FrameReceiver::FrameDecoder` class and reporting that value in the status response. 

It is the responsibility of the derived decoder plugins to increment the `frames_dropped_` member variable as necessary, since buffer management is implementation dependent.