### PR TITLE
Stored configuration sequences

### DIFF
--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -127,6 +127,8 @@ private:
   boost::shared_ptr<SharedMemoryController>                       sharedMemController_;
   /** Map of plugins loaded, indexed by plugin index */
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> > plugins_;
+  /** Map of stored configuration objects */
+  std::map<std::string, std::string>                              stored_configs_;
   /** Condition for exiting this file writing process */
   boost::condition_variable                                       exitCondition_;
   /** Frames per dataset */

--- a/frameProcessor/include/FrameProcessorController.h
+++ b/frameProcessor/include/FrameProcessorController.h
@@ -49,6 +49,7 @@ public:
   void loadPlugin(const std::string& index, const std::string& name, const std::string& library);
   void connectPlugin(const std::string& index, const std::string& connectTo);
   void disconnectPlugin(const std::string& index, const std::string& disconnectFrom);
+  void disconnectAllPlugins();
   void run();
   void waitForShutdown();
   void shutdown();
@@ -84,6 +85,8 @@ private:
   static const std::string CONFIG_PLUGIN_CONNECT;
   /** Configuration constant for disconnecting plugins **/
   static const std::string CONFIG_PLUGIN_DISCONNECT;
+  /** Configuration keyword for disconnecting all plugins **/
+  static const std::string CONFIG_PLUGIN_DISCONNECT_ALL;
   /** Configuration constant for a plugin name **/
   static const std::string CONFIG_PLUGIN_NAME;
   /** Configuration constant for a plugin index **/
@@ -92,6 +95,15 @@ private:
   static const std::string CONFIG_PLUGIN_LIBRARY;
   /** Configuration constant for setting up a plugin connection **/
   static const std::string CONFIG_PLUGIN_CONNECTION;
+
+  /** Configuration constant for storing a named configuration object **/
+  static const std::string CONFIG_STORE;
+  /** Configuration constant for executing a named configuration object **/
+  static const std::string CONFIG_EXECUTE;
+  /** Configuration constant for the name of a stored configuration object **/
+  static const std::string CONFIG_INDEX;
+  /** Configuration constant for the value of a stored configuration object **/
+  static const std::string CONFIG_VALUE;
 
   /** Configuration constant for the meta TX channel high water mark **/
   static const int META_TX_HWM;

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -42,6 +42,7 @@ public:
   void version(OdinData::IpcMessage& status);
   void register_callback(const std::string& name, boost::shared_ptr<IFrameCallback> cb, bool blocking=false);
   void remove_callback(const std::string& name);
+  void remove_all_callbacks();
 
 protected:
   void push(boost::shared_ptr<Frame> frame);

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -422,7 +422,7 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
 
     if (storeConfig.has_param(FrameProcessorController::CONFIG_INDEX)) {
       std::string index = storeConfig.get_param<std::string>(FrameProcessorController::CONFIG_INDEX);
-      if (stored_configs_.count(index) > 0){
+      if (stored_configs_.count(index) > 0) {
         LOG4CXX_DEBUG_LEVEL(1, logger_, "Applying configuration [" << index << "] => " << stored_configs_[index]);
         rapidjson::Document param_doc;
         param_doc.Parse(stored_configs_[index].c_str());

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -559,6 +559,7 @@ void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config, Odi
   if (config.has_param(FrameProcessorController::CONFIG_PLUGIN_DISCONNECT)) {
     try
     {
+      // A standard disconnect will contain a dictionary with the plugin index and connection to remove
       OdinData::IpcMessage pluginConfig(config.get_param<const rapidjson::Value&>(FrameProcessorController::CONFIG_PLUGIN_DISCONNECT));
       if (pluginConfig.has_param(FrameProcessorController::CONFIG_PLUGIN_CONNECTION) &&
           pluginConfig.has_param(FrameProcessorController::CONFIG_PLUGIN_INDEX)) {
@@ -567,6 +568,8 @@ void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config, Odi
         this->disconnectPlugin(index, cnxn);
       }
     }
+    // If the JSON parser fails to parse a dictionary out of the disconnect parameter then it might be a simple string
+    // which contains the 'all' keyword.  In this case disconnect all of the plugins.
     catch (OdinData::IpcMessageException& e)
     {
       // Test to see if we have the keyword for dicsonnecting all

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -227,6 +227,28 @@ void FrameProcessorPlugin::remove_callback(const std::string& name)
 }
 
 /**
+ * Remove all registered callbacks for this plugin.
+ */
+void FrameProcessorPlugin::remove_all_callbacks()
+{
+  // Loop over blocking callbacks, removing each one
+  std::map<std::string, boost::shared_ptr<IFrameCallback> >::iterator bcbIter;
+  for (bcbIter = blocking_callbacks_.begin(); bcbIter != blocking_callbacks_.end(); ++bcbIter) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Removing callback " << bcbIter->first << " from " << name_);
+    bcbIter->second->confirmRemoval(name_);
+  }
+  // Loop over non-blocking callbacks, removing each one
+  std::map<std::string, boost::shared_ptr<IFrameCallback> >::iterator cbIter;
+  for (cbIter = callbacks_.begin(); cbIter != callbacks_.end(); ++cbIter) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Removing callback " << cbIter->first << " from " << name_);
+    cbIter->second->confirmRemoval(name_);
+  }
+  // Now empty the two callback stores
+  callbacks_.clear();
+  blocking_callbacks_.clear();
+}
+
+/**
  * We have been called back with a frame from a plugin that we registered
  * with. This method calls the processFrame pure virtual method that
  * must be overridden by any children of this abstract class.


### PR DESCRIPTION
This PR provides a mechanism for storing arbitrarily complex configuration sequences within an FP controller 

`"store": {"index": <index name>, "value": <sequence of configuration dictionaries>}`

that can be replayed at any time by sending the configuration 

`"execute": {"index": <index name>}`

The use case for this is to be able to tear down plugin chains and rebuild them.  This involves submission of many configurations to update each connection.  With this mechanism each plugin chain can be stored by and index and then executed with a single configuration item.  This will be required at Diamond for pulling in and out compression and gap filling plugins.

The mechanism used to store and replay is the same as for loading json config files from the command line, with the sequences of configurations stored as JSON.

NOTE: The reason for storing the sequences within the FP itself is to eliminate inconsistencies between FP applications and adapters which we have previously suffered from when applications are being re-loaded.

Open to discussion...

p.s. Also added the single configuration option to be able to disconnect a whole plugin chain without needing to know the setup of the chain.
