### PR TITLE
Live view count fix

### DIFF
--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -102,6 +102,8 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
     {
       LOG4CXX_TRACE(logger_, "LiveViewPlugin No Tag(s) found, frame skipped.");
     }
+    //push frame down the pipeline no matter if frame was passed to live viewer or not
+    frame_count_ ++;
   }
   else
   {
@@ -109,8 +111,6 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
   }
 
   LOG4CXX_TRACE(logger_, "Pushing Data Frame" );
-  //push frame down the pipeline no matter if frame was passed to live viewer or not
-  frame_count_ ++;
   this->push(frame);
 }
 

--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -97,13 +97,13 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
         LOG4CXX_TRACE(logger_, "LiveViewPlugin Frame " << frame->get_frame_number() << " to be displayed.");
         pass_live_frame(frame);
       }
+      //Count all frames that match the dataset(s) and tag(s)
+      frame_count_ ++;
     }
     else
     {
       LOG4CXX_TRACE(logger_, "LiveViewPlugin No Tag(s) found, frame skipped.");
     }
-    //push frame down the pipeline no matter if frame was passed to live viewer or not
-    frame_count_ ++;
   }
   else
   {


### PR DESCRIPTION
Small change to the way the Live View plugin counts frames for the downscale filter. If the frames are filtered by tags and/or datasets, then it will only count frames that match those filters first. This should more closely match how you'd expect these filters to interact with one another.