### PR TITLE
Fix inconsistent logger hierarchy names in frameProcessor

### DIFF
--- a/config/fp_log4cxx.xml
+++ b/config/fp_log4cxx.xml
@@ -5,45 +5,29 @@
  <appender name="ApplicationConsoleAppender" class="org.apache.log4j.ConsoleAppender">
   <param name="Target" value="System.out" />
   <layout class="org.apache.log4j.PatternLayout">
-   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-14c %-5p (%F:%L) - %m%n"/> -->
-   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-14c %-5p - %m%n" />
+   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-16c %-5p (%F:%L) - %m%n"/> -->
+   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
- <appender name="FileWriterAppender" class="org.apache.log4j.FileAppender">
-  <param name="file" value="/tmp/fileWriter.log" />
+ <appender name="FrameProcessorAppender" class="org.apache.log4j.FileAppender">
+  <param name="file" value="/tmp/frameProcessor.log" />
   <param name="append" value="false" />
   <layout class="org.apache.log4j.PatternLayout">
-   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-16c %-5p (%F:%L) - %m%n" />
+   <param name="ConversionPattern" value="%d  %-16c %-5p - %m%n" />
   </layout>
  </appender>
- 
-<!-- 
-<appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-  <param name="Facility" value="LOCAL1"/>
-  <param name="SyslogHost" value="localhost:5140"/>
-  <param name="Threshold" value="INFO"/>
-  <layout class="org.apache.log4j.PatternLayout">
-    <param name="ConversionPattern"  value="%d{HH:mm:ss,SSS} %-16c %-5p - %m%n"/>
-  </layout>
-</appender>
- -->
- 
+
  <!-- all of the loggers inherit settings from the root -->
  <root>
   <priority value="all" />
   <appender-ref ref="ApplicationConsoleAppender" />
-  <!--   <appender-ref ref="syslog" /> -->
  </root>
 
- <!-- The file writer application logger hierachy -->
- <logger name="FW">
+ <!-- The frame processor application logger hierachy -->
+ <logger name="FP">
   <priority value="all" />
-  <appender-ref ref="FileWriterAppender" />
+  <appender-ref ref="FrameProcessorAppender" />
  </logger>
- <logger name="FW.APP"></logger>
- <logger name="FW.SHM"></logger>
- <logger name="FW.Frame"></logger>
- <logger name="FW.FileWriter"></logger>
-
+ 
 </log4j:configuration>

--- a/config/fr_log4cxx.xml
+++ b/config/fr_log4cxx.xml
@@ -5,8 +5,8 @@
  <appender name="ApplicationConsoleAppender" class="org.apache.log4j.ConsoleAppender">
   <param name="Target" value="System.out" />
   <layout class="org.apache.log4j.PatternLayout">
-   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-14c %-5p (%F:%L) - %m%n"/> -->
-   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-14c %-5p - %m%n" />
+   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-16c %-5p (%F:%L) - %m%n"/> -->
+   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
@@ -15,7 +15,7 @@
   <param name="file" value="/tmp/frameReceiver.log" />
   <param name="append" value="false" />
   <layout class="org.apache.log4j.PatternLayout">
-   <param name="ConversionPattern" value="%d %-5p %c{1} - %m%n" />
+   <param name="ConversionPattern" value="%d  %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
@@ -23,7 +23,7 @@
   <param name="file" value="/tmp/frameReceiver_packetDump.log" />
   <param name="append" value="false" />
   <layout class="org.apache.log4j.PatternLayout">
-   <param name="ConversionPattern" value="%d %-5p %c{1} - %m%n" />
+   <param name="ConversionPattern" value="%d  %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
@@ -36,10 +36,9 @@
  <!-- The frame receiver application logger hierachy -->
  <logger name="FR">
   <priority value="all" />
- </logger>
- <logger name="FR.App">
   <appender-ref ref="FrameReceiverAppender" />
  </logger>
+ 
  <logger name="FR.PacketLogger" additivity="false">
   <priority value="info" />
   <appender-ref ref="FrameReceiverPacketAppender" />

--- a/config/fs_log4cxx.xml
+++ b/config/fs_log4cxx.xml
@@ -5,8 +5,8 @@
  <appender name="ApplicationConsoleAppender" class="org.apache.log4j.ConsoleAppender">
   <param name="Target" value="System.out" />
   <layout class="org.apache.log4j.PatternLayout">
-   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-14c %-5p (%F:%L) - %m%n"/> -->
-   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-14c %-5p - %m%n" />
+   <!-- <param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %-16c %-5p (%F:%L) - %m%n"/> -->
+   <param name="ConversionPattern" value="%d{HH:mm:ss,SSS}  %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
@@ -15,7 +15,7 @@
   <param name="file" value="/tmp/frameSimulator.log" />
   <param name="append" value="false" />
   <layout class="org.apache.log4j.PatternLayout">
