### PR TITLE
Added performance stats to the FP plugins for monitoring and debug.

### DIFF
--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -40,6 +40,8 @@ public:
   virtual void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   virtual void requestConfiguration(OdinData::IpcMessage& reply);
   virtual void status(OdinData::IpcMessage& status);
+  void add_performance_stats(OdinData::IpcMessage& status);
+  void reset_performance_stats();
   void version(OdinData::IpcMessage& status);
   void register_callback(const std::string& name, boost::shared_ptr<IFrameCallback> cb, bool blocking=false);
   void remove_callback(const std::string& name);
@@ -53,6 +55,8 @@ private:
   LoggerPtr logger_;
 
   void callback(boost::shared_ptr<Frame> frame);
+
+  unsigned int elapsed_ms(struct timespec& start, struct timespec& end);
 
   /**
    * This is called by the callback method when any new frames have
@@ -70,6 +74,12 @@ private:
   std::map<std::string, boost::shared_ptr<IFrameCallback> > blocking_callbacks_;
   /** Error message array*/
   std::vector<std::string> error_messages_;
+  /** Last process time */
+  uint64_t last_process_time_;
+  /** Maximum process time since last reset */
+  uint64_t max_process_time_;
+  /** Exp average process time since last reset */
+  double average_process_time_; 
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -56,7 +56,7 @@ private:
 
   void callback(boost::shared_ptr<Frame> frame);
 
-  unsigned int elapsed_ms(struct timespec& start, struct timespec& end);
+  unsigned int elapsed_us(struct timespec& start, struct timespec& end);
 
   /**
    * This is called by the callback method when any new frames have

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -284,7 +284,10 @@ void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply)
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> >::iterator iter;
   for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
     reply.set_param("plugins/names[]", iter->first);
+    // Request status for the plugin
     iter->second->status(reply);
+    // Add performance statistics
+    iter->second->add_performance_stats(reply);
     // Read error level
     std::vector<std::string> plugin_errors = iter->second->get_errors();
     error_messages.insert(error_messages.end(), plugin_errors.begin(), plugin_errors.end());
@@ -502,6 +505,7 @@ void FrameProcessorController::resetStatistics(OdinData::IpcMessage& reply)
   // Loop over plugins and call reset statistics on each
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> >::iterator iter;
   for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
+    iter->second->reset_performance_stats();
     reset_ok = iter->second->reset_statistics();
     // Check for failure
     if (!reset_ok){

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -293,7 +293,7 @@ void FrameProcessorPlugin::callback(boost::shared_ptr<Frame> frame)
   gettime(&start_time);
   this->process_frame(frame);
   gettime(&end_time);
-  uint64_t ts = elapsed_ms(start_time, end_time);
+  uint64_t ts = elapsed_us(start_time, end_time);
   // Store the raw process time
   last_process_time_ = ts;
   // Store the maximum process time since the last reset
@@ -328,22 +328,22 @@ void FrameProcessorPlugin::push(boost::shared_ptr<Frame> frame)
   }
 }
 
-/** Calculate and return an elapsed time in milliseconds.
+/** Calculate and return an elapsed time in microseconds.
  * 
- * This method calculates and returns an elapsed time in milliseconds based on the start and
+ * This method calculates and returns an elapsed time in microseconds based on the start and
  * end timespec structs passed as arguments.
  * 
  * \param[in] start - start time in timespec struct format
  * \param[in] end - end time in timespec struct format
- * \return elapsed time between start and end in milliseconds
+ * \return elapsed time between start and end in microseconds
  */
-unsigned int FrameProcessorPlugin::elapsed_ms(struct timespec& start, struct timespec& end)
+unsigned int FrameProcessorPlugin::elapsed_us(struct timespec& start, struct timespec& end)
 {
 
   double start_ns = ((double) start.tv_sec * 1000000000) + start.tv_nsec;
   double end_ns = ((double) end.tv_sec * 1000000000) + end.tv_nsec;
 
-  return (unsigned int)((end_ns - start_ns) / 1000000);
+  return (unsigned int)((end_ns - start_ns) / 1000);
 }
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -8,6 +8,7 @@
 #include "logging.h"
 #include "FrameProcessorPlugin.h"
 #include "DebugLevelLogger.h"
