### PR TITLE
Kafka Producer plugin

### DIFF
--- a/.travis-install-librdkafka.sh
+++ b/.travis-install-librdkafka.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+VERSION="1.0.0"
+MODULE="librdkafka-${VERSION}"
+wget https://github.com/edenhill/librdkafka/archive/v${VERSION}.tar.gz
+tar xvfz v${VERSION}.tar.gz
+cd "$MODULE"
+mkdir "$HOME/$MODULE"
+./configure --prefix="$HOME/$MODULE"
+make -j
+make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,23 @@ matrix:
         - libpcap-dev
     env: PYTHONPATH=./lib/python FR_TEST_CONFIG=test_config/fr_test.config FP_TEST_CONFIG=test_config/fp_test.config
       HDF5_ROOT=$HOME/hdf5-1.10.1 BLOSC_ROOT=$HOME/c-blosc-1.14.2 INSTALL_PREFIX=$HOME/install_prefix
+      KAFKA_ROOT=$HOME/librdkafka-1.0.0
     before_install:
     - bash .travis-install-hdf5.sh
     - bash .travis-install-blosc.sh
+    - bash .travis-install-librdkafka.sh
     cache:
       directories:
       - "$HOME/hdf5-1.10.1"
       - "$HOME/c-blosc-1.14.2"
+      - "$HOME/librdkafka-1.0.0"
       - "$HOME/.cache/pip"
       - "$HOME/.local/lib"
 install:
 - mkdir -p build
 - mkdir -p $INSTALL_PREFIX
 - cd build
-- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT -DBLOSC_ROOT_DIR=$BLOSC_ROOT ..
+- cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DHDF5_ROOT=$HDF5_ROOT -DBLOSC_ROOT_DIR=$BLOSC_ROOT -DKAFKA_ROOT_DIR=$KAFKA_ROOT ..
 - make -j 4 VERBOSE=1
 - make install
 - HDF5_DIR=$HDF5_ROOT pip install --user h5py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ find_package(Log4CXX 0.10.0 REQUIRED)
 find_package(ZeroMQ 3.2.4 REQUIRED)
 find_package(PCAP 1.4.0 REQUIRED)
 find_package(Blosc REQUIRED)
+find_package(Kafka)
 
 # find package HDF5
 # FindHDF5.cmake is essentially broken and does not allow

--- a/cmake/FindKafka.cmake
+++ b/cmake/FindKafka.cmake
@@ -1,0 +1,47 @@
+#
+# Finds the Kafka C client library. This module defines:
+#   - KAFKA_INCLUDE_DIR, directory containing headers
+#   - KAFKA_LIBRARIES, the Kafka library path
+#   - KAFKA_FOUND, whether Kafka has been found
+# Define KAFKA_ROOT_DIR  if librdkafka is installed in a non-standard location.
+
+message ("\nLooking for kafka headers and libraries")
+
+
+if (KAFKA_ROOT_DIR)
+    message (STATUS "Kafka Root Dir: ${KAFKA_ROOT_DIR}")
+endif ()
+
+# Find header files
+if(KAFKA_ROOT_DIR)
+    find_path(
+        KAFKA_INCLUDE_DIR librdkafka
+        PATHS ${KAFKA_ROOT_DIR}/include
+        NO_DEFAULT_PATH
+    )
+else()
+    find_path(KAFKA_INCLUDE_DIR librdkafka)
+endif()
+
+# Find library
+if(KAFKA_ROOT_DIR)
+    find_library(
+        KAFKA_LIBRARIES NAMES rdkafka
+        PATHS ${KAFKA_ROOT_DIR}/lib
+        NO_DEFAULT_PATH
+    )
+else()
+    find_library(KAFKA_LIBRARIES NAMES rdkafka)
+endif()
+
+if(KAFKA_INCLUDE_DIR AND KAFKA_LIBRARIES)
+    message(STATUS "Found Kafka: ${KAFKA_LIBRARIES}")
+    set(KAFKA_FOUND TRUE)
+else()
+    set(KAFKA_FOUND FALSE)
+endif()
+
+if(NOT KAFKA_FOUND)
+    message(STATUS "Could not find the Kafka library.")
+endif()
+

--- a/frameProcessor/include/CMakeLists.txt
+++ b/frameProcessor/include/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Install header files into installation prefix
 
-SET(HEADERS DataBlock.h DataBlockPool.h Frame.h FrameProcessorPlugin.h FileWriterPlugin.h IFrameCallback.h MetaMessage.h MetaMessagePublisher.h WorkQueue.h HDF5File.h Acquisition.h FrameProcessorDefinitions.h BloscPlugin.h SumPlugin.h GapFillPlugin.h)
+SET(HEADERS DataBlock.h DataBlockPool.h Frame.h FrameProcessorPlugin.h
+    FileWriterPlugin.h IFrameCallback.h MetaMessage.h MetaMessagePublisher.h
+    WorkQueue.h HDF5File.h Acquisition.h FrameProcessorDefinitions.h
+    BloscPlugin.h SumPlugin.h GapFillPlugin.h KafkaProducerPlugin.h)
 INSTALL(FILES ${HEADERS} DESTINATION include/frameProcessor)

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -20,8 +20,8 @@ using namespace log4cxx::helpers;
 #define KAFKA_ERROR_BUFFER_LEN 512
 #define KAFKA_MAX_MSG_LEN 512
 #define KAFKA_LINGER_MS 1000
-#define KAFKA_DATASET_TOPIC_SEPARATOR ":"
 #define KAFKA_DEFAULT_DATASET "data"
+#define KAFKA_DEFAULT_TOPIC   "data"
 #define KAFKA_POLLING_MS 5000
 #define KAFKA_MESSAGE_MAX_BYTES "134217728"
 #define MSG_HEADER_FRAME_SIZE_KEY "data_size"
