### PR TITLE
Blosc compression plugin

### DIFF
--- a/.travis-install-blosc.sh
+++ b/.travis-install-blosc.sh
@@ -3,7 +3,7 @@ set -e
 BLOSC=c-blosc-1.13.1
 
 # check to see if blosc folder is empty
-if [ ! -d "$HOME/${BLOSC}/" ]; then
+if [ ! -d "$HOME/${BLOSC}/blosc" ]; then
   curl --output ${BLOSC}.tar.gz -L https://codeload.github.com/Blosc/c-blosc/tar.gz/v1.13.1;
   tar -zxf ${BLOSC}.tar.gz;
   cd ${BLOSC};

--- a/.travis-install-blosc.sh
+++ b/.travis-install-blosc.sh
@@ -3,14 +3,13 @@ set -e
 BLOSC=c-blosc-1.13.1
 
 # check to see if blosc folder is empty
-if [ ! -d "$HOME/${BLOSC}/blosc" ]; then
+if [ ! -d "$HOME/${BLOSC}/lib" ]; then
   curl --output ${BLOSC}.tar.gz -L https://codeload.github.com/Blosc/c-blosc/tar.gz/v1.13.1;
   tar -zxf ${BLOSC}.tar.gz;
   cd ${BLOSC};
-  install_prefix=`pwd`
   mkdir build;
   cd build;
-  cmake -DCMAKE_INSTALL_PREFIX=$install_prefix ..;
+  cmake -DCMAKE_INSTALL_PREFIX=$HOME/$BLOSC ..;
   cmake --build . --target install;
 else
   echo 'Using cached directory.';

--- a/.travis-install-blosc.sh
+++ b/.travis-install-blosc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+BLOSC=c-blosc-1.13.1
+
+# check to see if blosc folder is empty
+if [ ! -d "$HOME/${BLOSC}/" ]; then
+  curl --output ${BLOSC}.tar.gz -L https://codeload.github.com/Blosc/c-blosc/tar.gz/v1.13.1;
+  tar -zxf ${BLOSC}.tar.gz;
+  cd ${BLOSC};
+  install_prefix=`pwd`
+  mkdir build;
+  cd build;
+  cmake -DCMAKE_INSTALL_PREFIX=$install_prefix ..;
+  cmake --build . --target install;
+else
+  echo 'Using cached directory.';
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 - mkdir -p build
 - mkdir -p $INSTALL_PREFIX
 - cd build
-- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT -DBLOSC_ROOT=$BLOSC_ROOT ..
+- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT -DBLOSC_ROOT_DIR=$BLOSC_ROOT ..
 - make -j 4 VERBOSE=1
 - make install
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,21 @@ matrix:
         - libboost-thread-dev
         - libzmq3-dev
     env: PYTHONPATH=./lib/python FR_TEST_CONFIG=test_config/fr_test.config FP_TEST_CONFIG=test_config/fp_test.config
-      HDF5_ROOT=$HOME/hdf5-1.10.1 INSTALL_PREFIX=$HOME/install_prefix
+      HDF5_ROOT=$HOME/hdf5-1.10.1 BLOSC_ROOT=$HOME/c-blosc-1.13.1 INSTALL_PREFIX=$HOME/install_prefix
     before_install:
     - bash .travis-install-hdf5.sh
+    - bash .travis-install-blosc.sh
     cache:
       directories:
       - "$HOME/hdf5-1.10.1"
+      - "$HOME/c-blosc-1.13.1"
       - "$HOME/.cache/pip"
       - "$HOME/.local/lib"
 install:
 - mkdir -p build
 - mkdir -p $INSTALL_PREFIX
 - cd build
-- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT ..
+- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT -DBLOSC_ROOT=$BLOSC_ROOT ..
 - make -j 4 VERBOSE=1
 - make install
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ endif(APPLE)
 # Set up RPATH handling correctly so that both built and installed targets have the appropriate
 # settings - see https://cmake.org/Wiki/CMake_RPATH_handling
 
+set(CMAKE_MACOSX_RPATH 1)
+
 # Use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ find_package( Boost 1.41.0
 	      COMPONENTS program_options system filesystem unit_test_framework date_time thread)
 find_package(Log4CXX 0.10.0 REQUIRED)
 find_package(ZeroMQ 3.2.4 REQUIRED)
