### PR TITLE
Kafka config

### DIFF
--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -25,12 +25,14 @@ using namespace log4cxx::helpers;
 #define KAFKA_DEFAULT_DATASET "data"
 #define KAFKA_DEFAULT_TOPIC "data"
 #define KAFKA_DEFAULT_RETRIES "1000"
-#define KAFKA_DEFAULT_BACKOFF "100"
+#define KAFKA_DEFAULT_BACKOFF "500"
 #define KAFKA_DEFAULT_MAX_TIME "300000"
-#define KAFKA_DEFAULT_MAX_Q "2097151"
+#define KAFKA_DEFAULT_MAX_Q_MSGS "200"
+#define KAFKA_DEFAULT_MAX_Q_SIZE "2097151"
+#define KAFKA_DEFAULT_BATCH_MSGS "1"
 #define KAFKA_DEFAULT_ACKS "all"
 #define KAFKA_DEFAULT_MAX_BYTES "134217728"
-#define KAFKA_DEFAULT_MAX_Q_BUFFER_TIME "5"
+#define KAFKA_DEFAULT_MAX_Q_BUFFER_TIME "0"
 #define MSG_HEADER_FRAME_SIZE_KEY "data_size"
 #define MSG_HEADER_DATA_TYPE_KEY "data_type"
 #define MSG_HEADER_FRAME_NUMBER_KEY "frame_number"
@@ -55,19 +57,21 @@ namespace FrameProcessor {
    *  topic: Topic name of the queue to send the message to. Defaults to "data".
    *  partition: Partition number. Defaults to RD_KAFKA_PARTITION_UA (automatic partitioning)
    *  max_retries: How many times to retry sending a failing Message. Defaults to 1000.
-   *  retry_backoff: The backoff time in ms before retrying a protocol request. Defaults to 100 ms.
+   *  retry_backoff: The backoff time in ms before retrying a protocol request. Defaults to 500 ms.
    *  retry_max_time: Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. 
    *                  A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). 
    *                  Delivery error occurs when either the retry count or the message timeout are exceeded. Defaults to 300000 ms.
+   *  max_q_msgs: Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions. Defaults to 200.
    *  max_q_size: Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. 
    *              This property has higher priority than queue.buffering.max.messages. Defaults to 2097151 kB (maximum possible).
+   *  batch_msgs: Maximum number of messages batched in one MessageSet. Defaults to 1.
    *  acks: This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: 
    *        *0*=Broker does not send any response/ack to client, *-1* or *all*=Broker will block until message is committed by all in sync replicas
    *        (ISRs). If there are less than `min.insync.replicas` (broker configuration) in the ISR set the produce request will fail. Defaults to
    *        *all*.
    *  max_msg_bytes: Maximum Kafka protocol request message size. Defaults to 134217728 B.
    *  max_q_buffer_time: Delay in ms to wait for messages in the producer queue to accumulate before constructing message batches to transmit to brokers.
-   *                     Defaults to 5 ms.
+   *                     Defaults to 0 ms.
    *  include_parameters: Boolean indicating if frame parameters should be included in the message.
    *                      Defaults to true.
    *
