### PR TITLE
Live view startup fix

### DIFF
--- a/frameProcessor/include/LiveViewPlugin.h
+++ b/frameProcessor/include/LiveViewPlugin.h
@@ -99,6 +99,8 @@ private:
   /**List of Parameter names to look for. If a frame comes in without one of these tags it will be ignored*/
   std::vector<std::string> tags_;
 
+  /**Boolean that shows if the plugin has a successfully bound ZMQ endpoint*/
+  bool is_bound_;
 };
 
 }/* namespace FrameProcessor */

--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -39,7 +39,6 @@ LiveViewPlugin::LiveViewPlugin() :
 
   set_frame_freq_config(DEFAULT_FRAME_FREQ);
   set_per_second_config(DEFAULT_PER_SECOND);
-  set_socket_addr_config(DEFAULT_IMAGE_VIEW_SOCKET_ADDR);
   set_dataset_name_config(DEFAULT_DATASET_NAME);
   set_tagged_filter_config(DEFAULT_TAGGED_FILTER);
 
@@ -169,6 +168,11 @@ void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessag
     {
       set_socket_addr_config(config.get_param<std::string>(CONFIG_SOCKET_ADDR));
     }
+    else
+    {
+      set_socket_addr_config(DEFAULT_IMAGE_VIEW_SOCKET_ADDR);
+    }
+    
   }
   catch (std::runtime_error& e)
   {

--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -36,16 +36,10 @@ LiveViewPlugin::LiveViewPlugin() :
   logger_->setLevel(Level::getAll());
   LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");
 
-
   set_frame_freq_config(DEFAULT_FRAME_FREQ);
   set_per_second_config(DEFAULT_PER_SECOND);
   set_dataset_name_config(DEFAULT_DATASET_NAME);
   set_tagged_filter_config(DEFAULT_TAGGED_FILTER);
-
-  if(!is_bound_)
-  {
-    LOG4CXX_WARN(logger_, "Socket is unbound after initilization. Check if default address " << DEFAULT_IMAGE_VIEW_SOCKET_ADDR << " is already in use");
-  }
 }
 
 /**


### PR DESCRIPTION
A fix for https://github.com/odin-detector/odin-data/issues/171 , so that it no longer crashes if trying to bind to a socket address that is already in use. Will warn the user if the socket is unbound after initialization and when attempting to process a frame of data. 

