### PR TITLE
Set remove_when_deleted flag on FR SharedBufferManager instance

### DIFF
--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -617,7 +617,7 @@ void FrameReceiverController::configure_buffer_manager(OdinData::IpcMessage& con
 
       // Create a new shared buffer manager
       buffer_manager_.reset(new SharedBufferManager(
-          shared_buffer_name, max_buffer_mem,frame_decoder_->get_frame_buffer_size(), false)
+          shared_buffer_name, max_buffer_mem,frame_decoder_->get_frame_buffer_size(), true)
       );
 
       LOG4CXX_DEBUG_LEVEL(1, logger_, "Configured frame buffer manager of total size " <<


### PR DESCRIPTION
This PR is in partial mitigation of the issue described in #195, where the FR hangs when attempting to map a shared buffer with the wrong permissions. The underlying problem is a bug in the `shared_memory_object` implementation in boost <= 1.53, which affects the default version on EL7 platforms. 

The mitigation is to have the FR use the existing `remove_when_deleted` mechanism in the `SharedBufferManager` so that the shared memory file is unlinked and marked for deletion when the FR shuts down. The FP can continue to use the mapped memory until it closes down, or a new FR starts up and advertises a new shared buffer to it, at which point the FP closes the old instance and re-maps the new one. This behaviour has been confirmed by watching file inodes over the lifetime of the FR and FP:

New FR and FP started: both have the same SHM inode open
```
$ /usr/sbin/lsof -p $(pidof frameReceiver) | grep shm
frameRece 119219 tcn45  mem       REG    0,19 840000024    1166861 /dev/shm/ExcaliburFrameBuffer01
frameRece 119219 tcn45   18u      REG    0,19 840000024    1166861 /dev/shm/ExcaliburFrameBuffer01
$ /usr/sbin/lsof -p $(pidof frameProcessor) | grep shm
frameProc 118587 tcn45  mem       REG    0,19 840000024    1166861 /dev/shm/ExcaliburFrameBuffer01
frameProc 118587 tcn45   26u      REG    0,19 840000024    1166861 /dev/shm/ExcaliburFrameBuffer01
```
Shut down the FR; FP has SHM still mem-mapped but marked for deletion:
```
$ /usr/sbin/lsof -p $(pidof frameProcessor) | grep shm
frameProc 118587 tcn45  DEL       REG    0,19              1166861 /dev/shm/ExcaliburFrameBuffer01
frameProc 118587 tcn45   26u      REG    0,19 840000024    1166861 /dev/shm/ExcaliburFrameBuffer01 (deleted)
```
Start a new FR while leaving the FP running; FR advertises new shared buffer, FP remaps, both have same, new inode open:
```
$ /usr/sbin/lsof -p $(pidof frameReceiver) | grep shm
frameRece 119465 tcn45  mem       REG    0,19 840000024    1158008 /dev/shm/ExcaliburFrameBuffer01
frameRece 119465 tcn45   18u      REG    0,19 840000024    1158008 /dev/shm/ExcaliburFrameBuffer01
$ /usr/sbin/lsof -p $(pidof frameProcessor) | grep shm
frameProc 118587 tcn45  mem       REG    0,19 840000024    1158008 /dev/shm/ExcaliburFrameBuffer01
frameProc 118587 tcn45   26u      REG    0,19 840000024    1158008 /dev/shm/ExcaliburFrameBuffer01
```