### PR TITLE
Fix missing ZeroMQ include path in integration test application

### DIFF
--- a/test/integrationTest/src/CMakeLists.txt
+++ b/test/integrationTest/src/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${TEST_DIR}/integrationTest/include
 		${TEST_INCLUDE_DIRS}
 		${HDF5_INCLUDE_DIRS}
 		${Boost_INCLUDE_DIRS}
+		${ZEROMQ_INCLUDE_DIRS}
 		${LOG4CXX_INCLUDE_DIRS}/..)
 
 add_definitions(${HDF5_DEFINITIONS})


### PR DESCRIPTION
This PR fixes a build problem introduced by #215 where the ZeroMQ include path is not set appropriately for the integration test application.