### PR TITLE
Update to use static dimensions for HDF5 datasets when frame count given

### DIFF
--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -43,6 +43,9 @@ public:
     std::vector<hsize_t> dataset_dimensions;
     /** Array of offsets of the dataset **/
     std::vector<hsize_t> dataset_offsets;
+    /** Extent of the (outermost dimension of the) dataset that has had frames written to, including any gaps
+     * i.e. the highest offset that has been written to + 1 */
+    size_t actual_dataset_size_;
   };
 
 
@@ -58,10 +61,11 @@ public:
   void create_dataset(const DatasetDefinition& definition, int low_index, int high_index);
   void write_frame(const Frame& frame, hsize_t frame_offset, uint64_t outer_chunk_dimension);
   void write_parameter(const Frame& frame, DatasetDefinition dataset_definition, hsize_t frame_offset);
-  size_t get_dataset_frames(const std::string dset_name);
+  size_t get_dataset_frames(const std::string& dset_name);
   void start_swmr();
   size_t get_file_index();
   std::string get_filename();
+  void set_unlimited();
 
 private:
 
@@ -75,7 +79,7 @@ private:
   /** Flush rate for parameter datasets in miliseconds */
   static const int PARAM_FLUSH_RATE = 1000;
 
-  HDF5Dataset_t& get_hdf5_dataset(const std::string dset_name);
+  HDF5Dataset_t& get_hdf5_dataset(const std::string& dset_name);
   void extend_dataset(HDF5File::HDF5Dataset_t& dset, size_t frame_no) const;
   hid_t datatype_to_hdf_type(DataType data_type) const;
 
@@ -94,6 +98,8 @@ private:
   std::string filename_;
   /** Whether to use the earliest version of the hdf5 library */
   bool use_earliest_version_;
+  /** Whether datasets use H5S_UNLIMITED as the outermost dimension extent */
+  bool unlimited_;
   /** Mutex used to make this class thread safe */
   boost::recursive_mutex mutex_;
   /* Parameters memspace */

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -168,11 +168,9 @@ public:
                                 9,10,11,12 };
     dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
     dimensions_t chunk_dims(3); chunk_dims[0] = 1; chunk_dims[1] = 3; chunk_dims[2] = 4;
-    //PercivalEmulator::FrameHeader img_header;
-    //img_header.frame_number = 7;
 
     dset_def.name = "data";
-    dset_def.num_frames = 2; //unused?
+    dset_def.num_frames = 10;
     dset_def.data_type = FrameProcessor::raw_16bit;
     dset_def.frame_dimensions = dimensions_t(2);
     dset_def.frame_dimensions[0] = 3;
@@ -319,6 +317,8 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
 BOOST_AUTO_TEST_CASE( HDF5FileAdjustHugeOffset )
 {
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_huge_offset.h5", 0, false, 1, 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.set_unlimited());
+  BOOST_REQUIRE_NO_THROW(dset_def.num_frames = 0);
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   hsize_t huge_offset = 100000;


### PR DESCRIPTION
This is to solve a problem with VDS datasets mapping to OdinData HDF5 files. If the underlying files are H5S_UNLIMITED in extent, the VDS mappings exhibit strange behaviour, or can't even be opened, via SWMR. The file has to be closed before the data can be processed. With this change, when datasets are created with a non-zero frame count, the exact size will be used for the dataset size. If frame count is set to 0, it will use the old behavior and the file will have to be manually closed when the client knows the acquisition has ended.