### PR TITLE
Pass frame params

### DIFF
--- a/frameProcessor/include/Frame.h
+++ b/frameProcessor/include/Frame.h
@@ -164,6 +164,7 @@ public:
   void set_parameter(const std::string& index, uint64_t value);
   void set_parameter(const std::string& index, float value);
   std::map<std::string, Parameter> & get_parameters();
+  void set_parameters(std::map<std::string, Parameter>& parameters);
   Parameter get_parameter(const std::string& index) const;
   uint8_t get_i8_parameter(const std::string& index) const;
   uint16_t get_i16_parameter(const std::string& index) const;

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -154,6 +154,7 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
   // I wish we had a shallow-copy feature on the Frame class...
   dest_frame->set_data_type(src_frame->get_data_type());
   dest_frame->set_frame_number(src_frame->get_frame_number());
+  dest_frame->set_parameters(src_frame->get_parameters());
   dest_frame->set_acquisition_id(src_frame->get_acquisition_id());
   dest_frame->set_dimensions(src_frame->get_dimensions());
   return dest_frame;

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -452,6 +452,18 @@ std::map<std::string, Parameter> & Frame::get_parameters()
   return parameters_;
 }
 
+/** Set all of the supplied parameters into this Frame.
+ *
+ * \param[in] parameters - a map of parameters to set.
+ */
+void Frame::set_parameters(std::map<std::string, Parameter>& parameters)
+{
+  std::map<std::string, Parameter>::const_iterator iter;
+  for (iter = parameters.begin(); iter != parameters.end(); ++iter){
+    parameters_[iter->first] = iter->second;
+  }
+}
+
 /** Check if the Frame contains a parameter.
  *
  * This method checks if the parameter exists within the Frame.

--- a/frameProcessor/src/GapFillPlugin.cpp
+++ b/frameProcessor/src/GapFillPlugin.cpp
@@ -181,6 +181,7 @@ namespace FrameProcessor
         img_dims[1] = img_x;
         gap_frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame(frame->get_dataset_name()));
         gap_frame->set_frame_number(frame->get_frame_number());
+        gap_frame->set_parameters(frame->get_parameters());
         gap_frame->set_dimensions(img_dims);
         gap_frame->copy_data(static_cast<void*>(new_image), img_x * img_y * frame->get_data_type_size());
         gap_frame->set_data_type(frame->get_data_type());


### PR DESCRIPTION
This is a patch necessary until the upgraded Frame class is available.  GapFill and Blosc plugins need to pass their parameters through to the newly created Frames.