### PR TITLE
Add file_prefix to metalistener adapter and change from status to config

### DIFF
--- a/tools/python/odin_data/meta_listener_adapter.py
+++ b/tools/python/odin_data/meta_listener_adapter.py
@@ -27,7 +27,8 @@ class MetaListenerAdapter(OdinDataAdapter):
         # means the client does not need to send things in a certain order.
         self._config_parameters = {
             "config/output_dir": "",
-            "config/flush": 100
+            "config/flush": 100,
+            "config/file_prefix": ""
         }
 
         # Parameters must be created before base init called
@@ -118,7 +119,8 @@ class MetaListenerAdapter(OdinDataAdapter):
             config = dict(
                 acquisition_id=self.acquisitionID,
                 output_dir=self._config_parameters["config/output_dir"],
-                flush=self._config_parameters["config/flush"]
+                flush=self._config_parameters["config/flush"],
+                file_prefix=self._config_parameters["config/file_prefix"]
             )
             status_code, response = self._send_config(config)
         elif path == "config/stop":

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -147,8 +147,7 @@ class MetaListener:
         for key in self._writers:
             writer = self._writers[key]
             status_dict[key] = {'filename': writer.full_file_name, 'num_processors': writer.number_processes_running,
-                                'written': writer.write_count, 'writing': writer.file_created and not writer.finished,
-                                'file_prefix': writer.file_prefix}
+                                'written': writer.write_count, 'writing': writer.file_created and not writer.finished}
             writer.write_timeout_count = writer.write_timeout_count + 1
 
         reply = IpcMessage(IpcMessage.ACK, 'status', id=msg_id)
@@ -173,7 +172,8 @@ class MetaListener:
         acquisitions_dict = {}
         for key in self._writers:
             writer = self._writers[key]
-            acquisitions_dict[key] = {'output_dir': writer.directory, 'flush': writer.flush_frequency}
+            acquisitions_dict[key] = {'output_dir': writer.directory, 'flush': writer.flush_frequency,
+                                      'file_prefix': writer.file_prefix}
 
         reply = IpcMessage(IpcMessage.ACK, 'request_configuration', id=msg_id)
         reply.set_param('acquisitions', acquisitions_dict)


### PR DESCRIPTION
During integration with ADOdin, discovered that the file_prefix should be on the request_configuration message instead of status, and that a change is needed in the adapter to make it work as desired.