### PR TITLE
Remove concept of configured/current offset in OffsetAdjustmentPlugin

### DIFF
--- a/frameProcessor/include/OffsetAdjustmentPlugin.h
+++ b/frameProcessor/include/OffsetAdjustmentPlugin.h
@@ -2,7 +2,7 @@
  * OffsetAdjustmentPlugin.h
  *
  *  Created on: 16 Aug 2018
- *      Author: vtu42223
+ *      Author: Matt Taylor
  */
 
 #ifndef FRAMEPROCESSOR_OFFSETADJUSTMENTPLUGIN_H_
@@ -22,9 +22,7 @@ namespace FrameProcessor
 {
 
 const int DEFAULT_OFFSET_ADJUSTMENT = 0;
-const int DEFAULT_OFFSET_FIRST_FRAME = 0;
 static const std::string OFFSET_ADJUSTMENT_CONFIG = "offset_adjustment";
-static const std::string FIRST_FRAME_OFFSET_CONFIG = "first_frame_number";
 
 /**
  * This plugin class alters the frame offset by a configured amount
@@ -48,12 +46,8 @@ private:
 
   /** Pointer to logger */
   LoggerPtr logger_;
-  /** Offset adjustment currently in use **/
-  int64_t current_offset_adjustment_;
-  /** Offset adjustment configured to be used from next first frame onwards **/
-  int64_t configured_offset_adjustment_;
-  /** Frame number of the first frame in an acquisition from the detector **/
-  uint64_t first_frame_number_;
+  /** Offset adjustment to use **/
+  int64_t offset_adjustment_;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/OffsetAdjustmentPlugin.cpp
+++ b/frameProcessor/src/OffsetAdjustmentPlugin.cpp
@@ -2,7 +2,7 @@
  * OffsetAdjustmentPlugin.cpp
  *
  *  Created on: 16 Aug 2018
- *      Author: vtu42223
+ *      Author: Matt Taylor
  */
 
 #include "OffsetAdjustmentPlugin.h"
@@ -15,9 +15,7 @@ namespace FrameProcessor
  * The constructor sets up logging used within the class.
  */
 OffsetAdjustmentPlugin::OffsetAdjustmentPlugin() :
-    current_offset_adjustment_(DEFAULT_OFFSET_ADJUSTMENT),
-    configured_offset_adjustment_(DEFAULT_OFFSET_ADJUSTMENT),
-    first_frame_number_(DEFAULT_OFFSET_FIRST_FRAME)
+    offset_adjustment_(DEFAULT_OFFSET_ADJUSTMENT)
 {
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.OffsetAdjustmentPlugin");
@@ -42,13 +40,7 @@ OffsetAdjustmentPlugin::~OffsetAdjustmentPlugin()
  */
 void OffsetAdjustmentPlugin::process_frame(boost::shared_ptr<Frame> frame)
 {
-  if (frame->get_frame_number() == first_frame_number_)
-  {
-    // If at first frame, set the offset value to the the configured value to apply it from now on
-    current_offset_adjustment_ = configured_offset_adjustment_;
-  }
-
-  frame->meta_data().adjust_frame_offset(current_offset_adjustment_);
+  frame->meta_data().adjust_frame_offset(offset_adjustment_);
   this->push(frame);
 }
 
@@ -64,16 +56,10 @@ void OffsetAdjustmentPlugin::process_frame(boost::shared_ptr<Frame> frame)
 void OffsetAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
 {
   try {
-    // Check if we are setting the uid adjustment
+    // Check if we are setting the offset adjustment
     if (config.has_param(OFFSET_ADJUSTMENT_CONFIG)) {
-      configured_offset_adjustment_ = (int64_t) config.get_param<int64_t>(OFFSET_ADJUSTMENT_CONFIG);
-      LOG4CXX_INFO(logger_, "Setting offset adjustment to " << configured_offset_adjustment_);
-    }
-
-    // Check if we are setting the first frame number
-    if (config.has_param(FIRST_FRAME_OFFSET_CONFIG)) {
-      first_frame_number_ = (uint64_t) config.get_param<uint64_t>(FIRST_FRAME_OFFSET_CONFIG);
-      LOG4CXX_INFO(logger_, "Setting first frame number to " << first_frame_number_);
+      offset_adjustment_ = (int64_t) config.get_param<int64_t>(OFFSET_ADJUSTMENT_CONFIG);
+      LOG4CXX_INFO(logger_, "Setting offset adjustment to " << offset_adjustment_);
     }
   }
   catch (std::runtime_error& e)
@@ -92,8 +78,7 @@ void OffsetAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::I
  */
 void OffsetAdjustmentPlugin::requestConfiguration(OdinData::IpcMessage& reply)
 {
-  reply.set_param(get_name() + "/" + FIRST_FRAME_OFFSET_CONFIG, first_frame_number_);
-  reply.set_param(get_name() + "/" + OFFSET_ADJUSTMENT_CONFIG, configured_offset_adjustment_);
+  reply.set_param(get_name() + "/" + OFFSET_ADJUSTMENT_CONFIG, offset_adjustment_);
 }
 
 int OffsetAdjustmentPlugin::get_version_major()

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -782,14 +782,7 @@ BOOST_AUTO_TEST_CASE( AdjustOffset )
   cfg.set_param(FrameProcessor::OFFSET_ADJUSTMENT_CONFIG, 4);
   plugin.configure(cfg, reply);
 
-  // Check the offset is not applied as not seen first frame since configuring
-  offset = 28;
-  frame->set_frame_number(offset);
-  frame->meta_data().set_frame_offset(offset);
-  plugin.process_frame(frame);
-  BOOST_CHECK_EQUAL(28, frame->get_meta_data().get_frame_offset());
-
-  // Check the offset is applied when a new first frame is now sent
+  // Check the offset is applied when a new frame is now sent
   offset = 0;
   frame->set_frame_number(offset);
   frame->meta_data().set_frame_offset(offset);
@@ -803,45 +796,12 @@ BOOST_AUTO_TEST_CASE( AdjustOffset )
   plugin.process_frame(frame);
   BOOST_CHECK_EQUAL(14, frame->get_meta_data().get_frame_offset());
 
-  // Check the offset is still applied when uid is different to frame number
+  // Check the offset is still applied when offset is different to frame number
   offset = 100;
   frame->set_frame_number(27);
   frame->meta_data().set_frame_offset(offset);
   plugin.process_frame(frame);
   BOOST_CHECK_EQUAL(104, frame->get_meta_data().get_frame_offset());
-
-  // Configure a start frame of 1
-  cfg.set_param(FrameProcessor::OFFSET_ADJUSTMENT_CONFIG, 33);
-  cfg.set_param(FrameProcessor::FIRST_FRAME_OFFSET_CONFIG, 1);
-  plugin.configure(cfg, reply);
-
-  // Check the new offset is not applied when not on frame 0
-  offset = 12;
-  frame->set_frame_number(offset);
-  frame->meta_data().set_frame_offset(offset);
-  plugin.process_frame(frame);
-  BOOST_CHECK_EQUAL(16, frame->get_meta_data().get_frame_offset());
-
-  // Check the new offset is not applied when on frame 0
-  offset = 0;
-  frame->set_frame_number(offset);
-  frame->meta_data().set_frame_offset(offset);
-  plugin.process_frame(frame);
-  BOOST_CHECK_EQUAL(4, frame->get_meta_data().get_frame_offset());
-
-  // Check the new offset is applied when on frame 1
-  offset = 1;
-  frame->set_frame_number(offset);
-  frame->meta_data().set_frame_offset(offset);
-  plugin.process_frame(frame);
-  BOOST_CHECK_EQUAL(34, frame->get_meta_data().get_frame_offset());
-
-  // Check the new offset is applied when on frame 2
-  offset = 2;
-  frame->set_frame_number(offset);
-  frame->meta_data().set_frame_offset(offset);
-  plugin.process_frame(frame);
-  BOOST_CHECK_EQUAL(35, frame->get_meta_data().get_frame_offset());
 }
 
 BOOST_AUTO_TEST_SUITE_END(); //UIDAdjustmentPluginUnitTest


### PR DESCRIPTION
Gets rid of the 'first frame to apply offset from' configuration, so
that any configured offset will apply as soon as it has been configured