+#include "gettime.h"
 
 namespace FrameProcessor
 {
@@ -16,7 +17,10 @@ namespace FrameProcessor
  * Constructor, initialises name_ and meta data channel.
  */
 FrameProcessorPlugin::FrameProcessorPlugin() :
-    name_("")
+  name_(""),
+  last_process_time_(0),
+  max_process_time_(0),
+  average_process_time_(0.0)
 {
   OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   logger_ = log4cxx::Logger::getLogger("FP.FrameProcessorPlugin");
@@ -141,6 +145,32 @@ void FrameProcessorPlugin::status(OdinData::IpcMessage& status)
 }
 
 /**
+ * Collate performance statistics for the plugin.
+ *
+ * The performance metrics are added to the status IpcMessage object.
+ *
+ * \param[out] status - Reference to an IpcMessage value to store the performance stats.
+ */
+void FrameProcessorPlugin::add_performance_stats(OdinData::IpcMessage& status)
+{
+  status.set_param(get_name() + "/timing/last_process", last_process_time_);
+  status.set_param(get_name() + "/timing/max_process", max_process_time_);
+  status.set_param(get_name() + "/timing/mean_process", average_process_time_);
+}
+
+/**
+ * Reset performance statistics for the plugin.
+ *
+ * The performance metrics are reset to zero.
+ */
+void FrameProcessorPlugin::reset_performance_stats()
+{
+  last_process_time_ = 0;
+  max_process_time_ = 0;
+  average_process_time_ = 0.0;
+}
+
+/**
  * Collate version information for the plugin.
  *
  * The version information is added to the status IpcMessage object.
@@ -257,8 +287,21 @@ void FrameProcessorPlugin::remove_all_callbacks()
  */
 void FrameProcessorPlugin::callback(boost::shared_ptr<Frame> frame)
 {
-  // Calls process frame
+  // Calls process frame and times how long the process takes
+  struct timespec start_time;
+  struct timespec end_time;
+  gettime(&start_time);
   this->process_frame(frame);
+  gettime(&end_time);
+  uint64_t ts = elapsed_ms(start_time, end_time);
+  // Store the raw process time
+  last_process_time_ = ts;
+  // Store the maximum process time since the last reset
+  if (ts > max_process_time_){
+    max_process_time_ = ts;
+  }
+  // Store a simple exp average with alpha = 0.5
+  average_process_time_ = (average_process_time_ * 0.5) + (double(ts) * 0.5);
 }
 
 /** Push the supplied frame to any registered callbacks.
@@ -283,6 +326,24 @@ void FrameProcessorPlugin::push(boost::shared_ptr<Frame> frame)
   for (cbIter = callbacks_.begin(); cbIter != callbacks_.end(); ++cbIter) {
     cbIter->second->getWorkQueue()->add(frame);
   }
+}
+
+/** Calculate and return an elapsed time in milliseconds.
+ * 
+ * This method calculates and returns an elapsed time in milliseconds based on the start and
+ * end timespec structs passed as arguments.
+ * 
+ * \param[in] start - start time in timespec struct format
+ * \param[in] end - end time in timespec struct format
+ * \return elapsed time between start and end in milliseconds
+ */
+unsigned int FrameProcessorPlugin::elapsed_ms(struct timespec& start, struct timespec& end)
+{
+
+  double start_ns = ((double) start.tv_sec * 1000000000) + start.tv_nsec;
+  double end_ns = ((double) end.tv_sec * 1000000000) + end.tv_nsec;
+
+  return (unsigned int)((end_ns - start_ns) / 1000000);
 }
 
 } /* namespace FrameProcessor */


### PR DESCRIPTION
This is all handled in the plugin base class and so no changes required on specific plugins.
Each plugin reports the following additional status eg

`{
  'timing': {
    'mean_process': 5.0,
    'last_process': 5,
    'max_process': 9
  }
}`

I'm open to name changes for the status items.  Calling reset on the FP will now also reset these statistics.