### PR TITLE
Set high water mark on meta writer receive socket to reasonable value

### DIFF
--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -61,6 +61,7 @@ class MetaListener:
             # Socket to receive messages on
             for x in inputs_list:
                 new_receiver = context.socket(zmq.SUB)
+                new_receiver.set_hwm(100000)
                 new_receiver.connect(x)
                 new_receiver.setsockopt(zmq.SUBSCRIBE, '')
                 receiver_list.append(new_receiver)

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -61,7 +61,7 @@ class MetaListener:
             # Socket to receive messages on
             for x in inputs_list:
                 new_receiver = context.socket(zmq.SUB)
-                new_receiver.set_hwm(100000)
+                new_receiver.set_hwm(10000)
                 new_receiver.connect(x)
                 new_receiver.setsockopt(zmq.SUBSCRIBE, '')
                 receiver_list.append(new_receiver)


### PR DESCRIPTION
The default value is 1000. Elsewhere in odin, we've set the default value to 10000 to cope with higher frame rates, so setting the meta writer in-line with the others