@@ -145,8 +149,12 @@ namespace FrameProcessor {
     std::string retry_backoff_;
     /** Max time to produce message (inc retries) */
     std::string retry_max_time_;
+    /** Max producer queue msgs */
+    std::string max_q_msgs_;
     /** Max producer queue size */
     std::string max_q_size_;
+    /** Max producer batch msgs */
+    std::string batch_msgs_;
     /** Kafka acknowledgments */
     std::string acks_;
     /** Kafka max message bytes */
@@ -189,8 +197,12 @@ namespace FrameProcessor {
     static const std::string CONFIG_KAFKA_RETRY_BACKOFF;
     /** Configuration constant for kafka max time for producing message (inc retries). 0 is infinite */
     static const std::string CONFIG_KAFKA_MAX_RETRY_TIME;
+    /** Configuration constant for kafka max producer queue number of messages */
+    static const std::string CONFIG_KAFKA_MAX_Q_MSGS;
     /** Configuration constant for kafka max producer queue size (max is 2097151 kB) */
     static const std::string CONFIG_KAFKA_MAX_Q_SIZE;
+    /** Configuration constant for kafka max producer batch number of messages*/
+    static const std::string CONFIG_KAFKA_BATCH_MSGS;
     /** Configuration constant for kafka acknowledgments */
     static const std::string CONFIG_KAFKA_ACKS;
     /** Configuration constant for kafka max msg size */

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -26,6 +26,8 @@ using namespace log4cxx::helpers;
 #define KAFKA_DEFAULT_TOPIC   "data"
 #define KAFKA_POLLING_MS 5000
 #define KAFKA_MESSAGE_MAX_BYTES "134217728"
+#define KAFKA_MESSAGE_MAX_RETRIES "10000000"
+#define KAFKA_QUEUE_SIZE "2097151"
 #define MSG_HEADER_FRAME_SIZE_KEY "data_size"
 #define MSG_HEADER_DATA_TYPE_KEY "data_type"
 #define MSG_HEADER_FRAME_NUMBER_KEY "frame_number"

--- a/frameProcessor/include/KafkaProducerPlugin.h
+++ b/frameProcessor/include/KafkaProducerPlugin.h
@@ -23,11 +23,14 @@ using namespace log4cxx::helpers;
 #define KAFKA_MAX_MSG_LEN 512
 #define KAFKA_LINGER_MS 1000
 #define KAFKA_DEFAULT_DATASET "data"
-#define KAFKA_DEFAULT_TOPIC   "data"
-#define KAFKA_POLLING_MS 5000
-#define KAFKA_MESSAGE_MAX_BYTES "134217728"
-#define KAFKA_MESSAGE_MAX_RETRIES "10000000"
-#define KAFKA_QUEUE_SIZE "2097151"
+#define KAFKA_DEFAULT_TOPIC "data"
+#define KAFKA_DEFAULT_RETRIES "1000"
+#define KAFKA_DEFAULT_BACKOFF "100"
+#define KAFKA_DEFAULT_MAX_TIME "300000"
+#define KAFKA_DEFAULT_MAX_Q "2097151"
+#define KAFKA_DEFAULT_ACKS "all"
+#define KAFKA_DEFAULT_MAX_BYTES "134217728"
+#define KAFKA_DEFAULT_MAX_Q_BUFFER_TIME "5"
 #define MSG_HEADER_FRAME_SIZE_KEY "data_size"
 #define MSG_HEADER_DATA_TYPE_KEY "data_type"
 #define MSG_HEADER_FRAME_NUMBER_KEY "frame_number"
@@ -51,6 +54,20 @@ namespace FrameProcessor {
    *  dataset: Dataset name of frame that will be delivered. Defaults to "data".
    *  topic: Topic name of the queue to send the message to. Defaults to "data".
    *  partition: Partition number. Defaults to RD_KAFKA_PARTITION_UA (automatic partitioning)
+   *  max_retries: How many times to retry sending a failing Message. Defaults to 1000.
+   *  retry_backoff: The backoff time in ms before retrying a protocol request. Defaults to 100 ms.
+   *  retry_max_time: Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. 
+   *                  A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). 
+   *                  Delivery error occurs when either the retry count or the message timeout are exceeded. Defaults to 300000 ms.
+   *  max_q_size: Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. 
+   *              This property has higher priority than queue.buffering.max.messages. Defaults to 2097151 kB (maximum possible).
+   *  acks: This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: 
+   *        *0*=Broker does not send any response/ack to client, *-1* or *all*=Broker will block until message is committed by all in sync replicas
+   *        (ISRs). If there are less than `min.insync.replicas` (broker configuration) in the ISR set the produce request will fail. Defaults to
+   *        *all*.
+   *  max_msg_bytes: Maximum Kafka protocol request message size. Defaults to 134217728 B.
+   *  max_q_buffer_time: Delay in ms to wait for messages in the producer queue to accumulate before constructing message batches to transmit to brokers.
+   *                     Defaults to 5 ms.
    *  include_parameters: Boolean indicating if frame parameters should be included in the message.
    *                      Defaults to true.
    *
@@ -92,6 +109,8 @@ namespace FrameProcessor {
 
     void configure_partition(int32_t partition);
 
+    void set_property(rd_kafka_conf_t *, const char *, const char *, char *);
+
     void configure_dataset(std::string dataset);
 
     void *create_message(boost::shared_ptr<Frame> frame,
@@ -120,6 +139,20 @@ namespace FrameProcessor {
     std::string servers_;
     /** Partition number */
     int32_t partition_;
+    /** Maximum number of produce retries for kafka */
+    std::string max_retries_;
+    /** Time to wait between retries */
+    std::string retry_backoff_;
+    /** Max time to produce message (inc retries) */
+    std::string retry_max_time_;
+    /** Max producer queue size */
+    std::string max_q_size_;
+    /** Kafka acknowledgments */
+    std::string acks_;
+    /** Kafka max message bytes */
+    std::string max_msg_bytes_;
+    /** Kafka max queue buffer time (ms) */
+    std::string max_q_buffer_time_;
     /** Pointer to a Kafka producer handler */
     rd_kafka_t *kafka_producer_;
     /** Pointer to a Kafka topic handler */
@@ -150,6 +183,20 @@ namespace FrameProcessor {
     static const std::string CONFIG_DATASET;
     /** Configuration constant for include_parameters */
     static const std::string CONFIG_INCLUDE_PARAMETERS;
+    /** Configuration constant for kafka max retries */
+    static const std::string CONFIG_KAFKA_RETRIES;
+    /** Configuration constant for kafka time between retries */
+    static const std::string CONFIG_KAFKA_RETRY_BACKOFF;
+    /** Configuration constant for kafka max time for producing message (inc retries). 0 is infinite */
+    static const std::string CONFIG_KAFKA_MAX_RETRY_TIME;
+    /** Configuration constant for kafka max producer queue size (max is 2097151 kB) */
+    static const std::string CONFIG_KAFKA_MAX_Q_SIZE;
+    /** Configuration constant for kafka acknowledgments */
+    static const std::string CONFIG_KAFKA_ACKS;
+    /** Configuration constant for kafka max msg size */
+    static const std::string CONFIG_KAFKA_MAX_MSQ_BYTES;
+    /** Configuration constant for kafka max queue buffer time (ms)*/
+    static const std::string CONFIG_KAFKA_MAX_Q_BUFFER_TIME;
 
   };
 

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -194,6 +194,19 @@ namespace FrameProcessor {
     kafka_config = rd_kafka_conf_new();
     int status;
 
+
+    status = rd_kafka_conf_set(kafka_config,
+                               "message.send.max.retries",
+                               KAFKA_MESSAGE_MAX_RETRIES,
+                               errBuf,
+                               sizeof(errBuf));
+
+    if (status != RD_KAFKA_CONF_OK) {
+      LOG4CXX_ERROR(logger_, "Kafka configuration error while setting max retries: "
+        << errBuf);
+      return;
+    }
+
     status = rd_kafka_conf_set(kafka_config,
                                "message.max.bytes",
                                KAFKA_MESSAGE_MAX_BYTES,
@@ -208,7 +221,7 @@ namespace FrameProcessor {
 
     status = rd_kafka_conf_set(kafka_config,
                                "queue.buffering.max.kbytes",
-                               "2097151",
+                               KAFKA_QUEUE_SIZE,
                                errBuf,
                                sizeof(errBuf));
 

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -99,15 +99,6 @@ namespace FrameProcessor {
                                       OdinData::IpcMessage &reply)
   {
     boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    if (config.has_param(CONFIG_SERVERS)) {
-      destroy_kafka();
-      configure_kafka_servers(config.get_param<std::string>(CONFIG_SERVERS));
-      configure_kafka_topic(this->topic_name_);
-    }
-
-    if (config.has_param(CONFIG_TOPIC)) {
-      configure_kafka_topic(config.get_param<std::string>(CONFIG_TOPIC));
-    }
 
     if (config.has_param(CONFIG_PARTITION)) {
       configure_partition(config.get_param<uint32_t>(CONFIG_PARTITION));
@@ -147,6 +138,17 @@ namespace FrameProcessor {
 
     if (config.has_param(CONFIG_KAFKA_MAX_Q_BUFFER_TIME)) {
       this->max_q_buffer_time_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_Q_BUFFER_TIME);
+    }
+
+    bool need_configure_topic = false;
+    if (config.has_param(CONFIG_SERVERS)) {
+      destroy_kafka();
+      configure_kafka_servers(config.get_param<std::string>(CONFIG_SERVERS));
+      need_configure_topic = true;
+    }
+
+    if (config.has_param(CONFIG_TOPIC) || need_configure_topic) {
+      configure_kafka_topic(config.get_param<std::string>(CONFIG_TOPIC));
     }
 
   }

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -116,50 +116,60 @@ namespace FrameProcessor {
       this->include_parameters_ = config.get_param<bool>(CONFIG_INCLUDE_PARAMETERS);
     }
 
+    //servers must be reconfigured if any of the following kafka parameters are changed
+    bool need_configure_servers = false;
+
     if (config.has_param(CONFIG_KAFKA_RETRIES)) {
       this->max_retries_ = config.get_param<std::string>(CONFIG_KAFKA_RETRIES);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_RETRY_BACKOFF)) {
       this->retry_backoff_ = config.get_param<std::string>(CONFIG_KAFKA_RETRY_BACKOFF);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_MAX_RETRY_TIME)) {
       this->retry_max_time_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_RETRY_TIME);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_MAX_Q_MSGS)) {
       this->max_q_msgs_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_Q_MSGS);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_MAX_Q_SIZE)) {
       this->max_q_size_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_Q_SIZE);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_BATCH_MSGS)) {
       this->batch_msgs_ = config.get_param<std::string>(CONFIG_KAFKA_BATCH_MSGS);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_ACKS)) {
       this->acks_ = config.get_param<std::string>(CONFIG_KAFKA_ACKS);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_MAX_MSQ_BYTES)) {
       this->max_msg_bytes_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_MSQ_BYTES);