+find_package(Blosc REQUIRED)
 
 # find package HDF5
 # FindHDF5.cmake is essentially broken and does not allow

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The following libraries and packages are required:
 * [Boost](http://www.boost.org) : portable C++ utility libraries. The following components are used - program_options, unit_test_framework, date_time, interprocess, bimap (version >= 1.41)
 * [ZeroMQ](http://zeromq.org) : high-performance asynchronous messaging library (version >= 3.2.4)
 * [Log4CXX](http://logging.apache.org/log4cxx/): Configurable message logger (version >= 0.10.0)
-* [HDF5](https://www.hdfgroup.org/HDF5): __Optional:__ if found, the filewriter application will be built (version >= 1.8.14)
+* [HDF5](https://www.hdfgroup.org/HDF5): __Optional:__ if found, the frame processor application will be built (version >= 1.8.14)
+* [Blosc](http://blosc.org)/[c-blosc](https://github.com/blosc/c-blosc): __Optional:__ if found, the frame processor plugin "BloscPlugin" will be built
 
 Installing dependencies
 -----------------------
@@ -63,7 +64,8 @@ the above libraries and packages can be used by setting the following flags:
 * BOOST_ROOT
 * ZEROMQ_ROOTDIR
 * LOG4CXX_ROOT_DIR
-* HDF5_ROOT
+* HDF5_ROOT - optional: the frameProcessor will __not__ be built if HDF5 is not found.
+* BLOSC_ROOT_DIR - optional: BloscPlugin will not be built if the blosc library is not found
 
 Applications are compiled into the `bin` directory within `build` and the additional python etc tools installed into
 tools. Sample configuration files for testing the system are installed into `test_config`.  See the sections below

--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -1,0 +1,70 @@
+#
+# FindBLOSC.cmake
+#
+#
+# The MIT License
+#
+# Copyright (c) 2016 MIT and Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Finds the Blosc library. This module defines:
+#   - BLOSC_INCLUDE_DIR, directory containing headers
+#   - BLOSC_LIBRARIES, the Blosc library path
+#   - BLOSC_FOUND, whether Blosc has been found
+# Define BLOSC_ROOT_DIR if blosc is installed in a non-standard location.
+
+message ("\nLooking for blosc headers and libraries")
+
+if (BLOSC_ROOT_DIR)
+    message (STATUS "Searching Blosc Root dir: ${BLOSC_ROOT_DIR}")
+endif ()
+
+# Find header files
+if(BLOSC_ROOT_DIR)
+    find_path(
+            BLOSC_INCLUDE_DIR blosc.h
+            PATHS ${BLOSC_ROOT_DIR}/include
+            NO_DEFAULT_PATH
+    )
+else()
+    find_path(BLOSC_INCLUDE_DIR blosc.h)
+endif()
+
+# Find library
+if(BLOSC_ROOT_DIR)
+    find_library(
+            BLOSC_LIBRARIES NAMES blosc
+            PATHS ${BLOSC_ROOT_DIR}/lib
+            NO_DEFAULT_PATH
+    )
+else()
+    find_library(BLOSC_LIBRARIES NAMES blosc)
+endif()
+
+if(BLOSC_INCLUDE_DIR AND BLOSC_LIBRARIES)
+    message(STATUS "Found Blosc: ${BLOSC_LIBRARIES}")
+    set(BLOSC_FOUND TRUE)
+else()
+    set(BLOSC_FOUND FALSE)
+endif()
+
+if(NOT BLOSC_FOUND)
+    message(STATUS "Could not find the Blosc library.")
+endif()

--- a/config/fp_log4cxx.xml
+++ b/config/fp_log4cxx.xml
@@ -45,5 +45,6 @@
  <logger name="FW.SHM"></logger>
  <logger name="FW.Frame"></logger>
  <logger name="FW.FileWriter"></logger>
+ <logger name="FW.BloscPlugin"></logger>
 
 </log4j:configuration>

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -23,7 +23,7 @@ typedef struct{
   size_t type_size;
   size_t uncompressed_size;
   unsigned int threads;
-  unsigned int blosc_compressor; // TODO: change from using blosc compressor definition as unsigned int to string
+  unsigned int blosc_compressor;
 } BloscCompressionSettings;
 void create_cd_values(const BloscCompressionSettings& settings, std::vector<unsigned int> cd_values);
 

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -9,11 +9,7 @@
 #define TOOLS_FILEWRITER_BLOSCPLUGIN_H_
 
 #include <log4cxx/logger.h>
-#include <log4cxx/basicconfigurator.h>
-#include <log4cxx/propertyconfigurator.h>
-#include <log4cxx/helpers/exception.h>
 using namespace log4cxx;
-using namespace log4cxx::helpers;
 
 #include "FrameProcessorPlugin.h"
 #include "ClassLoader.h"
@@ -33,6 +29,7 @@ class BloscPlugin : public FrameProcessorPlugin
 public:
   BloscPlugin();
   virtual ~BloscPlugin();
+  boost::shared_ptr<Frame> compress_frame(boost::shared_ptr<Frame> frame);
 
 private:
   void process_frame(boost::shared_ptr<Frame> frame);

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -17,6 +17,15 @@ using namespace log4cxx;
 namespace FrameProcessor
 {
 
+typedef struct{
+  int compression_level;
+  unsigned int shuffle;
+  size_t type_size;
+  size_t uncompressed_size;
+  unsigned int blosc_compressor;
+} BloscCompressionSettings;
+void create_cd_values(const BloscCompressionSettings& settings, std::vector<unsigned int> cd_values);
+
 /**
 * This is a compression plugin using the Blosc library
 *
@@ -34,6 +43,7 @@ public:
 
 private:
   void process_frame(boost::shared_ptr<Frame> frame);
+  const BloscCompressionSettings &update_compression_settings(const std::string &acquisition_id);
 
   /** Pointer to logger */
   LoggerPtr logger_;

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -5,8 +5,8 @@
  *      Author: Ulrik Pedersen
  */
 
-#ifndef TOOLS_FILEWRITER_BLOSCPLUGIN_H_
-#define TOOLS_FILEWRITER_BLOSCPLUGIN_H_
+#ifndef BLOSCPLUGIN_H_
+#define BLOSCPLUGIN_H_
 
 #include <log4cxx/logger.h>
 using namespace log4cxx;
@@ -18,14 +18,15 @@ namespace FrameProcessor
 {
 
 /**
- * This is a compression plugin using the Blosc library
- *
- * When this plugin receives a frame, processFrame is called and the class
- * uses the blosc compression methods to compress the data and output a new,
- * compressed Frame.
- */
+* This is a compression plugin using the Blosc library
+*
+* When this plugin receives a frame, processFrame is called and the class
+* uses the blosc compression methods to compress the data and output a new,
+* compressed Frame.
+*/
 class BloscPlugin : public FrameProcessorPlugin
 {
+
 public:
   BloscPlugin();
   virtual ~BloscPlugin();
@@ -58,4 +59,4 @@ REGISTER(FrameProcessorPlugin, BloscPlugin, "BloscPlugin");
 
 } /* namespace FrameProcessor */
 
-#endif /* TOOLS_FILEWRITER_BLOSCPLUGIN_H_ */
+#endif /* BLOSCPLUGIN_H_ */

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -43,7 +43,7 @@ public:
 
 private:
   void process_frame(boost::shared_ptr<Frame> frame);
-  const BloscCompressionSettings &update_compression_settings(const std::string &acquisition_id);
+  void update_compression_settings(const std::string &acquisition_id);
 
   /** Pointer to logger */
   LoggerPtr logger_;

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -82,12 +82,6 @@ private:
 
 };
 
-/**
- * Registration of this plugin through the ClassLoader. This macro
- * registers the class without needing to worry about name mangling
- */
-REGISTER(FrameProcessorPlugin, BloscPlugin, "BloscPlugin");
-
 } /* namespace FrameProcessor */
 
 #endif /* BLOSCPLUGIN_H_ */

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -1,0 +1,64 @@
+/*
+ * BloscPlugin.h
+ *
+ *  Created on: 22 Jan 2018
+ *      Author: Ulrik Pedersen
+ */
+
+#ifndef TOOLS_FILEWRITER_BLOSCPLUGIN_H_
+#define TOOLS_FILEWRITER_BLOSCPLUGIN_H_
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "FrameProcessorPlugin.h"
+#include "ClassLoader.h"
+
+namespace FrameProcessor
+{
+
+/**
+ * This is a compression plugin using the Blosc library
+ *
+ * When this plugin receives a frame, processFrame is called and the class
+ * uses the blosc compression methods to compress the data and output a new,
+ * compressed Frame.
+ */
+class BloscPlugin : public FrameProcessorPlugin
+{
+public:
+  BloscPlugin();
+  virtual ~BloscPlugin();
+
+private:
+  void process_frame(boost::shared_ptr<Frame> frame);
+
+  /** Pointer to logger */
+  LoggerPtr logger_;
+  /** Current acquisition ID */
+  std::string current_acquisition_;
+  /** Compression settings */
+  BloscCompressionSettings compression_settings_;
+  /** Compression settings for the next acquisition */
+  BloscCompressionSettings commanded_compression_settings_;
+
+  int get_version_major();
+  int get_version_minor();
+  int get_version_patch();
+  std::string get_version_short();
+  std::string get_version_long();
+};
+
+/**
+ * Registration of this plugin through the ClassLoader. This macro
+ * registers the class without needing to worry about name mangling
+ */
+REGISTER(FrameProcessorPlugin, BloscPlugin, "BloscPlugin");
+
+} /* namespace FrameProcessor */
+
+#endif /* TOOLS_FILEWRITER_BLOSCPLUGIN_H_ */

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -55,7 +55,7 @@ private:
   std::string get_version_long();
 
   // Methods unique to this class
-  void update_compression_settings(const std::string &acquisition_id);
+  void update_compression_settings();
 
   // private data
   /** Pointer to logger */

--- a/frameProcessor/include/BloscPlugin.h
+++ b/frameProcessor/include/BloscPlugin.h
@@ -56,6 +56,7 @@ private:
 
   // Methods unique to this class
   void update_compression_settings();
+  void * get_buffer(size_t nbytes);
 
   // private data
   /** Pointer to logger */
@@ -68,6 +69,9 @@ private:
   BloscCompressionSettings compression_settings_;
   /** Compression settings for the next acquisition */
   BloscCompressionSettings commanded_compression_settings_;
+  /** Temporary buffer for compressed data */
+  void * data_buffer_ptr_;
+  size_t data_buffer_size_;
 
 private:
   /** Configuration constants */

--- a/frameProcessor/include/CMakeLists.txt
+++ b/frameProcessor/include/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Install header files into installation prefix
 
-SET(HEADERS DataBlock.h DataBlockPool.h Frame.h FrameProcessorPlugin.h FileWriterPlugin.h IFrameCallback.h MetaMessage.h MetaMessagePublisher.h WorkQueue.h HDF5File.h Acquisition.h FrameProcessorDefinitions.h)
+SET(HEADERS DataBlock.h DataBlockPool.h Frame.h FrameProcessorPlugin.h FileWriterPlugin.h BloscPlugin.h IFrameCallback.h MetaMessage.h MetaMessagePublisher.h WorkQueue.h HDF5File.h Acquisition.h FrameProcessorDefinitions.h)
 INSTALL(FILES ${HEADERS} DESTINATION include/frameProcessor)

--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -99,6 +99,10 @@ private:
   static const std::string CONFIG_DATASET_COMPRESSION;
   /** Configuration constant for data high/low indexes */
   static const std::string CONFIG_DATASET_INDEXES;
+  /** Configurations for Blosc compression */
+  static const std::string CONFIG_DATASET_BLOSC_COMPRESSOR;
+  static const std::string CONFIG_DATASET_BLOSC_LEVEL;
+  static const std::string CONFIG_DATASET_BLOSC_SHUFFLE;
 
   /** Configuration constant for number of frames to write */
   static const std::string CONFIG_FRAMES;

--- a/frameProcessor/include/Frame.h
+++ b/frameProcessor/include/Frame.h
@@ -173,6 +173,7 @@ public:
   bool has_parameter(const std::string& index);
   void set_compression(int compression);
   void set_data_type(int data_type);
+  size_t get_data_type_size();
 
 private:
   Frame();

--- a/frameProcessor/include/FrameProcessorDefinitions.h
+++ b/frameProcessor/include/FrameProcessorDefinitions.h
@@ -80,6 +80,10 @@ namespace FrameProcessor
     std::vector<long long unsigned int> chunks;
     /** Compression state of data **/
     CompressionType compression;
+    /** Compression configuration settings **/
+    unsigned int blosc_compressor;
+    unsigned int blosc_level;
+    unsigned int blosc_shuffle;
     /** Whether to create Low/High indexes for this dataset **/
     bool create_low_high_indexes;
   };

--- a/frameProcessor/include/FrameProcessorDefinitions.h
+++ b/frameProcessor/include/FrameProcessorDefinitions.h
@@ -17,7 +17,7 @@ namespace FrameProcessor
   /**
    * Enumeration to store the compression type of the incoming image
    */
-  enum CompressionType { no_compression, lz4, bslz4 };
+  enum CompressionType { no_compression, lz4, bslz4, blosc };
   /**
    * Enumeration to store the compression type of the incoming image
    */

--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -69,6 +69,8 @@ private:
   static const H5Z_filter_t LZ4_FILTER = (H5Z_filter_t)32004;
   /** Filter definition to write datasets with bitshuffle processed data */
   static const H5Z_filter_t BSLZ4_FILTER = (H5Z_filter_t)32008;
+  /** Filter definition to write datasets with Blosc processed data */
+  static const H5Z_filter_t BLOSC_FILTER = (H5Z_filter_t)32001;
 
   /** Flush rate for parameter datasets in miliseconds */
   static const int PARAM_FLUSH_RATE = 1000;

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -385,7 +385,7 @@ bool Acquisition::check_frame_valid(boost::shared_ptr<Frame> frame)
     ss << "Invalid frame: Frame has compression " << frame->get_compression() <<
           ", expected " << dataset.compression <<
           " for dataset " << dataset.name <<
-          " (0: None, 1: LZ4, 2: BSLZ4)";
+          " (0: None, 1: LZ4, 2: BSLZ4, 3: Blosc)";
     last_error_ = ss.str();
     LOG4CXX_ERROR(logger_, last_error_);
     invalid = true;

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -55,17 +55,19 @@ current_acquisition_("")
   this->commanded_compression_settings_.compression_level = 1;
   this->commanded_compression_settings_.type_size = 0;
   this->commanded_compression_settings_.uncompressed_size = 0;
+  this->commanded_compression_settings_.threads = 1;
   this->compression_settings_ = this->commanded_compression_settings_;
 
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.BloscPlugin");
   logger_->setLevel(Level::getAll());
-  LOG4CXX_TRACE(logger_, "BloscPlugin constructor");
+  LOG4CXX_TRACE(logger_, "BloscPlugin constructor. Version: " << this->get_version_long());
 
   //blosc_init(); // not required for blosc >= v1.9
   int ret = 0;
   ret = blosc_set_compressor(BLOSC_LZ4_COMPNAME);
   if (ret < 0) LOG4CXX_ERROR(logger_, "Blosc unable to set compressor: " << BLOSC_LZ4_COMPNAME);
+  blosc_set_nthreads(this->compression_settings_.threads);
   LOG4CXX_TRACE(logger_, "Blosc Version: " << blosc_get_version_string());
   LOG4CXX_TRACE(logger_, "Blosc list available compressors: " << blosc_list_compressors());
   LOG4CXX_TRACE(logger_, "Blosc current compressor: " << blosc_get_compressor());

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -133,7 +133,7 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
     dest_frame->set_frame_number(src_frame->get_frame_number());
     dest_frame->set_acquisition_id(src_frame->get_acquisition_id());
     // TODO: is this the correct way to get and set dimensions?
-    dest_frame->set_dimensions("data", src_frame->get_dimensions("data"));
+    dest_frame->set_dimensions(src_frame->get_dimensions());
   }
   catch (const std::exception& e) {
     LOG4CXX_ERROR(logger_, "Serious error in Blosc compression: " << e.what());

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -1,0 +1,122 @@
+/*
+ * BloscPlugin.cpp
+ *
+ *  Created on: 22 Jan 2018
+ *      Author: Ulrik Pedersen
+ */
+
+#include <blosc.h>
+#include <version.h>
+#include <BloscPlugin.h>
+
+namespace FrameProcessor
+{
+
+/**
+ * The constructor sets up logging used within the class.
+ */
+BloscPlugin::BloscPlugin()
+{
+  // Setup logging for the class
+  logger_ = Logger::getLogger("FW.BloscPlugin");
+  logger_->setLevel(Level::getAll());
+  LOG4CXX_TRACE(logger_, "BloscPlugin constructor.");
+
+  //blosc_init(); // not required for blosc >= v1.9
+  LOG4CXX_TRACE(logger_, "Blosc Version: " << blosc_get_version_string());
+  LOG4CXX_TRACE(logger_, "Blosc list available compressors: " << blosc_list_compressors());
+  LOG4CXX_TRACE(logger_, "Blosc current compressor: " << blosc_get_compressor());
+  LOG4CXX_TRACE(logger_, "Blosc # threads: " << blosc_get_nthreads());
+
+}
+
+/**
+ * Destructor.
+ */
+BloscPlugin::~BloscPlugin()
+{
+  LOG4CXX_TRACE(logger_, "BloscPlugin destructor.");
+}
+
+/**
+ * Perform compression on the frame and output a new, compressed Frame.
+ *
+ * \param[in] frame - Pointer to a Frame object.
+ */
+void BloscPlugin::process_frame(boost::shared_ptr<Frame> src_frame)
+{
+  int compressed_size = 0;
+
+  LOG4CXX_TRACE(logger_, "Received a new frame...");
+
+  const void* src_data_ptr = static_cast<const void*>(
+      static_cast<const char*>(src_frame->get_data())
+  );
+  const size_t raw_data_size = src_frame->get_data_size();
+  LOG4CXX_TRACE(logger_, "Frame data size: " << raw_data_size);
+
+  try {
+    // TODO: is this malloc really necessary? Can't we get writable DataBlocks somehow?
+    void *dest_data_ptr = malloc(src_frame->get_data_size());
+    // TODO: error check on the malloc here...
+
+    LOG4CXX_TRACE(logger_, "Compressing frame no. " << src_frame->get_frame_number());
+    // TODO: all args are hard-coded here and need to be turned into parameters
+    compressed_size = blosc_compress(1, 1, src_frame->get_data_type_size(),
+                                     raw_data_size, src_data_ptr, dest_data_ptr, raw_data_size);
+    if (compressed_size > 0) {
+      double factor = 0.;
+      factor = (double)raw_data_size / (double)compressed_size;
+      LOG4CXX_TRACE(logger_, "Compression factor of: " << factor);
+    }
+
+    boost::shared_ptr <Frame> dest_frame;
+    dest_frame = boost::shared_ptr<Frame>(new Frame(src_frame->get_dataset_name()));
+
+    LOG4CXX_TRACE(logger_, "Copying compressed data to output frame. (" << compressed_size << " bytes)");
+    // I wish we had a pointer swap feature on the Frame class and avoid this unnecessary copy...
+    dest_frame->copy_data(dest_data_ptr, compressed_size);
+
+    // I wish we had a shallow-copy feature on the Frame class...
+    dest_frame->set_data_type(src_frame->get_data_type());
+    dest_frame->set_frame_number(src_frame->get_frame_number());
+    dest_frame->set_acquisition_id(src_frame->get_acquisition_id());
+    // TODO: is this the correct way to get and set dimensions?
+    dest_frame->set_dimensions("data", src_frame->get_dimensions("data"));
+
+    LOG4CXX_TRACE(logger_, "Pushing compressed frame");
+    this->push(dest_frame);
+    free(dest_data_ptr);
+    dest_data_ptr = NULL;
+  }
+  catch (const std::exception& e){
+    LOG4CXX_ERROR(logger_, "Serious error in Blosc compression: " << e.what());
+  }
+}
+
+int BloscPlugin::get_version_major()
+{
+  return ODIN_DATA_VERSION_MAJOR;
+}
+
+int BloscPlugin::get_version_minor()
+{
+  return ODIN_DATA_VERSION_MINOR;
+}
+
+int BloscPlugin::get_version_patch()
+{
+  return ODIN_DATA_VERSION_PATCH;
+}
+
+std::string BloscPlugin::get_version_short()
+{
+  return ODIN_DATA_VERSION_STR_SHORT;
+}
+
+std::string BloscPlugin::get_version_long()
+{
+  return ODIN_DATA_VERSION_STR;
+}
+
+} /* namespace FrameProcessor */

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -13,21 +13,56 @@ namespace FrameProcessor
 {
 
 /**
- * The constructor sets up logging used within the class.
+ * cd_values[7] meaning (see blosc.h):
+ *   0: reserved
+ *   1: reserved
+ *   2: type size
+ *   3: uncompressed size
+ *   4: compression level
+ *   5: 0: shuffle not active, 1: byte shuffle, 2: bit shuffle
+ *   6: the actual Blosc compressor to use. See blosc.h
+ *
+ * @param settings
+ * @return
  */
-BloscPlugin::BloscPlugin()
+void create_cd_values(const BloscCompressionSettings& settings, std::vector<unsigned int>& cd_values)
 {
+  if (cd_values.size() < 7) cd_values.resize(7);
+  cd_values[0] = 0;
+  cd_values[1] = 0;
+  cd_values[2] = static_cast<unsigned int>(settings.type_size);
+  cd_values[3] = static_cast<unsigned int>(settings.uncompressed_size);
+  cd_values[4] = settings.compression_level;
+  cd_values[5] = settings.shuffle;
+  cd_values[6] = settings.blosc_compressor;
+}
+
+/**
+* The constructor sets up logging used within the class.
+*/
+BloscPlugin::BloscPlugin() :
+current_acquisition_("")
+{
+  this->commanded_compression_settings_.blosc_compressor = BLOSC_LZ4;
+  this->commanded_compression_settings_.shuffle = BLOSC_BITSHUFFLE;
+  this->commanded_compression_settings_.compression_level = 1;
+  this->commanded_compression_settings_.type_size = 2;
+  this->commanded_compression_settings_.uncompressed_size = 0;
+  this->compression_settings_ = this->commanded_compression_settings_;
+
   // Setup logging for the class
   logger_ = Logger::getLogger("FW.BloscPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_TRACE(logger_, "BloscPlugin constructor.");
 
   //blosc_init(); // not required for blosc >= v1.9
+  int ret = 0;
+  ret = blosc_set_compressor(BLOSC_LZ4_COMPNAME);
+  if (ret < 0) LOG4CXX_ERROR(logger_, "Blosc unable to set compressor: " << BLOSC_LZ4_COMPNAME);
   LOG4CXX_TRACE(logger_, "Blosc Version: " << blosc_get_version_string());
   LOG4CXX_TRACE(logger_, "Blosc list available compressors: " << blosc_list_compressors());
   LOG4CXX_TRACE(logger_, "Blosc current compressor: " << blosc_get_compressor());
   LOG4CXX_TRACE(logger_, "Blosc # threads: " << blosc_get_nthreads());
-
 }
 
 /**
@@ -44,13 +79,16 @@ BloscPlugin::~BloscPlugin()
 boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> src_frame)
 {
   int compressed_size = 0;
+  BloscCompressionSettings c_settings;
   boost::shared_ptr <Frame> dest_frame;
 
   const void* src_data_ptr = static_cast<const void*>(
       static_cast<const char*>(src_frame->get_data())
   );
-  const size_t raw_data_size = src_frame->get_data_size();
-  LOG4CXX_TRACE(logger_, "Frame data size: " << raw_data_size);
+
+  c_settings = this->update_compression_settings(src_frame->get_acquisition_id());
+  c_settings.type_size = src_frame->get_data_type_size();
+  c_settings.uncompressed_size = src_frame->get_data_size();
 
   size_t dest_data_size = src_frame->get_data_size() + BLOSC_MAX_OVERHEAD;
   // TODO: is this malloc really necessary? Can't we get writable DataBlocks somehow?
@@ -58,13 +96,16 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
   if (dest_data_ptr == NULL) {throw std::runtime_error("Failed to malloc buffer for Blosc compression output");}
 
   try {
-    LOG4CXX_TRACE(logger_, "Compressing frame no. " << src_frame->get_frame_number());
+    LOG4CXX_TRACE(logger_, "Compressing frame no. " << src_frame->get_frame_number()
+      << " with: " << blosc_get_compressor());
     // TODO: all args are hard-coded here and need to be turned into parameters
-    compressed_size = blosc_compress(1, 1, src_frame->get_data_type_size(),
-                                     raw_data_size, src_data_ptr, dest_data_ptr, dest_data_size);
+    compressed_size = blosc_compress(c_settings.compression_level, c_settings.shuffle,
+                                     src_frame->get_data_type_size(),
+                                     src_frame->get_data_size(), src_data_ptr,
+                                     dest_data_ptr, dest_data_size);
     if (compressed_size > 0) {
       double factor = 0.;
-      factor = (double)raw_data_size / (double)compressed_size;
+      factor = (double)src_frame->get_data_size() / (double)compressed_size;
       LOG4CXX_TRACE(logger_, "Compression factor of: " << factor);
     }
 
@@ -88,6 +129,34 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
     if (dest_data_ptr != NULL) {free(dest_data_ptr); dest_data_ptr = NULL;}
   }
   return dest_frame;
+}
+
+/**
+ * Update the compression settings used if the acquisition ID differs from the current one.
+ * i.e. if a new acquisition has been started.
+ *
+ * @param acquisition_id
+ * @return a const ref to the compression settings
+ */
+const BloscCompressionSettings& BloscPlugin::update_compression_settings(const std::string &acquisition_id)
+{
+  if (acquisition_id != this->current_acquisition_){
+    LOG4CXX_TRACE(logger_, "New acquisition detected: "<< acquisition_id);
+    this->compression_settings_ = this->commanded_compression_settings_;
+    this->current_acquisition_ = acquisition_id;
+    int ret = 0;
+    char * compressor_name;
+    blosc_compcode_to_compname(this->compression_settings_.blosc_compressor,
+                               &compressor_name);
+    ret = blosc_set_compressor(compressor_name);
+    if (ret < 0) {
+      LOG4CXX_ERROR(logger_, "Blosc failed to set compressor: "
+          << " " << this->compression_settings_.blosc_compressor
+          << " " << compressor_name)
+      throw std::runtime_error("Blosc failed to set compressor");
+    }
+  }
+  return this->compression_settings_;
 }
 
   /**

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -121,6 +121,12 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
                                      c_settings.type_size,
                                      c_settings.uncompressed_size, src_data_ptr,
                                      dest_data_ptr, dest_data_size);
+    if (compressed_size < 0) {
+      std::stringstream ss;
+      ss << "blosc_compress failed. error=" << compressed_size << ss_blosc_settings.str();
+      LOG4CXX_ERROR(logger_, ss.str());
+      throw std::runtime_error(ss.str());
+    }
     double factor = 0.;
     if (compressed_size > 0) {
       factor = (double)src_frame->get_data_size() / (double)compressed_size;

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -51,7 +51,7 @@ current_acquisition_("")
   this->compression_settings_ = this->commanded_compression_settings_;
 
   // Setup logging for the class
-  logger_ = Logger::getLogger("FW.BloscPlugin");
+  logger_ = Logger::getLogger("FP.BloscPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_TRACE(logger_, "BloscPlugin constructor.");
 

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -87,7 +87,12 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
   );
 
   c_settings = this->update_compression_settings(src_frame->get_acquisition_id());
-  c_settings.type_size = src_frame->get_data_type_size();
+  if (src_frame->get_data_type() >= 0) {
+    c_settings.type_size = src_frame->get_data_type_size();
+  }
+  else { // TODO: This if/else is a hack to work around Frame::data_type_ not being set. See https://jira.diamond.ac.uk/browse/BC-811
+    c_settings.type_size = 2; // hack: just default to 16bit per pixel as Excalibur use that
+  }
   c_settings.uncompressed_size = src_frame->get_data_size();
 
   size_t dest_data_size = c_settings.uncompressed_size + BLOSC_MAX_OVERHEAD;

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -167,7 +167,7 @@ void BloscPlugin::update_compression_settings()
   this->compression_settings_ = this->commanded_compression_settings_;
 
   int ret = 0;
-  const char * p_compressor_name;
+  char * p_compressor_name;
   ret = blosc_compcode_to_compname(this->compression_settings_.blosc_compressor, &p_compressor_name);
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Blosc compression settings: "
                                   << " acquisition=\"" << this->current_acquisition_ << "\""
@@ -181,7 +181,7 @@ void BloscPlugin::update_compression_settings()
   if (ret < 0) {
     LOG4CXX_ERROR(logger_, "Blosc failed to set compressor: "
         << " " << this->compression_settings_.blosc_compressor
-        << " " << *p_compressor_name)
+        << " " << *p_compressor_name);
     throw std::runtime_error("Blosc failed to set compressor");
   }
   blosc_set_nthreads(this->compression_settings_.threads);

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -4,7 +4,7 @@
  *  Created on: 22 Jan 2018
  *      Author: Ulrik Pedersen
  */
-
+#include <cstdlib>
 #include <blosc.h>
 #include <version.h>
 #include <BloscPlugin.h>
@@ -39,15 +39,12 @@ BloscPlugin::~BloscPlugin()
 }
 
 /**
- * Perform compression on the frame and output a new, compressed Frame.
- *
- * \param[in] frame - Pointer to a Frame object.
+ * Compress one frame, return compressed frame.
  */
-void BloscPlugin::process_frame(boost::shared_ptr<Frame> src_frame)
+boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> src_frame)
 {
   int compressed_size = 0;
-
-  LOG4CXX_TRACE(logger_, "Received a new frame...");
+  boost::shared_ptr <Frame> dest_frame;
 
   const void* src_data_ptr = static_cast<const void*>(
       static_cast<const char*>(src_frame->get_data())
@@ -56,26 +53,28 @@ void BloscPlugin::process_frame(boost::shared_ptr<Frame> src_frame)
   LOG4CXX_TRACE(logger_, "Frame data size: " << raw_data_size);
 
   try {
+    size_t dest_data_size = src_frame->get_data_size() + BLOSC_MAX_OVERHEAD;
     // TODO: is this malloc really necessary? Can't we get writable DataBlocks somehow?
-    void *dest_data_ptr = malloc(src_frame->get_data_size());
+    void *dest_data_ptr = malloc(dest_data_size);
     // TODO: error check on the malloc here...
 
     LOG4CXX_TRACE(logger_, "Compressing frame no. " << src_frame->get_frame_number());
     // TODO: all args are hard-coded here and need to be turned into parameters
     compressed_size = blosc_compress(1, 1, src_frame->get_data_type_size(),
-                                     raw_data_size, src_data_ptr, dest_data_ptr, raw_data_size);
+                                     raw_data_size, src_data_ptr, dest_data_ptr, dest_data_size);
     if (compressed_size > 0) {
       double factor = 0.;
       factor = (double)raw_data_size / (double)compressed_size;
       LOG4CXX_TRACE(logger_, "Compression factor of: " << factor);
     }
 
-    boost::shared_ptr <Frame> dest_frame;
     dest_frame = boost::shared_ptr<Frame>(new Frame(src_frame->get_dataset_name()));
 
     LOG4CXX_TRACE(logger_, "Copying compressed data to output frame. (" << compressed_size << " bytes)");
     // I wish we had a pointer swap feature on the Frame class and avoid this unnecessary copy...
     dest_frame->copy_data(dest_data_ptr, compressed_size);
+    free(dest_data_ptr);
+    dest_data_ptr = NULL;
 
     // I wish we had a shallow-copy feature on the Frame class...
     dest_frame->set_data_type(src_frame->get_data_type());
@@ -83,15 +82,24 @@ void BloscPlugin::process_frame(boost::shared_ptr<Frame> src_frame)
     dest_frame->set_acquisition_id(src_frame->get_acquisition_id());
     // TODO: is this the correct way to get and set dimensions?
     dest_frame->set_dimensions("data", src_frame->get_dimensions("data"));
-
-    LOG4CXX_TRACE(logger_, "Pushing compressed frame");
-    this->push(dest_frame);
-    free(dest_data_ptr);
-    dest_data_ptr = NULL;
   }
-  catch (const std::exception& e){
+  catch (const std::exception& e) {
     LOG4CXX_ERROR(logger_, "Serious error in Blosc compression: " << e.what());
   }
+  return dest_frame;
+}
+
+  /**
+ * Perform compression on the frame and output a new, compressed Frame.
+ *
+ * \param[in] frame - Pointer to a Frame object.
+ */
+void BloscPlugin::process_frame(boost::shared_ptr<Frame> src_frame)
+{
+  LOG4CXX_TRACE(logger_, "Received a new frame...");
+  boost::shared_ptr <Frame> compressed_frame = this->compress_frame(src_frame);
+  LOG4CXX_TRACE(logger_, "Pushing compressed frame");
+  this->push(compressed_frame);
 }
 
 int BloscPlugin::get_version_major()

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -145,14 +145,14 @@ const BloscCompressionSettings& BloscPlugin::update_compression_settings(const s
     this->compression_settings_ = this->commanded_compression_settings_;
     this->current_acquisition_ = acquisition_id;
     int ret = 0;
-    char * compressor_name;
+    const char ** p_compressor_name;
     blosc_compcode_to_compname(this->compression_settings_.blosc_compressor,
-                               &compressor_name);
-    ret = blosc_set_compressor(compressor_name);
+                               p_compressor_name);
+    ret = blosc_set_compressor(*p_compressor_name);
     if (ret < 0) {
       LOG4CXX_ERROR(logger_, "Blosc failed to set compressor: "
           << " " << this->compression_settings_.blosc_compressor
-          << " " << compressor_name)
+          << " " << *p_compressor_name)
       throw std::runtime_error("Blosc failed to set compressor");
     }
   }

--- a/frameProcessor/src/BloscPluginLib.cpp
+++ b/frameProcessor/src/BloscPluginLib.cpp
@@ -1,0 +1,20 @@
+/*
+ * BloscPluginLib.cpp
+ *
+ */
+
+#include "BloscPlugin.h"
+#include "ClassLoader.h"
+
+namespace FrameProcessor
+{
+    /**
+     * Registration of this plugin through the ClassLoader.  This macro
+     * registers the class without needing to worry about name mangling
+     */
+	REGISTER(FrameProcessorPlugin, BloscPlugin, "BloscPlugin");
+
+} // namespace FrameProcessor
+
+
+

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS DummyPlugin DESTINATION lib)
 # Add library for Blosc plugin
 if (${BLOSC_FOUND})
   include_directories(${BLOSC_INCLUDE_DIR})
-  add_library(BloscPlugin SHARED BloscPlugin.cpp)
+  add_library(BloscPlugin SHARED BloscPlugin.cpp BloscPluginLib.cpp)
   target_link_libraries(BloscPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${BLOSC_LIBRARIES} ${COMMON_LIBRARY})
   install(TARGETS BloscPlugin DESTINATION lib)
 endif()

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -43,6 +43,14 @@ add_library(DummyPlugin SHARED DummyPlugin.cpp)
 target_link_libraries(DummyPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 install(TARGETS DummyPlugin DESTINATION lib)
 
+# Add library for Blosc plugin
+if (${BLOSC_FOUND})
+  include_directories(${BLOSC_INCLUDE_DIR})
+  add_library(BloscPlugin SHARED BloscPlugin.cpp)
+  target_link_libraries(BloscPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${BLOSC_LIBRARIES} ${COMMON_LIBRARY})
+  install(TARGETS BloscPlugin DESTINATION lib)
+endif()
+
 # Add library for HDF5 writer plugin
 add_library(Hdf5Plugin SHARED FileWriterPlugin.cpp FileWriterPluginLib.cpp HDF5File.cpp Acquisition.cpp)
 target_link_libraries(Hdf5Plugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -586,16 +586,21 @@ void FileWriterPlugin::configure_dataset(const std::string& dataset_name, OdinDa
     LOG4CXX_INFO(logger_, "Enabling compression: " << dset.compression);
 
     // Blosc compression require a set of parameters to be defined
-    // TODO: Check parameters for valid ranges
     if (dset.compression == blosc) {
       if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR)) {
-        dset.blosc_compressor = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR);
+        dset.blosc_compressor = config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR);
+        if (dset.blosc_compressor<0 || dset.blosc_compressor>5)
+          LOG4CXX_ERROR(logger_, "Invalid blosc compression setting " << dset.blosc_compressor);
       }
       if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL)) {
-        dset.blosc_level = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL);
+        dset.blosc_level = config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL);
+        if (dset.blosc_level<0 || dset.blosc_level>9)
+          LOG4CXX_ERROR(logger_, "Invalid blosc level setting " << dset.blosc_level);
       }
       if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE)) {
-        dset.blosc_shuffle = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE);
+        dset.blosc_shuffle = config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE);
+        if (dset.blosc_shuffle<-1 || dset.blosc_shuffle>2)
+          LOG4CXX_ERROR(logger_, "Invalid blosc shuffle setting " << dset.blosc_shuffle);
       }
       LOG4CXX_INFO(logger_, "Blosc compression settings: compressor=" << dset.blosc_compressor
                              << " level=" << dset.blosc_level << " shuffle=" << dset.blosc_shuffle);

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -39,6 +39,9 @@ const std::string FileWriterPlugin::CONFIG_DATASET_DIMS                = "dims";
 const std::string FileWriterPlugin::CONFIG_DATASET_CHUNKS              = "chunks";
 const std::string FileWriterPlugin::CONFIG_DATASET_COMPRESSION         = "compression";
 const std::string FileWriterPlugin::CONFIG_DATASET_INDEXES             = "indexes";
