### PR TITLE
Perform checks of dropped frames or low buffers

### DIFF
--- a/tools/python/odin_data/frame_processor_adapter.py
+++ b/tools/python/odin_data/frame_processor_adapter.py
@@ -16,7 +16,6 @@ from tornado.ioloop import IOLoop
 FP_ADAPTER_KEY = 'fr_adapter_name'
 FP_DEFAULT_ADAPTER_KEY = 'fr'
 PCT_BUFFER_FREE_KEY = 'buffer_threshold'
-DEFAULT_PCT_BUFFER_FREE = 5.0
 
 def bool_from_string(value):
     bool_value = False
@@ -49,12 +48,13 @@ class FrameProcessorAdapter(OdinDataAdapter):
 
         self._fr_adapter = None
 
-        self._fr_pct_buffer_threshold = DEFAULT_PCT_BUFFER_FREE
-        if PCT_BUFFER_FREE_KEY in kwargs:
-            try:
-                self._fr_pct_buffer_threshold = float(kwargs[PCT_BUFFER_FREE_KEY])
-            except:
-                logging.error("Could not set the buffer threshold to: {}".format(kwargs[PCT_BUFFER_FREE_KEY]))
+        # Set the bufer threshold check, default to 0.0 (no check) if the option
+        # does not exist or is badly formatted
+        self._fr_pct_buffer_threshold = 0.0
+        try:
+            self._fr_pct_buffer_threshold = float(self.options.get(PCT_BUFFER_FREE_KEY, 0.0))
+        except ValueError:
+            logging.error("Could not set the buffer threshold to: {}".format(kwargs[PCT_BUFFER_FREE_KEY]))
 
         self._param = {
             'config/hdf/acquisition_id': '',

--- a/tools/python/odin_data/frame_processor_adapter.py
+++ b/tools/python/odin_data/frame_processor_adapter.py
@@ -51,7 +51,10 @@ class FrameProcessorAdapter(OdinDataAdapter):
 
         self._fr_pct_buffer_threshold = DEFAULT_PCT_BUFFER_FREE
         if PCT_BUFFER_FREE_KEY in kwargs:
-            self._fr_pct_buffer_threshold = kwargs[PCT_BUFFER_FREE_KEY]
+            try:
+                self._fr_pct_buffer_threshold = float(kwargs[PCT_BUFFER_FREE_KEY])
+            except:
+                logging.error("Could not set the buffer threshold to: {}".format(kwargs[PCT_BUFFER_FREE_KEY]))
 
         self._param = {
             'config/hdf/acquisition_id': '',

--- a/tools/python/odin_data/frame_processor_adapter.py
+++ b/tools/python/odin_data/frame_processor_adapter.py
@@ -15,6 +15,8 @@ from tornado.ioloop import IOLoop
 
 FP_ADAPTER_KEY = 'fr_adapter_name'
 FP_DEFAULT_ADAPTER_KEY = 'fr'
+PCT_BUFFER_FREE_KEY = 'buffer_threshold'
+DEFAULT_PCT_BUFFER_FREE = 5.0
 
 def bool_from_string(value):
     bool_value = False
@@ -46,6 +48,10 @@ class FrameProcessorAdapter(OdinDataAdapter):
             self._fr_adapter_name = kwargs[FP_ADAPTER_KEY]
 
         self._fr_adapter = None
+
+        self._fr_pct_buffer_threshold = DEFAULT_PCT_BUFFER_FREE
+        if PCT_BUFFER_FREE_KEY in kwargs:
+            self._fr_pct_buffer_threshold = kwargs[PCT_BUFFER_FREE_KEY]
 
         self._param = {
             'config/hdf/acquisition_id': '',
@@ -210,7 +216,7 @@ class FrameProcessorAdapter(OdinDataAdapter):
                             valid_check = False
                             reason = "Frames dropped [{}] on at least one FR".format(frames_dropped)
                         pct_free = float(empty_buffers) / (float(empty_buffers+mapped_buffers)) * 100.0
-                        if pct_free < 5.0:
+                        if pct_free < self._fr_pct_buffer_threshold:
                             valid_check = False
                             reason = "There are only {}% free buffers left on at least one FR".format(pct_free)
                     except Exception as ex:


### PR DESCRIPTION
FP adapter can use inter adapter comms to check the free buffers and if any frames dropped in the FR adapter.
FP adapter will then reject any attempt to start a new file write until free buffers is above 5% and there are no dropped frames.
Resetting FR should clear dropped frames, free buffers would be resolved by fixing whatever has gone wrong.