### PR TITLE
Protect against shared buffer config race condition.

### DIFF
--- a/frameProcessor/include/SharedMemoryController.h
+++ b/frameProcessor/include/SharedMemoryController.h
@@ -63,6 +63,8 @@ private:
   OdinData::IpcChannel             txChannel_;
   /** Shared buffer configured status flag */
   bool sharedBufferConfigured_;
+  /** Shared buffer config request deferred flag */
+  bool sharedBufferConfigRequestDeferred_;
 
   /** Name of class used in status messages */
   static const std::string SHARED_MEMORY_CONTROLLER_NAME;


### PR DESCRIPTION
A race condition exists in the shared buffer configuration stage of initialising frame receivers and processors. If both are started and configured rapidly, it is possible for the FR to advertise the shared buffer configuration to the FP in the interval between the FP starting up and issuing a deferred buffer config request. This can lead to a controlling process determining that both are configured and starting readout, and hence data flow, before the FP triggers the deferred request and configures its shared buffers for a second time. This invalidates the shared buffer setup and causes transient data loss.

Thanks to @MRichards99 for identifying this while integrating odin-data into LPD readout.

This PR implements a fix: the SharedMemoryController now tracks if a deferred shared buffer
configuration request has been registered and, when the timer fires, suppresses the request if the shared buffer has already been configured by an unsolicited configuration message from the FR.