+const std::string FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR    = "blosc_compressor";
+const std::string FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL         = "blosc_level";
+const std::string FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE       = "blosc_shuffle";
 
 const std::string FileWriterPlugin::CONFIG_FRAMES                      = "frames";
 const std::string FileWriterPlugin::CONFIG_MASTER_DATASET              = "master";
@@ -353,6 +356,11 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
 
     // Add the dataset compression
     reply.set_param(get_name() + "/dataset/" + iter->first + "/" + FileWriterPlugin::CONFIG_DATASET_COMPRESSION, (int)iter->second.compression);
+    if ((int)iter->second.compression == blosc) {
+      reply.set_param(get_name() + "/dataset/" + iter->first + "/" + FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR, (int)iter->second.blosc_compressor);
+      reply.set_param(get_name() + "/dataset/" + iter->first + "/" + FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL, (int)iter->second.blosc_level);
+      reply.set_param(get_name() + "/dataset/" + iter->first + "/" + FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE, (int)iter->second.blosc_shuffle);
+    }
 
     // Check for and add dimensions
     if (iter->second.frame_dimensions.size() > 0) {
@@ -576,6 +584,22 @@ void FileWriterPlugin::configure_dataset(const std::string& dataset_name, OdinDa
   if (config.has_param(FileWriterPlugin::CONFIG_DATASET_COMPRESSION)) {
     dset.compression = (CompressionType)config.get_param<int>(FileWriterPlugin::CONFIG_DATASET_COMPRESSION);
     LOG4CXX_INFO(logger_, "Enabling compression: " << dset.compression);
+
+    // Blosc compression require a set of parameters to be defined
+    // TODO: Check parameters for valid ranges
+    if (dset.compression == blosc) {
+      if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR)) {
+        dset.blosc_compressor = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_COMPRESSOR);
+      }
+      if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL)) {
+        dset.blosc_level = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_LEVEL);
+      }
+      if (config.has_param(FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE)) {
+        dset.blosc_shuffle = (CompressionType)config.get_param<unsigned int>(FileWriterPlugin::CONFIG_DATASET_BLOSC_SHUFFLE);
+      }
+      LOG4CXX_INFO(logger_, "Blosc compression settings: compressor=" << dset.blosc_compressor
+                             << " level=" << dset.blosc_level << " shuffle=" << dset.blosc_shuffle);
+    }
   }
 
   // Check if creating the high/low indexes has been specified