@@ -52,6 +52,8 @@ namespace FrameProcessor {
 
     void requestConfiguration(OdinData::IpcMessage &reply);
 
+    void status(OdinData::IpcMessage &status);
+
     void process_frame(boost::shared_ptr <Frame> frame);
 
     bool reset_statistics();
@@ -69,12 +71,12 @@ namespace FrameProcessor {
 
     void configure_kafka_topic(std::string topic_name);
 
-    void configure_kafka_partition(int32_t partition);
+    void configure_partition(int32_t partition);
 
     void configure_dataset(std::string dataset);
 
     void *create_message(boost::shared_ptr<Frame> frame,
-            size_t &nbytes);
+                         size_t &nbytes);
 
     void enqueue_frame(boost::shared_ptr<Frame> frame);
 
@@ -93,10 +95,11 @@ namespace FrameProcessor {
     LoggerPtr logger_;
     std::string dataset_name_;
     std::string topic_name_;
+    std::string servers_;
+    int32_t partition_;
     /* Kafka related attributes */
     rd_kafka_t *kafka_producer_;
     rd_kafka_topic_t *kafka_topic_;
-    int32_t kafka_partition_;
     /* Frames statistics */
     uint32_t frames_sent_;
     uint32_t frames_lost_;
@@ -113,13 +116,14 @@ namespace FrameProcessor {
 
     /* plugin specific parameters */
     static const std::string CONFIG_SERVERS;
+    static const std::string CONFIG_TOPIC;
     static const std::string CONFIG_PARTITION;
     /* the datasets that will be published */
     static const std::string CONFIG_DATASET;
+    static const std::string CONFIG_INCLUDE_PARAMETERS;
     static const std::string CONFIG_SENT;
     static const std::string CONFIG_LOST;
     static const std::string CONFIG_ACK;
-    static const std::string CONFIG_INCLUDE_PARAMETERS;
 
   };
 

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -28,6 +28,10 @@ using namespace log4cxx::helpers;
 #define MSG_HEADER_DATA_TYPE_KEY "data_type"
 #define MSG_HEADER_FRAME_NUMBER_KEY "frame_number"
 #define MSG_HEADER_FRAME_DIMENSIONS_KEY "dims"
+#define MSG_HEADER_ACQUISITION_ID_KEY "acquisition_id"
+#define MSG_HEADER_COMPRESSION_KEY "compression"
+#define MSG_HEADER_FRAME_OFFSET_KEY "frame_offset"
+#define MSG_HEADER_FRAME_PARAMETERS_KEY "parameters"
 
 /**
  * This plugin class creates and send messages containing
@@ -104,6 +108,9 @@ namespace FrameProcessor {
      * want to poll or produce while the handlers are been destroyed */
     boost::recursive_mutex mutex_;
 
+    /* True if frame parameters need to be included in the message header */
+    bool include_parameters_;
+
     /* plugin specific parameters */
     static const std::string CONFIG_SERVERS;
     static const std::string CONFIG_PARTITION;
@@ -112,6 +119,7 @@ namespace FrameProcessor {
     static const std::string CONFIG_SENT;
     static const std::string CONFIG_LOST;
     static const std::string CONFIG_ACK;
+    static const std::string CONFIG_INCLUDE_PARAMETERS;
 
   };
 

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -123,9 +123,6 @@ namespace FrameProcessor {
     /* the datasets that will be published */
     static const std::string CONFIG_DATASET;
     static const std::string CONFIG_INCLUDE_PARAMETERS;
-    static const std::string CONFIG_SENT;
-    static const std::string CONFIG_LOST;
-    static const std::string CONFIG_ACK;
 
   };
 

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -1,7 +1,9 @@
-//
-// Created by hir12111 on 25/03/19.
-//
-
+/*
+ * KafkaProducerPlugin.h
+ *
+ *  Created on: 25 Mar 2019
+ *      Author: Emilio Perez
+ */
 #ifndef KAFKAPRODUCERPLUGIN_H
 #define KAFKAPRODUCERPLUGIN_H
 

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -1,0 +1,50 @@
+//
+// Created by hir12111 on 25/03/19.
+//
+
+#ifndef KAFKAPRODUCERPLUGIN_H
+#define KAFKAPRODUCERPLUGIN_H
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "FrameProcessorPlugin.h"
+
+/**
+ * This plugin class calculates the sum of each pixel and
+ * adds it as a parameter
+ *
+ */
+namespace FrameProcessor {
+
+  class KafkaProducer : public FrameProcessorPlugin {
+  public:
+    KafkaProducer();
+
+    ~KafkaProducer();
+
+    void process_frame(boost::shared_ptr <Frame> frame);
+
+    int get_version_major();
+
+    int get_version_minor();
+
+    int get_version_patch();
+
+    std::string get_version_short();
+
+    std::string get_version_long();
+
+  private:
+    /** Pointer to logger */
+    LoggerPtr logger_;
+  };
+
+} /* namespace FrameProcessor */
+
+#endif //KAFKAPRODUCERPLUGIN_H

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -35,13 +35,28 @@ using namespace log4cxx::helpers;
 #define MSG_HEADER_FRAME_OFFSET_KEY "frame_offset"
 #define MSG_HEADER_FRAME_PARAMETERS_KEY "parameters"
 
-/**
- * This plugin class creates and send messages containing
- * frames to one or more Kafka servers
- *
- */
 namespace FrameProcessor {
 
+  /**
+   * KafkaProducerPlugin integrates Odin with Kafka.
+   *
+   * It creates and send messages that contains frame data and metadata
+   * to one or more Kafka servers.
+   *
+   * Plugin parameters:
+   *  servers: Kafka broker list using format IP:PORT[,IP2:PORT2,...]
+   *           Once this is set, the plugin starts delivering to the specified server/s.
+   *  dataset: Dataset name of frame that will be delivered. Defaults to "data".
+   *  topic: Topic name of the queue to send the message to. Defaults to "data".
+   *  partition: Partition number. Defaults to RD_KAFKA_PARTITION_UA (automatic partitioning)
+   *  include_parameters: Boolean indicating if frame parameters should be included in the message.
+   *                      Defaults to true.
+   *
+   * Status variables:
+   *  sent: Number of sent frames.
+   *  lost: Number of lost frames.
+   *  ack:  Number of acknowledged frames.
+   */
   class KafkaProducerPlugin : public FrameProcessorPlugin {
   public:
 
@@ -93,18 +108,25 @@ namespace FrameProcessor {
     std::string get_version_long();
 
   private:
-    /* Pointer to logger */
+    /** Pointer to logger */
     LoggerPtr logger_;
+    /** Name of the dataset that will be delivered */
     std::string dataset_name_;
+    /** Topic name identifying the destination queue */
     std::string topic_name_;
+    /** Kafka brokers to connect to */
     std::string servers_;
+    /** Partition number */
     int32_t partition_;
-    /* Kafka related attributes */
+    /** Pointer to a Kafka producer handler */
     rd_kafka_t *kafka_producer_;
+    /** Pointer to a Kafka topic handler */
     rd_kafka_topic_t *kafka_topic_;
-    /* Frames statistics */
+    /** Number of sent frames */
     uint32_t frames_sent_;
+    /** Number of lost frames */
     uint32_t frames_lost_;
+    /** Number of acknowledged frames */
     uint32_t frames_ack_;
     /* Timer used for polling every KAFKA_POLLING_MS period
      * this is necessary to serve the delivery report queue */
@@ -113,15 +135,18 @@ namespace FrameProcessor {
      * want to poll or produce while the handlers are been destroyed */
     boost::recursive_mutex mutex_;
 
-    /* True if frame parameters need to be included in the message header */
+    /** True if frame parameters need to be included in the message header */
     bool include_parameters_;
 
-    /* plugin specific parameters */
+    /** Configuration constant for servers parameter */
     static const std::string CONFIG_SERVERS;
+    /** Configuration constant for topic parameter */
     static const std::string CONFIG_TOPIC;
+    /** Configuration constant for partition parameter */
     static const std::string CONFIG_PARTITION;
-    /* the datasets that will be published */
+    /** Configuration constant for dataset parameter */
     static const std::string CONFIG_DATASET;
+    /** Configuration constant for include_parameters */
     static const std::string CONFIG_INCLUDE_PARAMETERS;
 
   };

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -10,25 +10,69 @@
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/helpers/exception.h>
 
+#include <librdkafka/rdkafka.h>
+
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 
 #include "FrameProcessorPlugin.h"
 
+#define KAFKA_ERROR_BUFFER_LEN 512
+#define KAFKA_MAX_MSG_LEN 512
+#define KAFKA_LINGER_MS 1000
+#define KAFKA_DATASET_TOPIC_SEPARATOR ":"
+#define KAFKA_DEFAULT_DATASET "data"
+#define KAFKA_POLLING_MS 5000
+#define KAFKA_MESSAGE_MAX_BYTES "134217728"
+#define MSG_HEADER_FRAME_SIZE_KEY "data_size"
+#define MSG_HEADER_DATA_TYPE_KEY "data_type"
+#define MSG_HEADER_FRAME_NUMBER_KEY "frame_number"
+#define MSG_HEADER_FRAME_DIMENSIONS_KEY "dims"
+
 /**
- * This plugin class calculates the sum of each pixel and
- * adds it as a parameter
+ * This plugin class creates and send messages containing
+ * frames to one or more Kafka servers
  *
  */
 namespace FrameProcessor {
 
-  class KafkaProducer : public FrameProcessorPlugin {
+  class KafkaProducerPlugin : public FrameProcessorPlugin {
   public:
-    KafkaProducer();
 
-    ~KafkaProducer();
+    KafkaProducerPlugin();
+
+    ~KafkaProducerPlugin();
+
+    /* FrameProcessor interface methods */
+    void configure(OdinData::IpcMessage &config, OdinData::IpcMessage &reply);
+
+    void requestConfiguration(OdinData::IpcMessage &reply);
 
     void process_frame(boost::shared_ptr <Frame> frame);
+
+    bool reset_statistics();
+
+    /* KafkaProducerPlugin specific methods */
+    void destroy_kafka();
+
+    void poll_delivery_message_report_queue();
+
+    void on_message_ack();
+
+    void on_message_error(const char *error);
+
+    void configure_kafka_servers(std::string servers);
+
+    void configure_kafka_topic(std::string topic_name);
+
+    void configure_kafka_partition(int32_t partition);
+
+    void configure_dataset(std::string dataset);
+
+    void *create_message(boost::shared_ptr<Frame> frame,
+            size_t &nbytes);
+
+    void enqueue_frame(boost::shared_ptr<Frame> frame);
 
     int get_version_major();
 
@@ -41,8 +85,34 @@ namespace FrameProcessor {
     std::string get_version_long();
 
   private:
-    /** Pointer to logger */
+    /* Pointer to logger */
     LoggerPtr logger_;
+    std::string dataset_name_;
+    std::string topic_name_;
+    /* Kafka related attributes */
+    rd_kafka_t *kafka_producer_;
+    rd_kafka_topic_t *kafka_topic_;
+    int32_t kafka_partition_;
+    /* Frames statistics */
+    uint32_t frames_sent_;
+    uint32_t frames_lost_;
+    uint32_t frames_ack_;
+    /* Timer used for polling every KAFKA_POLLING_MS period
+     * this is necessary to serve the delivery report queue */
+    int polling_timer_id_;
+    /* For protecting critical region, specially when configuring, we don't
+     * want to poll or produce while the handlers are been destroyed */
+    boost::recursive_mutex mutex_;
+
+    /* plugin specific parameters */
+    static const std::string CONFIG_SERVERS;
+    static const std::string CONFIG_PARTITION;
+    /* the datasets that will be published */
+    static const std::string CONFIG_DATASET;
+    static const std::string CONFIG_SENT;
+    static const std::string CONFIG_LOST;
+    static const std::string CONFIG_ACK;
+
   };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -81,6 +81,11 @@ add_library(GapFillPlugin SHARED GapFillPlugin.cpp GapFillPluginLib.cpp)
 target_link_libraries(GapFillPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
 install(TARGETS GapFillPlugin DESTINATION lib)
 
+# Add library for Kafka Producer plugin
+add_library(KafkaProducerPlugin SHARED KafkaProducerPlugin.cpp KafkaProducerPluginLib.cpp)
+target_link_libraries(KafkaProducerPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
+install(TARGETS KafkaProducerPlugin DESTINATION lib)
+
 # Add test and project source files to executable
 if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
   # librt required for timing functions

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -81,10 +81,16 @@ add_library(GapFillPlugin SHARED GapFillPlugin.cpp GapFillPluginLib.cpp)
 target_link_libraries(GapFillPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
 install(TARGETS GapFillPlugin DESTINATION lib)
 
-# Add library for Kafka Producer plugin
-add_library(KafkaProducerPlugin SHARED KafkaProducerPlugin.cpp KafkaProducerPluginLib.cpp)
-target_link_libraries(KafkaProducerPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
-install(TARGETS KafkaProducerPlugin DESTINATION lib)
+if (${KAFKA_FOUND})
+    include_directories(${KAFKA_INCLUDE_DIR})
+    # Add library for Kafka Producer plugin
+    add_library(KafkaProducerPlugin SHARED KafkaProducerPlugin.cpp
+                                           KafkaProducerPluginLib.cpp)
+    target_link_libraries(KafkaProducerPlugin ${LIB_PROCESSOR}
+        ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES}
+        ${KAFKA_LIBRARIES} ${COMMON_LIBRARY})
+    install(TARGETS KafkaProducerPlugin DESTINATION lib)
+endif()
 
 # Add test and project source files to executable
 if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -1,64 +1,381 @@
 //
 // Created by hir12111 on 25/03/19.
 //
+#include <cstring>
+#include <cstdlib>
+#include <boost/algorithm/string.hpp>
+#include <climits>
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
 
 #include "KafkaProducerPlugin.h"
 #include "version.h"
 
 namespace FrameProcessor {
 
-/**
- * The constructor sets up logging used within the class.
- */
-  KafkaProducer::KafkaProducer()
+
+  // Callback function used to report status of a delivered message
+  static void kafka_message_callback(rd_kafka_t* kafka_producer,
+      const rd_kafka_message_t* kafka_message, void* opaque)
+  {
+    KafkaProducerPlugin* kafka_producer_plugin = static_cast<KafkaProducerPlugin*>(kafka_message->_private);
+    if (kafka_message->err) {
+      kafka_producer_plugin->on_message_error(
+          rd_kafka_err2str(kafka_message->err));
+    }
+    else {
+      // count message as acknowledged
+      kafka_producer_plugin->on_message_ack();
+    }
+  }
+
+  const std::string KafkaProducerPlugin::CONFIG_SERVERS = "servers";
+  const std::string KafkaProducerPlugin::CONFIG_PARTITION = "partition";
+  const std::string KafkaProducerPlugin::CONFIG_DATASET = "dataset";
+  const std::string KafkaProducerPlugin::CONFIG_SENT = "sent";
+  const std::string KafkaProducerPlugin::CONFIG_LOST = "lost";
+  const std::string KafkaProducerPlugin::CONFIG_ACK = "ack";
+
+  /**
+   * The constructor sets up logging used within the class.
+   */
+  KafkaProducerPlugin::KafkaProducerPlugin()
+      : dataset_name_(KAFKA_DEFAULT_DATASET), topic_name_(KAFKA_DEFAULT_DATASET),
+        kafka_producer_(NULL), kafka_topic_(NULL),
+        kafka_partition_(RD_KAFKA_PARTITION_UA)
   {
     // Setup logging for the class
     logger_ = Logger::getLogger("FP.KafkaProducer");
     logger_->setLevel(Level::getAll());
     LOG4CXX_TRACE(logger_, "KafkaProducer constructor.");
+    this->reset_statistics();
   }
 
-/**
- * Destructor.
- */
-  KafkaProducer::~KafkaProducer()
+  /**
+   * Destructor.
+   */
+  KafkaProducerPlugin::~KafkaProducerPlugin()
   {
     LOG4CXX_TRACE(logger_, "KafkaProducer destructor.");
+    destroy_kafka();
   }
 
+  void KafkaProducerPlugin::configure(OdinData::IpcMessage& config,
+      OdinData::IpcMessage& reply)
+  {
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    if (config.has_param(CONFIG_SERVERS)) {
+      configure_kafka_servers(config.get_param<std::string>(CONFIG_SERVERS));
+      configure_kafka_topic(this->topic_name_);
+    }
 
-/**
- * Send the frame to a Kafka Broker and push it
- *
- * \param[in] frame - Pointer to a Frame object.
- */
-  void KafkaProducer::process_frame(boost::shared_ptr <Frame> frame)
+    if (config.has_param(CONFIG_PARTITION)) {
+      configure_kafka_partition(config.get_param<uint32_t>(CONFIG_PARTITION));
+    }
+
+    if (config.has_param(CONFIG_DATASET)) {
+      configure_dataset(config.get_param<std::string>(CONFIG_DATASET));
+      configure_kafka_topic(this->topic_name_);
+    }
+  }
+
+  void KafkaProducerPlugin::requestConfiguration(OdinData::IpcMessage& reply)
+  {
+    // Make sure statistics are updated
+    poll_delivery_message_report_queue();
+
+    reply.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_SENT,
+        frames_sent_);
+    reply.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_LOST,
+        frames_lost_);
+    reply.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_ACK,
+        frames_ack_);
+  }
+
+  bool KafkaProducerPlugin::reset_statistics()
+  {
+    this->frames_sent_ = 0;
+    this->frames_lost_ = 0;
+    this->frames_ack_ = 0;
+    return true;
+  }
+
+  /**
+   * Destroy Kafka handlers for the connection and the topic
+   */
+  void KafkaProducerPlugin::destroy_kafka()
+  {
+    if (kafka_topic_ != NULL) {
+      rd_kafka_flush(kafka_producer_, KAFKA_LINGER_MS);
+      rd_kafka_topic_destroy(kafka_topic_);
+      kafka_topic_ = NULL;
+    }
+    if (kafka_producer_ != NULL) {
+      rd_kafka_destroy(kafka_producer_);
+      kafka_producer_ = NULL;
+    }
+  }
+
+  void KafkaProducerPlugin::poll_delivery_message_report_queue()
+  {
+    if (kafka_producer_ != NULL) {
+      boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+      rd_kafka_poll(kafka_producer_, 0);
+    }
+  }
+
+  /**
+   * Configure Kafka connection handler for the server/s specified
+   */
+  void KafkaProducerPlugin::configure_kafka_servers(std::string servers)
+  {
+    destroy_kafka();
+    rd_kafka_t* kafka_producer;
+    rd_kafka_conf_t* kafka_config;
+    char errBuf[KAFKA_ERROR_BUFFER_LEN];
+    kafka_config = rd_kafka_conf_new();
+    int status;
+
+    status = rd_kafka_conf_set(kafka_config,
+        "message.max.bytes",
+        KAFKA_MESSAGE_MAX_BYTES,
+        errBuf,
+        sizeof(errBuf));
+
+    if (status != RD_KAFKA_CONF_OK) {
+      LOG4CXX_ERROR(logger_, "Kafka configuration error while setting max message size: "
+          << errBuf);
+      return;
+    }
+
+    status = rd_kafka_conf_set(kafka_config,
+        "bootstrap.servers",
+        servers.c_str(),
+        errBuf,
+        sizeof(errBuf));
+
+    if (status != RD_KAFKA_CONF_OK) {
+      LOG4CXX_ERROR(logger_, "Kafka configuration error while setting botstrap servers"
+          << errBuf);
+      return;
+    }
+
+    // Configure callback to count ACKed messages
+    rd_kafka_conf_set_dr_msg_cb(kafka_config, kafka_message_callback);
+
+    // kafkaProducer will free kafka_config when destroyed
+    kafka_producer = rd_kafka_new(RD_KAFKA_PRODUCER, kafka_config, errBuf,
+        sizeof(errBuf));
+    if (!kafka_producer) {
+      LOG4CXX_ERROR(logger_, "Kafka handle error: " << errBuf);
+      return;
+    }
+
+    this->kafka_producer_ = kafka_producer;
+
+    LOG4CXX_TRACE(logger_, "Configured kafka servers: " << servers);
+
+  }
+
+  /**
+   * Configure Kafka topic handler for the topic specified
+   */
+  void KafkaProducerPlugin::configure_kafka_topic(std::string topic_name)
+  {
+
+    if (this->kafka_producer_ == NULL) {
+      LOG4CXX_WARN(logger_, "Broker is not configured");
+      this->kafka_topic_ = NULL;
+      return;
+    }
+
+    if (this->kafka_topic_ != NULL) {
+      rd_kafka_topic_destroy(kafka_topic_);
+    }
+
+    this->kafka_topic_ = rd_kafka_topic_new(kafka_producer_,
+        this->topic_name_.c_str(),
+        NULL);
+    if (!this->kafka_topic_) {
+      LOG4CXX_ERROR(logger_, "Kafka topic error");
+    }
+    LOG4CXX_TRACE(logger_, "Configured kafka topic: " << topic_name);
+  }
+
+  /**
+   * Configure the dataset that will be published, the topic name
+   * might be specified after a colon character, i.e: following the format {dataset}:{topic}
+   *
+   * If no topic is specified, it is assumed as the dataset name
+   */
+  void KafkaProducerPlugin::configure_dataset(std::string dataset)
+  {
+    // Parse "dataset:topic", if only dataset is provided
+    // the same name will be used as topic
+    size_t sep = dataset.find(KAFKA_DATASET_TOPIC_SEPARATOR);
+    if (sep == std::string::npos) {
+      this->dataset_name_ = dataset;
+      this->topic_name_ = dataset;
+    }
+    else {
+      this->dataset_name_ = dataset.substr(0, sep);
+      this->topic_name_ = dataset.substr(sep + 1, std::string::npos);
+    }
+    LOG4CXX_TRACE(logger_, "Configured dataset " << this->dataset_name_);
+  }
+
+  /**
+   * Set Kafka partition to send messages to
+   *
+   * If it is not configured, it defaults to automatic partitioning (using
+   * the topic's partitioner function)
+   */
+  void KafkaProducerPlugin::configure_kafka_partition(int32_t partition)
+  {
+    kafka_partition_ = partition;
+  }
+
+  /* Create a message with the following structure:
+   * [ json header length (2 bytes) ] + [ json header ] + [ frame data]  */
+  void* KafkaProducerPlugin::create_message(boost::shared_ptr<Frame> frame,
+      size_t& nbytes)
+  {
+    // creates header information
+    rapidjson::StringBuffer string_buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(string_buffer);
+    writer.StartObject();
+    writer.String(MSG_HEADER_FRAME_SIZE_KEY);
+    writer.Uint64(frame->get_data_size());
+    writer.String(MSG_HEADER_DATA_TYPE_KEY);
+    writer.Int(frame->get_data_type());
+    writer.String(MSG_HEADER_FRAME_NUMBER_KEY);
+    writer.Uint64(frame->get_frame_number());
+    writer.String(MSG_HEADER_FRAME_DIMENSIONS_KEY);
+    writer.StartArray();
+    dimensions_t dims = frame->get_dimensions();
+    for (dimensions_t::iterator it = dims.begin(); it != dims.end(); it++) {
+      writer.Uint64(*it);
+    }
+    writer.EndArray();
+    writer.EndObject();
+
+    if (string_buffer.GetSize() > USHRT_MAX) {
+      LOG4CXX_ERROR(logger_, "Header size is too big, it should be less than "
+          << USHRT_MAX);
+      nbytes = 0;
+      return NULL;
+    }
+
+    size_t message_size = sizeof(uint16_t) + string_buffer.GetSize() + 1
+        + frame->get_data_size();
+    char* msg = (char*) malloc(message_size);
+    uint16_t header_size = static_cast<uint16_t>(string_buffer.GetSize() + 1);
+
+    *(reinterpret_cast<uint16_t*>(msg)) = header_size;
+    // copy header data, this includes an ending null byte
+    memcpy(msg + sizeof(uint16_t), string_buffer.GetString(),
+        header_size);
+    // copy frame data
+    memcpy(msg + sizeof(uint16_t) + header_size, frame->get_data(),
+        frame->get_data_size());
+    nbytes = message_size;
+    return msg;
+  }
+
+  /**
+   * Create and enqueue a frame message to kafka server/s
+   */
+  void KafkaProducerPlugin::enqueue_frame(boost::shared_ptr<Frame> frame)
+  {
+    LOG4CXX_TRACE(logger_, "Sending frame to message queue ...");
+    if (!this->kafka_topic_) {
+      LOG4CXX_WARN(logger_, "Topic not configured");
+      return;
+    }
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    char* buf;
+    size_t len;
+    // This buffer is freed by kafka (when there are no errors)
+    buf = (char*) create_message(frame, len);
+    if (!buf) {
+      return;
+    }
+    // enqueue message
+    int status = rd_kafka_produce(
+        this->kafka_topic_,
+        kafka_partition_,
+        /* free buffer when enqueued */
+        RD_KAFKA_MSG_F_FREE,
+        /* Data */
+        buf, len,
+        /* No key */
+        NULL, 0,
+        /* Opaque pointer */
+        this);
+
+    if (status) {
+      // Dropping frame, probably the queue is full
+      LOG4CXX_ERROR(logger_, "Error while producing: "
+          << rd_kafka_err2str(rd_kafka_last_error()));
+      free(buf);
+      frames_lost_++;
+    }
+    else {
+      frames_sent_++;
+    }
+    rd_kafka_poll(this->kafka_producer_, 0);
+  }
+
+  /**
+   * It updates stats when a message is acknowledged
+   */
+  void KafkaProducerPlugin::on_message_ack()
+  {
+    this->frames_ack_++;
+  }
+
+  /**
+   * It logs an error when a message delivery has failed
+   */
+  void KafkaProducerPlugin::on_message_error(const char* error)
+  {
+    LOG4CXX_ERROR(logger_, "Error while delivering message: " << error);
+  }
+
+  /**
+   * If dataset configured matches, it sends the frame to kafka server/s
+   *
+   * \param[in] frame - Pointer to a Frame object.
+   */
+  void KafkaProducerPlugin::process_frame(boost::shared_ptr<Frame> frame)
   {
     LOG4CXX_TRACE(logger_, "Received a new frame...");
+    if (frame->get_dataset_name() == this->dataset_name_)
+      this->enqueue_frame(frame);
     this->push(frame);
   }
 
-  int KafkaProducer::get_version_major()
+  int KafkaProducerPlugin::get_version_major()
   {
     return ODIN_DATA_VERSION_MAJOR;
   }
 
-  int KafkaProducer::get_version_minor()
+  int KafkaProducerPlugin::get_version_minor()
   {
     return ODIN_DATA_VERSION_MINOR;
   }
 
-  int KafkaProducer::get_version_patch()
+  int KafkaProducerPlugin::get_version_patch()
   {
     return ODIN_DATA_VERSION_PATCH;
   }
 
-  std::string KafkaProducer::get_version_short()
+  std::string KafkaProducerPlugin::get_version_short()
   {
     return ODIN_DATA_VERSION_STR_SHORT;
   }
 
-  std::string KafkaProducer::get_version_long()
+  std::string KafkaProducerPlugin::get_version_long()
   {
     return ODIN_DATA_VERSION_STR;
   }

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -36,9 +36,6 @@ namespace FrameProcessor {
   const std::string KafkaProducerPlugin::CONFIG_PARTITION = "partition";
   const std::string KafkaProducerPlugin::CONFIG_DATASET = "dataset";
   const std::string KafkaProducerPlugin::CONFIG_INCLUDE_PARAMETERS = "include_parameters";
-  const std::string KafkaProducerPlugin::CONFIG_SENT = "sent";
-  const std::string KafkaProducerPlugin::CONFIG_LOST = "lost";
-  const std::string KafkaProducerPlugin::CONFIG_ACK = "ack";
 
   /**
    * The constructor sets up logging used within the class.
@@ -109,13 +106,12 @@ namespace FrameProcessor {
   {
     // Make sure statistics are updated
     poll_delivery_message_report_queue();
-
-    status.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_SENT,
-                     frames_sent_);
-    status.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_LOST,
-                     frames_lost_);
-    status.set_param(get_name() + "/" + KafkaProducerPlugin::CONFIG_ACK,
-                     frames_ack_);
+    /* Number of sent frames */
+    status.set_param(get_name() + "/" + "sent", frames_sent_);
+    /* Number of lost frames */
+    status.set_param(get_name() + "/" + "lost", frames_lost_);
+    /* Number of acknowledged frames */
+    status.set_param(get_name() + "/" + "ack", frames_ack_);
   }
 
   bool KafkaProducerPlugin::reset_statistics()

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -1,6 +1,9 @@
-//
-// Created by hir12111 on 25/03/19.
-//
+/*
+ * KafkaProducerPlugin.cpp
+ *
+ *  Created on: 25 Mar 2019
+ *      Author: Emilio Perez
+ */
 #include <cstring>
 #include <cstdlib>
 #include <boost/algorithm/string.hpp>

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -1,0 +1,66 @@
+//
+// Created by hir12111 on 25/03/19.
+//
+
+#include "KafkaProducerPlugin.h"
+#include "version.h"
+
+namespace FrameProcessor {
+
+/**
+ * The constructor sets up logging used within the class.
+ */
+  KafkaProducer::KafkaProducer()
+  {
+    // Setup logging for the class
+    logger_ = Logger::getLogger("FP.KafkaProducer");
+    logger_->setLevel(Level::getAll());
+    LOG4CXX_TRACE(logger_, "KafkaProducer constructor.");
+  }
+
+/**
+ * Destructor.
+ */
+  KafkaProducer::~KafkaProducer()
+  {
+    LOG4CXX_TRACE(logger_, "KafkaProducer destructor.");
+  }
+
+
+/**
+ * Send the frame to a Kafka Broker and push it
+ *
+ * \param[in] frame - Pointer to a Frame object.
+ */
+  void KafkaProducer::process_frame(boost::shared_ptr <Frame> frame)
+  {
+    LOG4CXX_TRACE(logger_, "Received a new frame...");
+    this->push(frame);
+  }
+
+  int KafkaProducer::get_version_major()
+  {
+    return ODIN_DATA_VERSION_MAJOR;
+  }
+
+  int KafkaProducer::get_version_minor()
+  {
+    return ODIN_DATA_VERSION_MINOR;
+  }
+
+  int KafkaProducer::get_version_patch()
+  {
+    return ODIN_DATA_VERSION_PATCH;
+  }
+
+  std::string KafkaProducer::get_version_short()
+  {
+    return ODIN_DATA_VERSION_STR_SHORT;
+  }
+
+  std::string KafkaProducer::get_version_long()
+  {
+    return ODIN_DATA_VERSION_STR;
+  }
+
+} /* namespace FrameProcessor */

--- a/frameProcessor/src/KafkaProducerPluginLib.cpp
+++ b/frameProcessor/src/KafkaProducerPluginLib.cpp
@@ -1,0 +1,16 @@
+//
+// Created by hir12111 on 25/03/19.
+//
+
+#include "KafkaProducerPlugin.h"
+#include "ClassLoader.h"
+
+namespace FrameProcessor
+{
+  /**
+   * Registration of this plugin through the ClassLoader. This macro
+   * registers the class without needing to worry about name mangling
+   */
+  REGISTER(FrameProcessorPlugin, KafkaProducer, "KafkaProducerPlugin");
+
+}  // namespace FrameProcessor

--- a/frameProcessor/src/KafkaProducerPluginLib.cpp
+++ b/frameProcessor/src/KafkaProducerPluginLib.cpp
@@ -1,7 +1,9 @@
-//
-// Created by hir12111 on 25/03/19.
-//
-
+/*
+ * KafkaProducerPluginLib.cpp
+ *
+ *  Created on: 25 Mar 2019
+ *      Author: Emilio Perez
+ */
 #include "KafkaProducerPlugin.h"
 #include "ClassLoader.h"
 

--- a/frameProcessor/src/KafkaProducerPluginLib.cpp
+++ b/frameProcessor/src/KafkaProducerPluginLib.cpp
@@ -11,6 +11,6 @@ namespace FrameProcessor
    * Registration of this plugin through the ClassLoader. This macro
    * registers the class without needing to worry about name mangling
    */
-  REGISTER(FrameProcessorPlugin, KafkaProducer, "KafkaProducerPlugin");
+  REGISTER(FrameProcessorPlugin, KafkaProducerPlugin, "KafkaProducerPlugin");
 
 }  // namespace FrameProcessor

--- a/frameProcessor/test/CMakeLists.txt
+++ b/frameProcessor/test/CMakeLists.txt
@@ -12,6 +12,11 @@ if (${BLOSC_FOUND})
   include_directories(${BLOSC_INCLUDE_DIR})
 endif()
 
+if (${KAFKA_FOUND})
+    list(APPEND TEST_SOURCES KafkaProducerPluginTest.cpp)
+    include_directories(${KAFKA_INCLUDE_DIR})
+endif()
+
 # Add test source files to executable
 add_executable(frameProcessorTest ${TEST_SOURCES})
 
@@ -34,6 +39,11 @@ target_link_libraries(frameProcessorTest
 # Link for BloscPlugin if Blosc is present
 if (${BLOSC_FOUND})
   target_link_libraries(frameProcessorTest ${BLOSC_LIBRARIES} BloscPlugin)
+endif()
+
+if (${KAFKA_FOUND})
+  target_link_libraries(frameProcessorTest ${KAFKA_LIBRARIES}
+      KafkaProducerPlugin)
 endif()
 
 if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )

--- a/frameProcessor/test/KafkaProducerPluginTest.cpp
+++ b/frameProcessor/test/KafkaProducerPluginTest.cpp
@@ -1,0 +1,88 @@
+#include <boost/test/unit_test.hpp>
+#include <cstring>
+#include <cstdlib>
+#include "rapidjson/document.h"
+#include "KafkaProducerPlugin.h"
+
+class KafkaProducerPluginTestFixture {
+public:
+  KafkaProducerPluginTestFixture()
+  {
+    frame = boost::shared_ptr<FrameProcessor::Frame>(new FrameProcessor::Frame("data"));
+    for (int i = 0; i < 12; i++) {
+      test_data[i] = i + 1;
+    }
+    test_dims.clear();
+    test_dims.push_back(3);
+    test_dims.push_back(4);
+    frame->set_frame_number(7);
+    frame->set_dimensions(test_dims);
+    frame->set_data_type(FrameProcessor::raw_16bit);
+    frame->copy_data(static_cast<void*>(test_data), sizeof(test_data));
+  }
+
+  ~KafkaProducerPluginTestFixture() { }
+
+  unsigned short test_data[12];
+  dimensions_t test_dims;
+  FrameProcessor::KafkaProducerPlugin plugin;
+  boost::shared_ptr<FrameProcessor::Frame> frame;
+};
+
+BOOST_FIXTURE_TEST_SUITE(KafkaProducerPluginUnitTest, KafkaProducerPluginTestFixture);
+
+BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageContent)
+{
+
+  size_t msg_size;
+  void* data = plugin.create_message(frame, msg_size);
+
+  BOOST_CHECK(data != NULL);
+
+  uint16_t header_size = *(static_cast<uint16_t*>(data));
+
+  // there is frame data and it's the same as TEST_DATA
+  BOOST_CHECK_EQUAL(0, memcmp(test_data,
+      static_cast<char*>(data) + sizeof(uint16_t)
+          + header_size,
+      sizeof(test_data)));
+  free(data);
+}
+
+BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageSize)
+{
+  size_t msg_size;
+  void* data = plugin.create_message(frame, msg_size);
+  uint16_t header_size = *(static_cast<uint16_t*>(data));
+
+  BOOST_CHECK(data != NULL);
+
+  // Total size is the sum of each part size: [header size] + [header] + [data]
+  BOOST_CHECK(msg_size == sizeof(uint16_t) + header_size + sizeof(test_data));
+  free(data);
+}
+
+BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageHeader)
+{
+  size_t msg_size;
+  void* data = plugin.create_message(frame, msg_size);
+
+  BOOST_CHECK(data != NULL);
+
+  uint16_t header_size = *(static_cast<uint16_t*>(data));
+  char* header_data = static_cast<char*>(data) + sizeof(uint16_t);
+  // Check that the header ends with a null byte
+  BOOST_CHECK(header_data[header_size - 1] == 0);
+  rapidjson::Document document;
+  document.Parse(header_data);
+  BOOST_CHECK(document[MSG_HEADER_FRAME_NUMBER_KEY].GetInt() == 7);
+  BOOST_CHECK(document[MSG_HEADER_DATA_TYPE_KEY].GetInt() == FrameProcessor::raw_16bit);
+  BOOST_CHECK(document[MSG_HEADER_FRAME_SIZE_KEY].GetInt() == sizeof(test_data));
+  rapidjson::Value& json_dims = document[MSG_HEADER_FRAME_DIMENSIONS_KEY];
+  for (int i = 0; i < test_dims.size(); i++) {
+    BOOST_CHECK(test_dims[i] == json_dims[i].GetUint());
+  }
+  free(data);
+}
+
+BOOST_AUTO_TEST_SUITE_END(); //KafkaProducerPluginUnitTest

--- a/frameProcessor/test/KafkaProducerPluginTest.cpp
+++ b/frameProcessor/test/KafkaProducerPluginTest.cpp
@@ -18,7 +18,7 @@ public:
     frame->set_frame_number(7);
     frame->set_dimensions(test_dims);
     frame->set_data_type(FrameProcessor::raw_16bit);
-    frame->copy_data(static_cast<void*>(test_data), sizeof(test_data));
+    frame->copy_data(static_cast<void *>(test_data), sizeof(test_data));
   }
 
   ~KafkaProducerPluginTestFixture() { }
@@ -35,25 +35,26 @@ BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageContent)
 {
 
   size_t msg_size;
-  void* data = plugin.create_message(frame, msg_size);
+  void *data = plugin.create_message(frame, msg_size);
 
   BOOST_CHECK(data != NULL);
 
-  uint16_t header_size = *(static_cast<uint16_t*>(data));
+  uint16_t header_size = *(static_cast<uint16_t *>(data));
 
   // there is frame data and it's the same as TEST_DATA
-  BOOST_CHECK_EQUAL(0, memcmp(test_data,
-      static_cast<char*>(data) + sizeof(uint16_t)
-          + header_size,
-      sizeof(test_data)));
+  BOOST_CHECK_EQUAL(0,
+                    memcmp(test_data,
+                           static_cast<char *>(data) + sizeof(uint16_t)
+                             + header_size,
+                           sizeof(test_data)));
   free(data);
 }
 
 BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageSize)
 {
   size_t msg_size;
-  void* data = plugin.create_message(frame, msg_size);
-  uint16_t header_size = *(static_cast<uint16_t*>(data));
+  void *data = plugin.create_message(frame, msg_size);
+  uint16_t header_size = *(static_cast<uint16_t *>(data));
 
   BOOST_CHECK(data != NULL);
 
@@ -65,12 +66,12 @@ BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageSize)
 BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageHeader)
 {
   size_t msg_size;
-  void* data = plugin.create_message(frame, msg_size);
+  void *data = plugin.create_message(frame, msg_size);
 
   BOOST_CHECK(data != NULL);
 
-  uint16_t header_size = *(static_cast<uint16_t*>(data));
-  char* header_data = static_cast<char*>(data) + sizeof(uint16_t);
+  uint16_t header_size = *(static_cast<uint16_t *>(data));
+  char* header_data = static_cast<char *>(data) + sizeof(uint16_t);
   // Check that the header ends with a null byte
   BOOST_CHECK(header_data[header_size - 1] == 0);
   rapidjson::Document document;
@@ -78,7 +79,7 @@ BOOST_AUTO_TEST_CASE(KafkaProducerPluginCheckMessageHeader)
   BOOST_CHECK(document[MSG_HEADER_FRAME_NUMBER_KEY].GetInt() == 7);
   BOOST_CHECK(document[MSG_HEADER_DATA_TYPE_KEY].GetInt() == FrameProcessor::raw_16bit);
   BOOST_CHECK(document[MSG_HEADER_FRAME_SIZE_KEY].GetInt() == sizeof(test_data));
-  rapidjson::Value& json_dims = document[MSG_HEADER_FRAME_DIMENSIONS_KEY];
+  rapidjson::Value &json_dims = document[MSG_HEADER_FRAME_DIMENSIONS_KEY];
   for (int i = 0; i < test_dims.size(); i++) {
     BOOST_CHECK(test_dims[i] == json_dims[i].GetUint());
   }


### PR DESCRIPTION
- Implementation of a plugin that allows sending frames to one or more Kafka servers asynchronously.
- Unit tests
- Kafka cmake file
- Travis dependency installer

A few decisions were made in this implementation:

 - librdkafka C library was used instead of the C++ version as it is more flexible.
 - The message header is json (for more flexibility and easy to parse), the message structure is: [2 bytes header size] + [json header] + [frame data]
 - The header contains the following keys: "data_size", "data_type", "frame_number", "dims", "frame_offset", "acquisition_id", "compression" and optionally "parameters" (object containing frame parameters)
 - The plugin is optional
 - The message is sent without blocking (or waiting for ack)
 - Default partition is automatic partitioning (RD_KAFKA_PARTITION_UA)
 - It allows choosing which dataset will be published, defaults to "data"
 - It allows choosing in which topic will be published, defaults to "data"
 - If many topics or datasets are required, the plugin could be instantiated many times with different configuration.

I've already tested it with Tom in our kafka cluster and everything works fine.
EDIT: it has also been tested with a real Eiger detector