-   <param name="ConversionPattern" value="%d %-5p %c{1} - %m%n" />
+   <param name="ConversionPattern" value="%d %-16c %-5p - %m%n" />
   </layout>
  </appender>
 
@@ -25,14 +25,9 @@
   <appender-ref ref="ApplicationConsoleAppender" />
  </root>
 
- <!-- The frame receiver application logger hierachy -->
+ <!-- The frame simulator application logger hierachy -->
  <logger name="FS">
   <priority value="all" />
- </logger>
- <logger name="FS.App">
-  <appender-ref ref="FrameSimulatorAppender" />
- </logger>
- <logger name="FS.pcapFrameSimulatorPlugin">
   <appender-ref ref="FrameSimulatorAppender" />
  </logger>
 

--- a/frameProcessor/src/DummyPlugin.cpp
+++ b/frameProcessor/src/DummyPlugin.cpp
@@ -17,7 +17,7 @@ namespace FrameProcessor
 DummyPlugin::DummyPlugin()
 {
   // Setup logging for the class
-  logger_ = Logger::getLogger("FW.DummyPlugin");
+  logger_ = Logger::getLogger("FP.DummyPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_INFO(logger_, "DummyPlugin version " << this->get_version_long() << " loaded");
 }

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -28,7 +28,7 @@ Frame::Frame(const std::string& index) :
     shared_channel_(0),
     data_type_(-1),
     compression_(-1),
-    logger(log4cxx::Logger::getLogger("FW.Frame"))
+    logger(log4cxx::Logger::getLogger("FP.Frame"))
 {
   logger->setLevel(log4cxx::Level::getAll());
   LOG4CXX_TRACE(logger, "Frame constructed");

--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -31,7 +31,7 @@ const std::string LiveViewPlugin::CONFIG_TAGGED_FILTER_NAME = "filter_tagged";
 LiveViewPlugin::LiveViewPlugin() :
     publish_socket_(ZMQ_PUB)
 {
-  logger_ = Logger::getLogger("FW.LiveViewPlugin");
+  logger_ = Logger::getLogger("FP.LiveViewPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");
 

--- a/frameProcessor/src/OffsetAdjustmentPlugin.cpp
+++ b/frameProcessor/src/OffsetAdjustmentPlugin.cpp
@@ -20,7 +20,7 @@ OffsetAdjustmentPlugin::OffsetAdjustmentPlugin() :
     first_frame_number_(DEFAULT_OFFSET_FIRST_FRAME)
 {
   // Setup logging for the class
-  logger_ = Logger::getLogger("FW.OffsetAdjustmentPlugin");
+  logger_ = Logger::getLogger("FP.OffsetAdjustmentPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_INFO(logger_, "OffsetAdjustmentPlugin version " << this->get_version_long() << " loaded");
 

--- a/frameProcessor/src/SharedMemoryController.cpp
+++ b/frameProcessor/src/SharedMemoryController.cpp
@@ -36,7 +36,7 @@ SharedMemoryController::SharedMemoryController(boost::shared_ptr<OdinData::IpcRe
     sharedBufferConfigRequestDeferred_(false)
 {
   // Setup logging for the class
-  logger_ = Logger::getLogger("FW.SharedMemoryController");
+  logger_ = Logger::getLogger("FP.SharedMemoryController");
   logger_->setLevel(Level::getAll());
   LOG4CXX_TRACE(logger_, "SharedMemoryController constructor.");
 

--- a/frameProcessor/src/UIDAdjustmentPlugin.cpp
+++ b/frameProcessor/src/UIDAdjustmentPlugin.cpp
@@ -20,7 +20,7 @@ UIDAdjustmentPlugin::UIDAdjustmentPlugin() :
     first_frame_number_(DEFAULT_FIRST_FRAME)
 {
   // Setup logging for the class
-  logger_ = Logger::getLogger("FW.UIDAdjustmentPlugin");
+  logger_ = Logger::getLogger("FP.UIDAdjustmentPlugin");
   logger_->setLevel(Level::getAll());
   LOG4CXX_INFO(logger_, "UIDAdjustmentPlugin version " << this->get_version_long() << " loaded");
 


### PR DESCRIPTION
Addresses issue #105 - all log4cxx loggers in the frameProcessor now have the `FP.` prefix, rather than the mix of `FP.` and `FW.`. 

As part of this fix the canonical log4cxx config files for frameReceiver, frameProcessor and frameSimulator have been tidied up to be consistent and to suppress expensive source location format specifiers.