### PR TITLE
HDF5 Error Logging

### DIFF
--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -51,11 +51,9 @@ public:
 
   HDF5File();
   ~HDF5File();
-  void hdf_error_handler(unsigned n, const H5E_error2_t *err_desc);
-  bool check_for_hdf_errors();
-  std::vector<std::string> read_hdf_errors();
+  void hdf_error_handler(unsigned n, const H5E_error2_t* err_desc);
   void clear_hdf_errors();
-  void handle_h5_error(std::string message, std::string function, std::string filename, int line) const;
+  void handle_h5_error(const std::string& message, const std::string& function, const std::string& filename, int line);
   void create_file(std::string file_name, size_t file_index, bool use_earliest_version, size_t alignment_threshold, size_t alignment_value);
   void close_file();
   void create_dataset(const DatasetDefinition& definition, int low_index, int high_index);
@@ -80,7 +78,7 @@ private:
   static const int PARAM_FLUSH_RATE = 1000;
 
   HDF5Dataset_t& get_hdf5_dataset(const std::string& dset_name);
-  void extend_dataset(HDF5File::HDF5Dataset_t& dset, size_t frame_no) const;
+  void extend_dataset(HDF5File::HDF5Dataset_t& dset, size_t frame_no);
   hid_t datatype_to_hdf_type(DataType data_type) const;
 
   LoggerPtr logger_;
@@ -89,7 +87,7 @@ private:
   /** Internal HDF5 error flag */
   bool hdf5_error_flag_;
   /** Internal HDF5 error recording */
-  std::vector<std::string> hdf5_errors_;
+  std::vector<H5E_error2_t> hdf5_errors_;
   /** Map of datasets that are being written to */
   std::map<std::string, HDF5Dataset_t> hdf5_datasets_;
   /** The index of this file across all processors in the acquisition, 0 indexed */


### PR DESCRIPTION
This completes the implementation of capturing the HDF5 stack trace when an error occurs to log via Log4CXX. Here is a snippet of the console output:

```
/dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/HDF5File.cpp:443:
 09:52:31,347 FP.HDF5File    INFO  - Creating dataset: sum
/dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/HDF5File.cpp:87:
 09:52:31,347 FP.HDF5File    ERROR - HDF5 Function Error: (H5Dcreate2 failed) in /dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/HDF5File.cpp:446: void FrameProcessor::HDF5File::create_dataset(const FrameProcessor::DatasetDefinition&, int, int)
 HDF5 Stack Trace:
  [0]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5D.c:145 in H5Dcreate2: "unable to create dataset"
  [1]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Dint.c:326 in H5D__create_named: "unable to create and link to dataset"
  [2]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5L.c:1572 in H5L_link_object: "unable to create new link to object"
  [3]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5L.c:1813 in H5L__create_real: "can't insert link"
  [4]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Gtraverse.c:851 in H5G_traverse: "internal path traversal failed"
  [5]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Gtraverse.c:627 in H5G__traverse_real: "traversal operator failed"
  [6]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5L.c:1619 in H5L__link_cb: "unable to create object"
  [7]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Oint.c:2645 in H5O_obj_create: "unable to open object"
  [8]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Doh.c:300 in H5O__dset_create: "unable to create dataset"
  [9]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Dint.c:1095 in H5D__create: "unable to construct layout information"
  [10]: /dls_sw/prod/tools/RHEL7-x86_64/hdf5/1-10-4/src/hdf5-1.10.4/src/H5Dchunk.c:870 in H5D__chunk_construct: "chunk size must be <= maximum dimension size for fixed-sized dimensions"
/dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/FrameProcessorPlugin.cpp:77:
 09:52:31,347 FP.FrameProcessorPlugin ERROR - HDF5 Function Error: (H5Dcreate2 failed) in /dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/HDF5File.cpp:446: void FrameProcessor::HDF5File::create_dataset(const FrameProcessor::DatasetDefinition&, int, int)
/dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/FrameProcessorController.cpp:178:
 09:52:31,347 FP.FrameProcessorController ERROR - Bad control message: HDF5 Function Error: (H5Dcreate2 failed) in /dls_sw/work/tools/RHEL7-x86_64/odin-data/frameProcessor/src/HDF5File.cpp:446: void FrameProcessor::HDF5File::create_dataset(const FrameProcessor::DatasetDefinition&, int, int)
```