### PR TITLE
Update FrameReceiverController to retain decoder config between rebuilds

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -121,6 +121,14 @@ public:
              MsgVal msg_val=MsgValIllegal,
              bool strict_validation=true);
 
+  //! Update parameters from another IPCMessage.
+  //!
+  //! This will iterate the parameters in the given IPCMessage and set them on this instance.
+  //!
+  //! \param other - IPCMessage to take parameters from
+
+  void update(const IpcMessage& other);
+
   //! Gets the value of a named parameter in the message.
   //!
   //! This template method returns the value of the specified parameter stored in the
@@ -190,7 +198,7 @@ public:
   //! Returns a vector of all parameter names contained in the message.
   //!
   //! \return A vector of all parameter names in this message
-  std::vector<std::string> get_param_names();
+  std::vector<std::string> get_param_names() const;
 
   //! Returns true if the parameter is found within the message
   bool has_param(const std::string& param_name) const;

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -141,11 +141,19 @@ IpcMessage::IpcMessage(const rapidjson::Value& value,
   doc_.AddMember("params", newValue, doc_.GetAllocator());
 }
 
+void IpcMessage::update(const IpcMessage& other)
+{
+  std::vector<std::string> params = other.get_param_names();
+  for (std::vector<std::string>::const_iterator itr = params.begin(); itr != params.end(); ++itr) {
+    this->set_param<const rapidjson::Value&>(*itr, other.get_param<const rapidjson::Value&>(*itr));
+  }
+}
+
 //! Returns a vector of all parameter names contained in the message.
 //!
 //! \return A vector of all parameter names in this message
 
-std::vector<std::string> IpcMessage::get_param_names()
+std::vector<std::string> IpcMessage::get_param_names() const
 {
   std::vector<std::string> names;
   rapidjson::Value::ConstMemberIterator itr = doc_.FindMember("params");

--- a/frameReceiver/include/FrameReceiverController.h
+++ b/frameReceiver/include/FrameReceiverController.h
@@ -69,6 +69,7 @@ namespace FrameReceiver
     void cleanup_ipc_channels(void);
 
     void configure_frame_decoder(OdinData::IpcMessage& config_msg);
+    bool new_decoder_class(OdinData::IpcMessage& config_msg);
     void configure_buffer_manager(OdinData::IpcMessage& config_msg);
     void configure_rx_thread(OdinData::IpcMessage& config_msg);
     void stop_rx_thread(void);

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -454,14 +454,14 @@ void FrameReceiverController::configure_frame_decoder(OdinData::IpcMessage& conf
 
   // Extract any decoder parameters from the configuration message and construct an
   // IpcMessage to pass to the decoder initialisation. Test if this differs from the current
-  // decoder configuration; swap in and force a reconfig if so
+  // decoder configuration; update and force a reconfig if so
   if (config_msg.has_param(CONFIG_DECODER_CONFIG))
   {
     boost::scoped_ptr<IpcMessage> new_decoder_config(
         new IpcMessage(config_msg.get_param<const rapidjson::Value&>(CONFIG_DECODER_CONFIG)));
     if (*new_decoder_config != *(config_.decoder_config_))
     {
-      config_.decoder_config_.swap(new_decoder_config);
+      config_.decoder_config_->update(*new_decoder_config);
       LOG4CXX_DEBUG_LEVEL(3, logger_,
         "Built new decoder configuration message: " << config_.decoder_config_->encode()
       );

--- a/frameReceiver/test/IpcMessageUnitTest.cpp
+++ b/frameReceiver/test/IpcMessageUnitTest.cpp
@@ -113,6 +113,52 @@ BOOST_AUTO_TEST_CASE( CreateAndModifyParametersInEmptyIpcMessage )
 
 }
 
+BOOST_AUTO_TEST_CASE( UpdateParametersInExistingIpcMessage )
+{
+  OdinData::IpcMessage msg1;
+
+  // Define and set some parameters
+  int paramIntVal = 1234;
+  int paramIntVal2 = 90210;
+  int paramIntVal3 = 4567;
+  std::string paramStringVal("paramString");
+
+  msg1.set_param("paramInt", paramIntVal);
+  msg1.set_param("paramInt2", paramIntVal2);
+  msg1.set_param("paramInt3", paramIntVal3);
+  msg1.set_param("paramStr", paramStringVal);
+
+  // Read them back and check they have correct values
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt"), paramIntVal);
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt2"), paramIntVal2);
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt3"), paramIntVal3);
+  BOOST_CHECK_EQUAL(msg1.get_param<std::string>("paramStr"), paramStringVal);
+
+  OdinData::IpcMessage msg2;
+
+  // Create a different message and update the first with it
+  int newParamIntVal2 = 90310;
+  int paramIntVal4 = 42;
+  std::string newParamStringVal("newParamStr");
+  std::string paramStringVal2("paramStr2");
+
+  msg2.set_param("paramInt2", newParamIntVal2);
+  msg2.set_param("paramInt4", paramIntVal4);
+  msg2.set_param("paramStr", newParamStringVal);
+  msg2.set_param("paramStr2", paramStringVal2);
+
+  msg1.update(msg2);
+
+  // Check that values are overwritten / added / still there
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt"), paramIntVal);
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt2"), newParamIntVal2);
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt3"), paramIntVal3);
+  BOOST_CHECK_EQUAL(msg1.get_param<int>("paramInt4"), paramIntVal4);
+  BOOST_CHECK_EQUAL(msg1.get_param<std::string>("paramStr"), newParamStringVal);
+  BOOST_CHECK_EQUAL(msg1.get_param<std::string>("paramStr2"), paramStringVal2);
+
+}
+
 BOOST_AUTO_TEST_CASE( RoundTripFromEmptyIpcMessage )
 {
 


### PR DESCRIPTION
Add update method to IPCMessage to add / overwrite parameters from
  from another IPCMessage
Update FrameReceiverController to call update when a different decoder
  config is received, while retaining any previous config that has not
  been overridden, instead of setting them to defaults.
Add unit test for update method