### PR TITLE
Fix remove_when_deleted regression in frameReceiver shared buffer manager

### DIFF
--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -615,6 +615,12 @@ void FrameReceiverController::configure_buffer_manager(OdinData::IpcMessage& con
       // receiving frames
       frame_decoder_->drop_all_buffers();
 
+      // If an there is already an existing shared buffer manager, delete it first to ensure
+      // cleanup of shared memory segment occurs before creation of new manager.
+      if (buffer_manager_) {
+        buffer_manager_.reset();
+      }
+
       // Create a new shared buffer manager
       buffer_manager_.reset(new SharedBufferManager(
           shared_buffer_name, max_buffer_mem,frame_decoder_->get_frame_buffer_size(), true)


### PR DESCRIPTION
This address #205, which is a regression introduced by PR #196, where the behaviour of the frameReceiver was changed to set the `remote_when_deleted` flag on SharedBufferManager instances. This created a condition in the FR where reconfiguration with the same name for the shared memory segment would cause the segment file (in `/dev/shm`) to be deleted on reconfiguration, since resetting the shared pointer on the buffer manager causes the new constructor to run before the old instance is deleted.

This PR modifies the behaviour of the `FrameReceiverController::configure_buffer_manager()` method to explicitly delete the old manager by resetting the shared pointer first before creating a new instance.