@@ -601,6 +625,9 @@ void FileWriterPlugin::create_new_dataset(const std::string& dset_name)
     dset_def.name = dset_name;
     dset_def.data_type = raw_8bit;
     dset_def.compression = no_compression;
+    dset_def.blosc_compressor = 0;
+    dset_def.blosc_level = 0;
+    dset_def.blosc_shuffle = 0;
     dset_def.num_frames = 1;
     std::vector<long long unsigned int> dims(0);
     dset_def.frame_dimensions = dims;

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -299,6 +299,10 @@ void Frame::set_data_type(int data_type)
   data_type_ = data_type;
 }
 
+/** Get the size of the data type
+ *
+ * \return data type size
+ */
 size_t Frame::get_data_type_size()
 {
   int dt = this->get_data_type();

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -279,7 +279,7 @@ void Frame::set_parameter(const std::string& index, float value)
 
 /** Set the compression type of the raw data.
  *
- * 0: None, 1: LZ4, 2: BSLZ4
+ * 0: None, 1: LZ4, 2: BSLZ4, 3: Blosc
  *
  * \param compression type.
  */
@@ -297,6 +297,16 @@ void Frame::set_compression(int compression)
 void Frame::set_data_type(int data_type)
 {
   data_type_ = data_type;
+}
+
+size_t Frame::get_data_type_size()
+{
+  int dt = this->get_data_type();
+  if (dt == -1) return 0;
+  else if (dt == 0) return 1;
+  else if (dt == 1) return 2;
+  else if (dt == 2) return 4;
+  else return 0;
 }
 
 /** Return a parameter for this Frame.

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -302,11 +302,20 @@ void Frame::set_data_type(int data_type)
 size_t Frame::get_data_type_size()
 {
   int dt = this->get_data_type();
-  if (dt == -1) return 0;
-  else if (dt == 0) return 1;
-  else if (dt == 1) return 2;
-  else if (dt == 2) return 4;
-  else return 0;
+  if (dt == -1) {
+    LOG4CXX_ERROR(logger, "Unable to determine data type size as data type have not been defined in this Frame ("
+                          << this->blockIndex_ << ")");
+    throw std::runtime_error("Unable to determine data type size as data type have not been defined in this Frame");
+  }
+  else if (dt == 0) return sizeof(uint8_t);  // 1 byte
+  else if (dt == 1) return sizeof(uint16_t); // 2 bytes
+  else if (dt == 2) return sizeof(uint32_t); // 4 bytes
+  else {
+    std::stringstream msg; msg << "Unable to determine data type size as enumerated data type: " << dt
+                               << " is not known for this frame (" << this->blockIndex_ << ")";
+    LOG4CXX_ERROR(logger, msg.str());
+    throw std::runtime_error(msg.str());
+  }
 }
 
 /** Return a parameter for this Frame.

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -396,6 +396,25 @@ void configureDetector(boost::shared_ptr<FrameProcessorController> fwc, po::vari
   fwc->configure(cfg, reply);
 }
 
+void configureDetectorDecoder(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
+  OdinData::IpcMessage cfg;
+  OdinData::IpcMessage reply;
+
+  string detector_decoder = vm["detector"].as<string>();
+  detector_decoder[0] = std::tolower(detector_decoder[0]);
+
+  if (vm.count("bit-depth")) {
+    cfg.set_param<string>(detector_decoder + "/bitdepth", vm["bit-depth"].as<string>());
+  }
+
+  if (vm.count("dims")) {
+    std::vector<int> dims = vm["dims"].as<std::vector<int> >();
+    cfg.set_param<int>(detector_decoder + "/height", dims[0]);
+    cfg.set_param<int>(detector_decoder + "/width", dims[1]);
+  }
+  fwc->configure(cfg, reply);
+}
+
 void configureBlosc(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
   OdinData::IpcMessage cfg;
   OdinData::IpcMessage reply;
@@ -490,6 +509,7 @@ void configureFileWriter(boost::shared_ptr<FrameProcessorController> fwc, po::va
 
 void configurePlugins(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
   configureDetector(fwc, vm);
+  configureDetectorDecoder(fwc, vm);
   if (isBloscRequired(vm)) {
     configureBlosc(fwc, vm);
   }

--- a/frameProcessor/src/FrameProcessorApp.cpp
+++ b/frameProcessor/src/FrameProcessorApp.cpp
@@ -101,7 +101,7 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
         ("bit-depth",     po::value<std::string>(),
            "Bit-depth mode of detector")
         ("compression",   po::value<int>(),
-           "Compression type of input data (0: None, 1: LZ4, 2: BSLZ4)")
+           "Compression type of input data (0: None, 1: LZ4, 2: BSLZ4, 3: Blosc)")
         ("output,o",      po::value<std::string>()->default_value("test.hdf5"),
            "Name of HDF5 file to write frames to (default: test.hdf5)")
         ("output-dir",    po::value<std::string>()->default_value("/tmp/"),
@@ -352,6 +352,11 @@ void parse_arguments(int argc, char** argv, po::variables_map& vm, LoggerPtr& lo
   }
 }
 
+bool isBloscRequired(po::variables_map vm)
+{
+  return vm.count("compression") && vm["compression"].as<int>() == 3;
+}
+
 void configureController(boost::shared_ptr<FrameProcessorController> fwc,
                          po::variables_map vm) {
   OdinData::IpcMessage cfg;
@@ -391,6 +396,19 @@ void configureDetector(boost::shared_ptr<FrameProcessorController> fwc, po::vari
   fwc->configure(cfg, reply);
 }
 
+void configureBlosc(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
+  OdinData::IpcMessage cfg;
+  OdinData::IpcMessage reply;
+
+  cfg.set_param<string>("plugin/load/library", "./lib/libBloscPlugin.so");
+  cfg.set_param<string>("plugin/load/index", "blosc");
+  cfg.set_param<string>("plugin/load/name", "BloscPlugin");
+  cfg.set_param<string>("plugin/connect/index", "blosc");
+  cfg.set_param<string>("plugin/connect/connection", vm["detector"].as<string>());
+
+  fwc->configure(cfg, reply);
+}
+
 void configureHDF5(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
   OdinData::IpcMessage cfg;
   OdinData::IpcMessage reply;
@@ -399,7 +417,11 @@ void configureHDF5(boost::shared_ptr<FrameProcessorController> fwc, po::variable
   cfg.set_param<string>("plugin/load/index", "hdf");
   cfg.set_param<string>("plugin/load/name", "FileWriterPlugin");
   cfg.set_param<string>("plugin/connect/index", "hdf");
-  cfg.set_param<string>("plugin/connect/connection", vm["detector"].as<string>());
+  if (isBloscRequired(vm)) {
+    cfg.set_param<string>("plugin/connect/connection", "blosc");
+  } else {
+    cfg.set_param<string>("plugin/connect/connection", vm["detector"].as<string>());
+  }
   cfg.set_param<unsigned int>("hdf/process/number", vm["processes"].as<unsigned int>());
   cfg.set_param<unsigned int>("hdf/process/rank", vm["rank"].as<unsigned int>());
   cfg.set_param<size_t>("hdf/process/frames_per_block", vm["block-size"].as<size_t>());
@@ -468,6 +490,9 @@ void configureFileWriter(boost::shared_ptr<FrameProcessorController> fwc, po::va
 
 void configurePlugins(boost::shared_ptr<FrameProcessorController> fwc, po::variables_map vm) {
   configureDetector(fwc, vm);
+  if (isBloscRequired(vm)) {
+    configureBlosc(fwc, vm);
+  }
   configureHDF5(fwc, vm);
 
   std::vector<string> datasets = vm["datasets"].as<std::vector<string> >();

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -414,7 +414,7 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
     cd_values[2] = static_cast<unsigned int>(pixel_type_size);       // type size
     cd_values[3] = frame_num_pixels * pixel_type_size;     // uncompressed size
     cd_values[4] = 1;       // compression level
-    cd_values[5] = 1;       // 0: shuffle not active, 1: shuffle active
+    cd_values[5] = 2;       // 0: shuffle not active, 1: shuffle, 2: bitshuffle
     cd_values[6] = 1;       // the actual Blosc compressor to use (default: LZ4). See blosc.h
     ensure_h5_result(H5Pset_filter(prop, BLOSC_FILTER, H5Z_FLAG_OPTIONAL,
                                    cd_values_length, cd_values), "H5Pset_filter failed to set the Blosc filter");

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -356,7 +356,9 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
   std::vector<hsize_t> frame_dims = definition.frame_dimensions;
   unsigned int frame_num_pixels = 1;
   std::vector<hsize_t>::iterator it;
-  for (it=frame_dims.begin(); it != frame_dims.end(); ++it) {frame_num_pixels *= *it;}
+  for (it=frame_dims.begin(); it != frame_dims.end(); ++it) {
+    frame_num_pixels *= *it;
+  }
 
   // Dataset dims: {1, <image size Y>, <image size X>}
   std::vector<hsize_t> dset_dims(1,1);

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -401,6 +401,20 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
     ensure_h5_result(H5Pset_filter(prop, BSLZ4_FILTER, H5Z_FLAG_MANDATORY,
         cd_values_length, cd_values), "H5Pset_filter failed to set the BSLZ4 filter");
   }
+  else if (definition.compression == blosc) {
+    LOG4CXX_INFO(logger_, "Compression type: Blosc");
+    // Create cd_values for filter to set default block size and to enable LZ4
+    unsigned int cd_values[7] = {0, 0, 0, 0, 0, 0, 0};
+    size_t cd_values_length = 7;
+    // TODO: configure the filter parameters dynamically instead of hardcoding like this.
+    cd_values[2] = 2;       // type size
+    cd_values[3] = 100;     // uncompressed size
+    cd_values[4] = 1;       // compression level
+    cd_values[5] = 1;       // 0: shuffle not active, 1: shuffle active
+    cd_values[6] = 0;       // the actual Blosc compressor to use. See blosc.h
+    ensure_h5_result(H5Pset_filter(prop, BLOSC_FILTER, H5Z_FLAG_OPTIONAL,
+                                   cd_values_length, cd_values), "H5Pset_filter failed to set the Blosc filter");
+  }
 
   ensure_h5_result(H5Pset_chunk(prop, dset_dims.size(), &chunk_dims.front()), "H5Pset_chunk failed");
 

--- a/frameProcessor/test/BloscPluginTest.cpp
+++ b/frameProcessor/test/BloscPluginTest.cpp
@@ -29,7 +29,7 @@ public:
 
     frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame("data"));
     frame->set_frame_number(7);
-    frame->set_dimensions("data", img_dims);
+    frame->set_dimensions(img_dims);
     frame->copy_data(static_cast<void*>(img), 24);
     frame->set_data_type(1); // 0: UINT8, 1: UINT16, 2: UINT32
     frame->set_acquisition_id("scan1");
@@ -42,7 +42,7 @@ public:
       tmp_frame->copy_data(static_cast<void*>(img), 24);
       tmp_frame->set_data_type(sizeof(img[0]));
       tmp_frame->set_acquisition_id("scan2");
-      tmp_frame->set_dimensions("data", img_dims);
+      tmp_frame->set_dimensions(img_dims);
       frames.push_back(tmp_frame);
     }
   }

--- a/frameProcessor/test/BloscPluginTest.cpp
+++ b/frameProcessor/test/BloscPluginTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * BloscPluginTest.cpp
+ *
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include "FrameProcessorDefinitions.h"
+#include "BloscPlugin.h"
+
+class BloscPluginTestFixture
+{
+public:
+  BloscPluginTestFixture()
+  {
+    unsigned short img[12] =  { 1, 2, 3, 4,
+                                5, 6, 7, 8,
+                                9,10,11,12 };
+    dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
+    dimensions_t chunk_dims(3); chunk_dims[0] = 1; chunk_dims[1] = 3; chunk_dims[2] = 4;
+
+    dset_def.name = "data";
+    dset_def.num_frames = 2; //unused?
+    dset_def.pixel = FrameProcessor::pixel_raw_16bit;
+    dset_def.frame_dimensions = dimensions_t(2);
+    dset_def.frame_dimensions[0] = 3;
+    dset_def.frame_dimensions[1] = 4;
+    dset_def.chunks = chunk_dims;
+
+    frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame("data"));
+    frame->set_frame_number(7);
+    frame->copy_data(static_cast<void*>(img), 24);
+
+    for (int i = 1; i<6; i++)
+    {
+      boost::shared_ptr<FrameProcessor::Frame> tmp_frame(new FrameProcessor::Frame("data")); //2, img_dims));
+      tmp_frame->set_frame_number(i);
+      img[0] = i;
+      tmp_frame->copy_data(static_cast<void*>(img), 24);
+      frames.push_back(tmp_frame);
+    }
+  }
+  ~BloscPluginTestFixture() {}
+  boost::shared_ptr<FrameProcessor::Frame> frame;
+  std::vector< boost::shared_ptr<FrameProcessor::Frame> >frames;
+  FrameProcessor::BloscPlugin blosc_plugin;
+  FrameProcessor::DatasetDefinition dset_def;
+};
+
+BOOST_FIXTURE_TEST_SUITE(BloscPluginUnitTest, BloscPluginTestFixture);
+
+BOOST_AUTO_TEST_CASE( BloscPlugin_process_frame )
+{
+  // TODO: simply push a frame through the BloscPlugin to trigger the process_frame call and test the compression
+  // Unfortunately process_frame is private and can't be called like this. So how?
+  //BOOST_REQUIRE_NO_THROW(blosc_plugin.process_frame(frame));
+}
+
+BOOST_AUTO_TEST_SUITE_END(); //BloscPluginUnitTest

--- a/frameProcessor/test/BloscPluginTest.cpp
+++ b/frameProcessor/test/BloscPluginTest.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-
+#include <DebugLevelLogger.h>
 #include "FrameProcessorDefinitions.h"
 #include "BloscPlugin.h"
 
@@ -13,6 +13,7 @@ class BloscPluginTestFixture
 public:
   BloscPluginTestFixture()
   {
+    set_debug_level(3);
     unsigned short img[12] =  { 1, 2, 3, 4,
                                 5, 6, 7, 8,
                                 9,10,11,12 };

--- a/frameProcessor/test/BloscPluginTest.cpp
+++ b/frameProcessor/test/BloscPluginTest.cpp
@@ -21,7 +21,7 @@ public:
 
     dset_def.name = "data";
     dset_def.num_frames = 2; //unused?
-    dset_def.pixel = FrameProcessor::pixel_raw_16bit;
+    dset_def.data_type = FrameProcessor::raw_16bit;
     dset_def.frame_dimensions = dimensions_t(2);
     dset_def.frame_dimensions[0] = 3;
     dset_def.frame_dimensions[1] = 4;
@@ -31,7 +31,8 @@ public:
     frame->set_frame_number(7);
     frame->set_dimensions("data", img_dims);
     frame->copy_data(static_cast<void*>(img), 24);
-    frame->set_data_type(sizeof(img[0]));
+    frame->set_data_type(1); // 0: UINT8, 1: UINT16, 2: UINT32
+    frame->set_acquisition_id("scan1");
 
     for (int i = 1; i<6; i++)
     {
@@ -39,6 +40,8 @@ public:
       tmp_frame->set_frame_number(i);
       img[0] = i;
       tmp_frame->copy_data(static_cast<void*>(img), 24);
+      tmp_frame->set_data_type(sizeof(img[0]));
+      tmp_frame->set_acquisition_id("scan2");
       tmp_frame->set_dimensions("data", img_dims);
       frames.push_back(tmp_frame);
     }
@@ -57,6 +60,9 @@ BOOST_AUTO_TEST_CASE( BloscPlugin_process_frame )
   // TODO: simply push a frame through the BloscPlugin to trigger the process_frame call and test the compression
   // Unfortunately process_frame is private and can't be called like this. So how?
   BOOST_REQUIRE_NO_THROW(blosc_plugin.compress_frame(frame));
+  BOOST_REQUIRE_NO_THROW(blosc_plugin.compress_frame(frame));
+  BOOST_REQUIRE_NO_THROW(blosc_plugin.compress_frame(frames[0]));
+
 }
 
 BOOST_AUTO_TEST_SUITE_END(); //BloscPluginUnitTest

--- a/frameProcessor/test/BloscPluginTest.cpp
+++ b/frameProcessor/test/BloscPluginTest.cpp
@@ -29,7 +29,9 @@ public:
 
     frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame("data"));
     frame->set_frame_number(7);
+    frame->set_dimensions("data", img_dims);
     frame->copy_data(static_cast<void*>(img), 24);
+    frame->set_data_type(sizeof(img[0]));
 
     for (int i = 1; i<6; i++)
     {
@@ -37,6 +39,7 @@ public:
       tmp_frame->set_frame_number(i);
       img[0] = i;
       tmp_frame->copy_data(static_cast<void*>(img), 24);
+      tmp_frame->set_dimensions("data", img_dims);
       frames.push_back(tmp_frame);
     }
   }
@@ -53,7 +56,7 @@ BOOST_AUTO_TEST_CASE( BloscPlugin_process_frame )
 {
   // TODO: simply push a frame through the BloscPlugin to trigger the process_frame call and test the compression
   // Unfortunately process_frame is private and can't be called like this. So how?
-  //BOOST_REQUIRE_NO_THROW(blosc_plugin.process_frame(frame));
+  BOOST_REQUIRE_NO_THROW(blosc_plugin.compress_frame(frame));
 }
 
 BOOST_AUTO_TEST_SUITE_END(); //BloscPluginUnitTest

--- a/frameProcessor/test/CMakeLists.txt
+++ b/frameProcessor/test/CMakeLists.txt
@@ -5,7 +5,12 @@ ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 include_directories(${FRAMEPROCESSOR_DIR}/include ${HDF5_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 add_definitions(${HDF5_DEFINITIONS})
 
-file(GLOB TEST_SOURCES *.cpp)
+file(GLOB TEST_SOURCES FrameProcessorUnitTestMain.cpp FrameProcessorTest.cpp)
+# Add tests for BloscPlugin if Blosc is present
+if (${BLOSC_FOUND})
+  list(APPEND TEST_SOURCES BloscPluginTest.cpp)
+  include_directories(${BLOSC_INCLUDE_DIR})
+endif()
 
 # Add test source files to executable
 add_executable(frameProcessorTest ${TEST_SOURCES})
@@ -23,6 +28,11 @@ target_link_libraries(frameProcessorTest
         OffsetAdjustmentPlugin
         LiveViewPlugin
         ${COMMON_LIBRARY})
+
+# Link for BloscPlugin if Blosc is present
+if (${BLOSC_FOUND})
+  target_link_libraries(frameProcessorTest ${BLOSC_LIBRARIES} BloscPlugin)
+endif()
 
 if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
   # librt required for timing functions

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -4,10 +4,7 @@
  */
 #include "DebugLevelLogger.h"
 
-#define BOOST_TEST_MODULE "FrameProcessorUnitTests"
-#define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-
 #include <log4cxx/logger.h>
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/simplelayout.h>

--- a/frameProcessor/test/FrameProcessorUnitTestMain.cpp
+++ b/frameProcessor/test/FrameProcessorUnitTestMain.cpp
@@ -1,0 +1,11 @@
+/*
+ * FrameProcessorUnitTestMain.cpp
+ *
+ *  Created on: 23. Jan 2018
+ *      Author: Ulrik Pedersen
+ */
+
+#define BOOST_TEST_MODULE "FrameProcessorUnitTests"
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+


### PR DESCRIPTION
Adding a Blosc compression plugin and associated changes to the HDF5 plugin to support writing the pre-compressed buffers to disk.

The Blosc plugin is an optional cmake build configuration in the usual fashion.