+      need_configure_servers = true;
     }
 
     if (config.has_param(CONFIG_KAFKA_MAX_Q_BUFFER_TIME)) {
       this->max_q_buffer_time_ = config.get_param<std::string>(CONFIG_KAFKA_MAX_Q_BUFFER_TIME);
+      need_configure_servers = true;
     }
 
-    bool need_configure_topic = false;
-    if (config.has_param(CONFIG_SERVERS)) {
+    if (config.has_param(CONFIG_SERVERS) || need_configure_servers) {
       destroy_kafka();
       configure_kafka_servers(config.get_param<std::string>(CONFIG_SERVERS));
-      need_configure_topic = true;
     }
 
-    if (config.has_param(CONFIG_TOPIC) || need_configure_topic) {
+    if (config.has_param(CONFIG_TOPIC) || need_configure_servers) {
       configure_kafka_topic(config.get_param<std::string>(CONFIG_TOPIC));
     }
 

--- a/frameProcessor/src/KafkaProducerPlugin.cpp
+++ b/frameProcessor/src/KafkaProducerPlugin.cpp
@@ -463,7 +463,7 @@ namespace FrameProcessor {
     }
 
     size_t message_size = sizeof(uint16_t) + string_buffer.GetSize() + 1
-      + frame->get_data_size();
+      + frame->get_image_size();
     char *msg = (char *) malloc(message_size);
     uint16_t header_size = static_cast<uint16_t>(string_buffer.GetSize() + 1);
 
@@ -472,8 +472,8 @@ namespace FrameProcessor {
     memcpy(msg + sizeof(uint16_t), string_buffer.GetString(),
            header_size);
     // copy frame data
-    memcpy(msg + sizeof(uint16_t) + header_size, frame->get_data_ptr(),
-           frame->get_data_size());
+    memcpy(msg + sizeof(uint16_t) + header_size, frame->get_image_ptr(),
+           frame->get_image_size());
     nbytes = message_size;
     return msg;
   }


### PR DESCRIPTION
Updated the kafka producer configuration:

* Allow frames to build up in the odin buffer when the internal kafka producer queue is full rather than dropping the frame.

* Allow selection of kafka parameters with an effect on throughput to be configurable. Default parameters achieve the highest throughput observed in testing. Parameters control:
    * The kafka producer queue : default max 200 messages or 2.1 GB, whichever reached first
    * Message batching : no message batching by default
    * Message acknowledgement : full acknowledgement by default

* Allocate memory the size of the compressed image rather than full data size