### PR TITLE
File Writing Metrics

### DIFF
--- a/common/include/IpcReactor.h
+++ b/common/include/IpcReactor.h
@@ -26,6 +26,7 @@
 #include <boost/function.hpp>
 #include <boost/ref.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
 #include "zmq/zmq.hpp"
 
 #include "IpcChannel.h"
@@ -146,6 +147,7 @@ private:
   ReactorCallback* callbacks_;     //!< Ptr to matched array of callbacks
   std::size_t      pollsize_;      //!< Number if active items to poll
   bool             needs_rebuild_; //!< Indicates that the poll item list needs rebuilding
+  boost::mutex mutex_;             //!< Mutex used to make some calls in this class thread safe
 };
 
 } // namespace OdinData

--- a/common/include/gettime.h
+++ b/common/include/gettime.h
@@ -38,4 +38,22 @@ clock_gettime(clockid, ts);
 #endif
 
 }
+
+/** Calculate and return an elapsed time in microseconds.
+ *
+ * This method calculates and returns an elapsed time in microseconds based on the start and
+ * end timespec structs passed as arguments.
+ *
+ * \param[in] start - start time in timespec struct format
+ * \param[in] end - end time in timespec struct format
+ * \return elapsed time between start and end in microseconds
+ */
+static inline unsigned int elapsed_us(const struct timespec& start, const struct timespec& end)
+{
+  double start_ns = ((double) start.tv_sec * 1000000000) + start.tv_nsec;
+  double end_ns = ((double) end.tv_sec * 1000000000) + end.tv_nsec;
+
+  return (unsigned int)((end_ns - start_ns) / 1000);
+}
+
 #endif /* INCLUDE_GETTIME_H_ */

--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -29,29 +29,31 @@ class Frame;
 class Acquisition : public MetaMessagePublisher
 {
 public:
-  Acquisition();
+  Acquisition(const HDF5ErrorDefinition_t& hdf5_error_definition);
   ~Acquisition();
   std::string get_last_error();
-  ProcessFrameStatus process_frame(boost::shared_ptr<Frame> frame);
-  void create_file(size_t file_number=0);
-  void close_file(boost::shared_ptr<HDF5File> file);
+  ProcessFrameStatus process_frame(boost::shared_ptr<Frame> frame, HDF5CallDurations_t& call_durations);
+  void create_file(size_t file_number, HDF5CallDurations_t& call_durations);
+  void close_file(boost::shared_ptr<HDF5File> file, HDF5CallDurations_t& call_durations);
   void validate_dataset_definition(DatasetDefinition definition);
   bool start_acquisition(
-      size_t concurrent_rank,
-      size_t concurrent_processes,
-      size_t frames_per_block,
-      size_t blocks_per_file,
-      std::string file_extension,
-      bool use_earliest_hdf5,
-      size_t alignment_threshold,
-      size_t alignment_value,
-      std::string master_frame);
-  void stop_acquisition();
+    size_t concurrent_rank,
+    size_t concurrent_processes,
+    size_t frames_per_block,
+    size_t blocks_per_file,
+    std::string file_extension,
+    bool use_earliest_hdf5,
+    size_t alignment_threshold,
+    size_t alignment_value,
+    std::string master_frame,
+    HDF5CallDurations_t& call_durations
+  );
+  void stop_acquisition(HDF5CallDurations_t& call_durations);
   bool check_frame_valid(boost::shared_ptr<Frame> frame);
   size_t get_frame_offset_in_file(size_t frame_offset) const;
   size_t get_file_index(size_t frame_offset) const;
   size_t adjust_frame_offset(boost::shared_ptr<Frame> frame) const;
-  boost::shared_ptr<HDF5File> get_file(size_t frame_offset);
+  boost::shared_ptr<HDF5File> get_file(size_t frame_offset, HDF5CallDurations_t& call_durations);
   std::string get_create_meta_header();
   std::string get_meta_header();
   std::string generate_filename(size_t file_number=0);
@@ -94,6 +96,9 @@ public:
   size_t frames_per_block_;
   /** Number of blocks to write in a file  */
   size_t blocks_per_file_;
+  /** HDF5 call error definitions */
+  const HDF5ErrorDefinition_t& hdf5_error_definition_;
+
 private:
   /** The current file that frames are being written to */
   boost::shared_ptr<HDF5File> current_file;

--- a/frameProcessor/include/CMakeLists.txt
+++ b/frameProcessor/include/CMakeLists.txt
@@ -1,4 +1,24 @@
 # Install header files into installation prefix
 
-SET(HEADERS DataBlock.h DataBlockPool.h FrameMetaData.h Frame.h SharedBufferFrame.h DataBlockFrame.h FrameProcessorPlugin.h FileWriterPlugin.h IFrameCallback.h MetaMessage.h MetaMessagePublisher.h WorkQueue.h HDF5File.h Acquisition.h FrameProcessorDefinitions.h BloscPlugin.h SumPlugin.h GapFillPlugin.h KafkaProducerPlugin.h)
+SET(HEADERS DataBlock.h
+            DataBlockPool.h
+            FrameMetaData.h
+            Frame.h
+            SharedBufferFrame.h
+            DataBlockFrame.h
+            FrameProcessorPlugin.h
+            FileWriterPlugin.h
+            IFrameCallback.h
+            MetaMessage.h
+            MetaMessagePublisher.h
+            WorkQueue.h
+            CallDuration.h
+            HDF5File.h
+            Acquisition.h
+            FrameProcessorDefinitions.h
+            BloscPlugin.h
+            SumPlugin.h
+            GapFillPlugin.h
+            KafkaProducerPlugin.h)
+
 INSTALL(FILES ${HEADERS} DESTINATION include/frameProcessor)

--- a/frameProcessor/include/CMakeLists.txt
+++ b/frameProcessor/include/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(HEADERS DataBlock.h
             MetaMessagePublisher.h
             WorkQueue.h
             CallDuration.h
+            WatchdogTimer.h
             HDF5File.h
             Acquisition.h
             FrameProcessorDefinitions.h

--- a/frameProcessor/include/CallDuration.h
+++ b/frameProcessor/include/CallDuration.h
@@ -1,0 +1,34 @@
+/*
+ * CallDuration.h
+ *
+ *  Created on: 20th March 2020
+ *      Author: Gary Yendell
+ */
+
+#ifndef FRAMEPROCESSOR_SRC_CALLDURATION_H_
+#define FRAMEPROCESSOR_SRC_CALLDURATION_H_
+
+namespace FrameProcessor {
+
+/**
+ * A simple store for call duration metrics.
+ *
+ * Durations in microseconds.
+ */
+class CallDuration
+{
+public:
+  void update(unsigned int duration);
+  void reset();
+
+  /** Last call duration **/
+  unsigned int last_;
+  /** Maximum call duration **/
+  unsigned int max_;
+  /** Mean call duration (exponential average) **/
+  unsigned int mean_;
+};
+
+} /* namespace FrameProcessor */
+
+#endif /* FRAMEPROCESSOR_SRC_CALLDURATION_H_ */

--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -50,6 +50,8 @@ public:
   void configure_dataset(const std::string& dataset_name, OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void create_new_dataset(const std::string& dset_name);
   void status(OdinData::IpcMessage& status);
+  void add_file_writing_stats(OdinData::IpcMessage& status);
+  bool reset_statistics();
   void stop_acquisition();
   void start_close_file_timeout();
   void run_close_file_timeout();
@@ -116,6 +118,11 @@ private:
   static const std::string CLOSE_TIMEOUT_PERIOD;
   /** Configuration constant for starting the close file timeout */
   static const std::string START_CLOSE_TIMEOUT;
+  /** Configuration constant for HDF5 call timeout durations before loggin an error */
+  static const std::string CREATE_ERROR_DURATION;
+  static const std::string WRITE_ERROR_DURATION;
+  static const std::string FLUSH_ERROR_DURATION;
+  static const std::string CLOSE_ERROR_DURATION;
 
   /**
    * Prevent a copy of the FileWriterPlugin plugin.
@@ -173,6 +180,10 @@ private:
   std::string file_extension_;
   /** Name of master frame. When a master frame is received frame numbers increment */
   std::string master_frame_;
+  /** HDF5 call warning and error durations */
+  HDF5ErrorDefinition_t hdf5_error_definition_;
+  /** HDF5 File IO performance stats */
+  HDF5CallDurations_t hdf5_call_durations_;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -8,6 +8,8 @@
 #ifndef TOOLS_FILEWRITER_FrameProcessorPlugin_H_
 #define TOOLS_FILEWRITER_FrameProcessorPlugin_H_
 
+#include <boost/thread.hpp>
+
 #include "IFrameCallback.h"
 #include "IVersionedObject.h"
 #include "MetaMessage.h"
@@ -71,8 +73,10 @@ private:
   std::map<std::string, boost::shared_ptr<IFrameCallback> > callbacks_;
   /** Map of registered plugins for blocking callbacks, indexed by name */
   std::map<std::string, boost::shared_ptr<IFrameCallback> > blocking_callbacks_;
-  /** Error message array*/
+  /** Error message array */
   std::vector<std::string> error_messages_;
+  /** Mutex to make accessing error_messages_ threadsafe */
+  boost::mutex mutex_;
   /** process_frame performance stats */
   CallDuration process_duration_;
 };

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -15,6 +15,7 @@
 #include "IpcChannel.h"
 #include "MetaMessagePublisher.h"
 #include "Frame.h"
+#include "CallDuration.h"
 
 namespace FrameProcessor
 {
@@ -72,12 +73,8 @@ private:
   std::map<std::string, boost::shared_ptr<IFrameCallback> > blocking_callbacks_;
   /** Error message array*/
   std::vector<std::string> error_messages_;
-  /** Last process time */
-  uint64_t last_process_time_;
-  /** Maximum process time since last reset */
-  uint64_t max_process_time_;
-  /** Exp average process time since last reset */
-  double average_process_time_;
+  /** process_frame performance stats */
+  CallDuration process_duration_;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -56,8 +56,6 @@ private:
 
   void callback(boost::shared_ptr<Frame> frame);
 
-  unsigned int elapsed_us(struct timespec& start, struct timespec& end);
-
   /**
    * This is called by the callback method when any new frames have
    * arrived and must be overridden by child classes.
@@ -79,7 +77,7 @@ private:
   /** Maximum process time since last reset */
   uint64_t max_process_time_;
   /** Exp average process time since last reset */
-  double average_process_time_; 
+  double average_process_time_;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -60,6 +60,7 @@ public:
   void write_frame(const Frame& frame, hsize_t frame_offset, uint64_t outer_chunk_dimension);
   void write_parameter(const Frame& frame, DatasetDefinition dataset_definition, hsize_t frame_offset);
   size_t get_dataset_frames(const std::string& dset_name);
+  size_t get_dataset_max_size(const std::string& dset_name);
   void start_swmr();
   size_t get_file_index();
   std::string get_filename();

--- a/frameProcessor/include/HDF5File.h
+++ b/frameProcessor/include/HDF5File.h
@@ -25,8 +25,35 @@ using namespace log4cxx;
 #include "Frame.h"
 #include "FrameProcessorDefinitions.h"
 #include "MetaMessagePublisher.h"
+#include "WatchdogTimer.h"
+#include "CallDuration.h"
 
 namespace FrameProcessor {
+
+/**
+ * A collection of CallDurations to pass around and update with HDF5 call metrics
+ */
+struct HDF5CallDurations_t
+{
+  CallDuration create;
+  CallDuration write;
+  CallDuration flush;
+  CallDuration close;
+};
+
+/**
+ * Definitions of what constitutes an error from the HDF5 library
+ *
+ * - Durations (milliseconds) of HDF5 calls over which an error message will be logged
+ */
+struct HDF5ErrorDefinition_t
+{
+  unsigned int create_duration;
+  unsigned int write_duration;
+  unsigned int flush_duration;
+  unsigned int close_duration;
+  boost::function<void(const std::string&)> callback;
+};
 
 class HDF5File
 {
@@ -48,16 +75,20 @@ public:
     size_t actual_dataset_size_;
   };
 
-
-  HDF5File();
+  HDF5File(const HDF5ErrorDefinition_t& hdf5_error_definition);
   ~HDF5File();
   void hdf_error_handler(unsigned n, const H5E_error2_t* err_desc);
   void clear_hdf_errors();
   void handle_h5_error(const std::string& message, const std::string& function, const std::string& filename, int line);
-  void create_file(std::string file_name, size_t file_index, bool use_earliest_version, size_t alignment_threshold, size_t alignment_value);
-  void close_file();
+  size_t create_file(std::string file_name, size_t file_index, bool use_earliest_version, size_t alignment_threshold, size_t alignment_value);
+  size_t close_file();
   void create_dataset(const DatasetDefinition& definition, int low_index, int high_index);
-  void write_frame(const Frame& frame, hsize_t frame_offset, uint64_t outer_chunk_dimension);
+  void write_frame(
+    const Frame& frame,
+    hsize_t frame_offset,
+    uint64_t outer_chunk_dimension,
+    HDF5CallDurations_t& call_durations
+  );
   void write_parameter(const Frame& frame, DatasetDefinition dataset_definition, hsize_t frame_offset);
   size_t get_dataset_frames(const std::string& dset_name);
   size_t get_dataset_max_size(const std::string& dset_name);
@@ -105,6 +136,10 @@ private:
   hid_t param_memspace_;
   /* Map containing time each dataset was last flushed*/
   std::map<std::string, boost::posix_time::ptime> last_flushed;
+  /* Watchdog timer for monitoring function call durations */
+  WatchdogTimer watchdog_timer_;
+  /** HDF5 call error definitions */
+  const HDF5ErrorDefinition_t& hdf5_error_definition_;
 };
 
 } /* namespace FrameProcessor */

--- a/frameProcessor/include/WatchdogTimer.h
+++ b/frameProcessor/include/WatchdogTimer.h
@@ -42,7 +42,7 @@ private:
   /* Timer watchdog thread */
   boost::thread worker_thread_;
   /** Flag to control start up timings of main thread and worker thread */
-  bool worker_thread_running_;
+  volatile bool worker_thread_running_;
   /** IpcReactor to use as a simple timer controller */
   OdinData::IpcReactor reactor_;
   /** Timeout of current timer in milliseconds */

--- a/frameProcessor/include/WatchdogTimer.h
+++ b/frameProcessor/include/WatchdogTimer.h
@@ -1,0 +1,62 @@
+/*
+ * WatchdogTimer.h
+ *
+ *  Created on: 10 Mar 2020
+ *      Author: Gary Yendell
+ */
+
+#ifndef FRAMEPROCESSOR_SRC_WATCHDOGTIMER_H_
+#define FRAMEPROCESSOR_SRC_WATCHDOGTIMER_H_
+
+#include <string>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+
+#include <IpcReactor.h>
+#include <gettime.h>
+
+#include <log4cxx/logger.h>
+using namespace log4cxx;
+
+namespace FrameProcessor {
+
+class WatchdogTimer
+{
+public:
+  WatchdogTimer(const boost::function<void(const std::string&)>& timeout_callback);
+  ~WatchdogTimer();
+
+  void start_timer(const std::string& function_name, unsigned int watchdog_timeout_ms);
+  unsigned int finish_timer();
+
+private:
+  void run();
+  void call_timeout_callback(const std::string& function_name) const;
+  void heartbeat();
+
+  /** Logger for logging */
+  LoggerPtr logger_;
+  /* Store for start time of watchdog */
+  struct timespec start_time_;
+  /* Timer watchdog thread */
+  boost::thread worker_thread_;
+  /** Flag to control start up timings of main thread and worker thread */
+  bool worker_thread_running_;
+  /** IpcReactor to use as a simple timer controller */
+  OdinData::IpcReactor reactor_;
+  /** Timeout of current timer in milliseconds */
+  unsigned int timeout_;
+  /** Name of function currently being timed */
+  std::string function_name_;
+  /** ID of current timer to cancel callback */
+  int timer_id_;
+  /** Counter to monitor number of ticks that have passed */
+  int ticks_;
+  /** Callback function to call when the timer expires */
+  const boost::function<void(const std::string&)>& timeout_callback_;
+};
+
+} /* namespace FrameProcessor */
+
+#endif /* FRAMEPROCESSOR_SRC_WATCHDOGTIMER_H_ */

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -88,7 +88,6 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame) {
           std::stringstream ss;
           ss << "Unexpected frame: " << frame_no << " in this process rank: " << this->concurrent_rank_;
           last_error_ = ss.str();
-          LOG4CXX_ERROR(logger_, last_error_);
           return status_invalid;
         }
       }
@@ -97,7 +96,6 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame) {
 
       if (file == 0) {
         last_error_ = "Unable to get file for this frame";
-        LOG4CXX_ERROR(logger_,last_error_);
         return status_invalid;
       }
 
@@ -201,7 +199,6 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame) {
     std::stringstream ss;
     ss << "Out of Range exception: " << e.what();
     last_error_ = ss.str();
-    LOG4CXX_ERROR(logger_, last_error_);
     return status_invalid;
   }
   catch (const std::range_error& e)
@@ -209,14 +206,12 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame) {
     std::stringstream ss;
     ss << "Range exception: " << e.what();
     last_error_ = ss.str();
-    LOG4CXX_ERROR(logger_, last_error_);
     return status_invalid;
   }
   catch (const std::exception& e) {
     std::stringstream ss;
     ss << "Unexpected exception: " << e.what();
     last_error_ = ss.str();
-    LOG4CXX_ERROR(logger_, last_error_);
     return status_invalid;
   }
   return return_status;

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -103,6 +103,12 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame) {
 
       size_t frame_offset_in_file = this->get_frame_offset_in_file(frame_offset);
 
+      int dataset_max_offset = file->get_dataset_max_size(frame_dataset_name) - 1;
+      if (dataset_max_offset && frame_offset_in_file > dataset_max_offset) {
+        last_error_ = "Frame offset exceeds dimensions of static dataset";
+        return status_invalid;
+      }
+
       uint64_t outer_chunk_dimension = 1;
       if (dataset_defs_.size() != 0) {
         outer_chunk_dimension = dataset_defs_.at(frame_dataset_name).chunks[0];

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -14,7 +14,8 @@ file(GLOB LIB_SOURCES DataBlock.cpp
                       DataBlockFrame.cpp
                       MetaMessage.cpp
                       MetaMessagePublisher.cpp
-                      IFrameCallback.cpp )
+                      IFrameCallback.cpp
+                      CallDuration.cpp )
 
 # Add library for common plugin code
 add_library(${LIB_PROCESSOR} SHARED ${LIB_SOURCES})

--- a/frameProcessor/src/CMakeLists.txt
+++ b/frameProcessor/src/CMakeLists.txt
@@ -15,7 +15,8 @@ file(GLOB LIB_SOURCES DataBlock.cpp
                       MetaMessage.cpp
                       MetaMessagePublisher.cpp
                       IFrameCallback.cpp
-                      CallDuration.cpp )
+                      CallDuration.cpp
+                      WatchdogTimer.cpp )
 
 # Add library for common plugin code
 add_library(${LIB_PROCESSOR} SHARED ${LIB_SOURCES})

--- a/frameProcessor/src/CallDuration.cpp
+++ b/frameProcessor/src/CallDuration.cpp
@@ -1,0 +1,38 @@
+/*
+ * CallDuration.cpp
+ *
+ *  Created on: 20th March 2020
+ *      Author: Gary Yendell
+ */
+
+#include "CallDuration.h"
+
+namespace FrameProcessor {
+
+/**
+ * Replace last, replace max if higher and recalculate mean
+ *
+ * \param[in] duration - Duration to update with
+ * */
+void CallDuration::update(unsigned int duration) {
+  last_ = duration;
+  if (duration > max_) {
+    max_ = duration;
+  }
+  if (mean_ == 0) {
+    mean_ = duration;
+  } else {
+    mean_ = (mean_ + (double) duration) / 2;
+  }
+}
+
+/**
+ * Reset all values to 0
+ * */
+void CallDuration::reset() {
+  last_ = 0;
+  max_ = 0;
+  mean_ = 0;
+}
+
+} /* namespace FrameProcessor */

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -61,6 +61,9 @@ std::string FrameProcessorPlugin::get_name()
  */
 void FrameProcessorPlugin::set_error(const std::string& msg)
 {
+  // Take lock to access error_messages_
+  boost::lock_guard<boost::mutex> lock(mutex_);
+
   // Loop over error messages, if this is a new message then add it
   std::vector<std::string>::iterator iter;
   bool found_error = false;
@@ -81,6 +84,8 @@ void FrameProcessorPlugin::set_error(const std::string& msg)
  */
 void FrameProcessorPlugin::clear_errors()
 {
+  // Take lock to access error_messages_
+  boost::lock_guard<boost::mutex> lock(mutex_);
   error_messages_.clear();
 }
 
@@ -99,6 +104,8 @@ bool FrameProcessorPlugin::reset_statistics()
  */
 std::vector<std::string> FrameProcessorPlugin::get_errors()
 {
+  // Take lock to access error_messages_
+  boost::lock_guard<boost::mutex> lock(mutex_);
   return error_messages_;
 }
 

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -328,22 +328,4 @@ void FrameProcessorPlugin::push(boost::shared_ptr<Frame> frame)
   }
 }
 
-/** Calculate and return an elapsed time in microseconds.
- * 
- * This method calculates and returns an elapsed time in microseconds based on the start and
- * end timespec structs passed as arguments.
- * 
- * \param[in] start - start time in timespec struct format
- * \param[in] end - end time in timespec struct format
- * \return elapsed time between start and end in microseconds
- */
-unsigned int FrameProcessorPlugin::elapsed_us(struct timespec& start, struct timespec& end)
-{
-
-  double start_ns = ((double) start.tv_sec * 1000000000) + start.tv_nsec;
-  double end_ns = ((double) end.tv_sec * 1000000000) + end.tv_nsec;
-
-  return (unsigned int)((end_ns - start_ns) / 1000);
-}
-
 } /* namespace FrameProcessor */

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -49,6 +49,9 @@ HDF5File::~HDF5File() {
   close_file();
 }
 
+/**
+ * Configure datasets to allow extension during write to an unlimited extent
+ */
 void HDF5File::set_unlimited() {
   if (hdf5_datasets_.empty()) {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Setting HDF5 datasets to use unlimited");
@@ -540,6 +543,22 @@ size_t HDF5File::get_dataset_frames(const std::string& dset_name)
   // Protect this method
   boost::lock_guard<boost::recursive_mutex> lock(mutex_);
   return this->get_hdf5_dataset(dset_name).actual_dataset_size_;
+}
+
+/** Get the maximum size of the given dataset
+ *
+ * \param[in] dataset - HDF5 dataset
+ * \return - 0 if unlimited_, else the extent of the outermost dimension of the dataset
+ */
+size_t HDF5File::get_dataset_max_size(const std::string& dset_name)
+{
+  // Protect this method
+  boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+  if (unlimited_) {
+    return 0;
+  } else {
+    return this->get_hdf5_dataset(dset_name).dataset_dimensions[0];
+  }
 }
 
 /**

--- a/frameProcessor/src/WatchdogTimer.cpp
+++ b/frameProcessor/src/WatchdogTimer.cpp
@@ -1,0 +1,127 @@
+/*
+ * WatchdogTimer.cpp
+ *
+ *  Created on: 10 Mar 2020
+ *      Author: Gary Yendell
+ */
+
+#include "WatchdogTimer.h"
+
+#include "logging.h"
+#include "DebugLevelLogger.h"
+
+#define WARNING_DURATION_FRACTION 0.1  // Fraction of error duration that will cause a warning to be logged
+
+namespace FrameProcessor {
+
+WatchdogTimer::WatchdogTimer(const boost::function<void(const std::string&)>& timeout_callback) :
+        worker_thread_running_(false),
+        worker_thread_(boost::bind(&WatchdogTimer::run, this)),
+        timeout_callback_(timeout_callback)
+{
+  this->logger_ = Logger::getLogger("FP.WatchdogTimer");
+  this->logger_->setLevel(Level::getTrace());
+
+  // Wait until worker thread is ready before returning
+  while (!worker_thread_running_) {}
+
+  LOG4CXX_TRACE(logger_, "WatchdogTimer constructor");
+}
+
+WatchdogTimer::~WatchdogTimer() {
+  worker_thread_running_ = false;
+  worker_thread_.join();
+}
+
+/**
+ * Store the start time and schedule a deadline_timer to print an error
+ *
+ * To be called before a function call
+ *
+ * \param[in] function_name - Function name for log message
+ * \param[in] watchdog_timeout_ms - Timeout for watchdog to log error message
+ */
+void WatchdogTimer::start_timer(const std::string& function_name, unsigned int watchdog_timeout_ms) {
+  gettime(&start_time_, true);
+  timeout_ = watchdog_timeout_ms;
+  function_name_ = function_name;
+
+  // Register timer to call timeout callback in watchdog_timeout milliseconds once
+  if (watchdog_timeout_ms > 0) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_,
+      "" << function_name << " | Registering " << watchdog_timeout_ms << "ms watchdog timer"
+    );
+    timer_id_ = reactor_.register_timer(
+        watchdog_timeout_ms, 1,
+        // Bind member function to this instance with function_name argument
+        boost::bind(&WatchdogTimer::call_timeout_callback, this, function_name)
+    );
+  }
+}
+
+/**
+ * Disable the watchdog, calculate the duration and then log and return
+ *
+ * To be called after a function returns
+ *
+ * \return - Duration in microseconds
+ */
+unsigned int WatchdogTimer::finish_timer() {
+  reactor_.remove_timer(timer_id_);
+
+  struct timespec now;
+  gettime(&now, true);
+  double duration = elapsed_us(start_time_, now);
+
+  std::stringstream message;
+  message << function_name_ << " | Call took " << duration << "us";
+  if (timeout_ > 0 && duration / 1000 > timeout_ * WARNING_DURATION_FRACTION) {
+    LOG4CXX_WARN(logger_, message.str());
+  } else {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, message.str());
+  }
+
+  return duration;
+}
+
+/**
+ * Function run by the worker_thread_
+ *
+ * This will register a heartbeat timer and then run the IpcReactor
+ */
+void WatchdogTimer::run() {
+  OdinData::configure_logging_mdc(OdinData::app_path.c_str());
+
+  // We are ready - Let the constructor return
+  worker_thread_running_ = true;
+
+  // Register a repeating timer to keep the reactor alive and check for shutdown every millisecond
+  reactor_.register_timer(1, 0, boost::bind(&WatchdogTimer::heartbeat, this));
+  reactor_.run();
+}
+
+/**
+ * Call the timeout_callback_ with an error message
+ */
+void WatchdogTimer::call_timeout_callback(const std::string& function_name) const {
+  std::stringstream error_message;
+  error_message << function_name << " | Watchdog timed out";
+  timeout_callback_(error_message.str());
+}
+
+/**
+ * Report the reactor is still alive and stop when flag set
+ */
+void WatchdogTimer::heartbeat() {
+  if (!worker_thread_running_) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Terminating watchdog reactor");
+    reactor_.stop();
+  } else if (ticks_ >= 1000) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Reactor running");
+    ticks_ = 0;
+  } else {
+    ticks_++;
+  }
+}
+
+} /* namespace FrameProcessor */

--- a/frameProcessor/test/FrameProcessorTest.cpp
+++ b/frameProcessor/test/FrameProcessorTest.cpp
@@ -26,6 +26,8 @@ using namespace log4cxx::xml;
 #include "FrameProcessorDefinitions.h"
 #include "TestHelperFunctions.h"
 
+void dummy_callback(const std::string& msg) {}
+
 class GlobalConfig {
 public:
   GlobalConfig() :
@@ -36,6 +38,7 @@ public:
     consoleAppender = new ConsoleAppender(LayoutPtr(new SimpleLayout()));
     BasicConfigurator::configure(AppenderPtr(consoleAppender));
     Logger::getRootLogger()->setLevel(Level::getWarn());
+    set_debug_level(3);
     metaRxChannel_.bind("inproc://meta_rx");
   }
   ~GlobalConfig() {
@@ -195,31 +198,39 @@ public:
       img[0] = i;
       frames.push_back(tmp_frame);
     }
+
+    hdf5_error_definition.create_duration = 0;
+    hdf5_error_definition.write_duration = 0;
+    hdf5_error_definition.flush_duration = 0;
+    hdf5_error_definition.close_duration = 0;
+    hdf5_error_definition.callback = boost::bind(&dummy_callback, _1);
   }
   ~FileWriterPluginTestFixture() {}
   boost::shared_ptr<FrameProcessor::DataBlockFrame> frame;
   std::vector< boost::shared_ptr<FrameProcessor::DataBlockFrame> >frames;
+  FrameProcessor::HDF5ErrorDefinition_t hdf5_error_definition;
   FrameProcessor::FileWriterPlugin fw;
   FrameProcessor::DatasetDefinition dset_def;
+  FrameProcessor::HDF5CallDurations_t durations;
 };
 
 BOOST_FIXTURE_TEST_SUITE(HDF5FileUnitTest, FileWriterPluginTestFixture);
 
 BOOST_AUTO_TEST_CASE( HDF5FileTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah.h5", 0, false, 1, 1));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
   BOOST_REQUIRE_EQUAL(dset_def.name, frame->get_meta_data().get_dataset_name());
 
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations));
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( HDF5FileMultiDatasetTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multidataset.h5", 0, false, 1, 1));
 
@@ -232,26 +243,26 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultiDatasetTest )
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
 
   // Write first frame to "data"
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations));
 
   // Write the frame to "stuff"
   BOOST_CHECK_NO_THROW(frame->meta_data().set_dataset_name("stuff"));
   BOOST_CHECK_EQUAL(dset_def.name, frame->get_meta_data().get_dataset_name());
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations));
 
   // write another frame to "data"
   BOOST_CHECK_EQUAL("data", frames[2]->get_meta_data().get_dataset_name());
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frames[2], frames[2]->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frames[2], frames[2]->get_frame_number(), 1, durations));
   // and yet another frame to "stuff"
   BOOST_CHECK_NO_THROW(frames[2]->meta_data().set_dataset_name("stuff"));
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frames[2], frames[2]->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frames[2], frames[2]->get_frame_number(), 1, durations));
 
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( HDF5FileBadFileTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   // Check for an error when a bad file path is provided
   BOOST_CHECK_THROW(hdf5f.create_file("/non/existent/path/blah_throw.h5", 0, false, 1, 1), std::runtime_error);
@@ -259,7 +270,7 @@ BOOST_AUTO_TEST_CASE( HDF5FileBadFileTest )
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginDatasetWithoutOpenFileTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   // Check for an error when a dataset is created without a file open
   BOOST_CHECK_THROW(hdf5f.create_dataset(dset_def, -1, -1), std::runtime_error);
@@ -267,13 +278,13 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginDatasetWithoutOpenFileTest )
 
 BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   // Create a file ready for writing
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0, false, 1, 1));
 
   // Write a frame without first creating the dataset
-  BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1), std::runtime_error);
+  BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations), std::runtime_error);
 
   // Attempt to close the file
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
@@ -281,19 +292,19 @@ BOOST_AUTO_TEST_CASE( HDF5FileNoDatasetDefinitionsTest )
 
 BOOST_AUTO_TEST_CASE( HDF5FileInvalidDatasetTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_throw.h5", 0, false, 1, 1));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
   BOOST_REQUIRE_NO_THROW(frame->meta_data().set_dataset_name("non_existing_dataset_name"));
 
-  BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1), std::runtime_error);
+  BOOST_CHECK_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations), std::runtime_error);
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginMultipleFramesTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/blah_multiple.h5", 0, false, 1, 1));
   BOOST_REQUIRE_NO_THROW(hdf5f.create_dataset(dset_def, -1, -1));
@@ -301,14 +312,14 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginMultipleFramesTest )
   std::vector<boost::shared_ptr<FrameProcessor::DataBlockFrame> >::iterator it;
   for (it = frames.begin(); it != frames.end(); ++it) {
     BOOST_TEST_MESSAGE("Writing frame: " <<  (*it)->get_frame_number());
-    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*it), (*it)->get_frame_number(), 1));
+    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*it), (*it)->get_frame_number(), 1, durations));
   }
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   // Just reverse through the list of frames and write them out.
   // The frames should still appear in the file in the original order...
@@ -319,19 +330,19 @@ BOOST_AUTO_TEST_CASE( HDF5FileMultipleReverseTest )
   // frame number. Frames received later with a smaller number would result
   // in negative file index...
   BOOST_TEST_MESSAGE("Writing frame: " << frame->get_frame_number());
-  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1));
+  BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*frame, frame->get_frame_number(), 1, durations));
 
   std::vector<boost::shared_ptr<FrameProcessor::DataBlockFrame> >::reverse_iterator rit;
   for (rit = frames.rbegin(); rit != frames.rend(); ++rit) {
     BOOST_TEST_MESSAGE("Writing frame: " <<  (*rit)->get_frame_number());
-    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*rit), (*rit)->get_frame_number(), 1));
+    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*rit), (*rit)->get_frame_number(), 1, durations));
   }
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( HDF5FileAdjustHugeOffset )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_huge_offset.h5", 0, false, 1, 1));
   BOOST_REQUIRE_NO_THROW(hdf5f.set_unlimited());
@@ -348,14 +359,14 @@ BOOST_AUTO_TEST_CASE( HDF5FileAdjustHugeOffset )
     //(*it)->copy_header(&img_header);
     (*it)->meta_data().set_frame_offset(huge_offset);
     (*it)->set_frame_number(frame_no + huge_offset);
-    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*it), (*it)->get_frame_number(), 1));
+    BOOST_REQUIRE_NO_THROW(hdf5f.write_frame(*(*it), (*it)->get_frame_number(), 1, durations));
   }
   BOOST_REQUIRE_NO_THROW(hdf5f.close_file());
 }
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginWriteParamTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_write_params.h5", 0, false, 1, 1));
 
@@ -382,7 +393,7 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginWriteParamTest )
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginWriteParamWrongTypeTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_wrong_params.h5", 0, false, 1, 1));
 
@@ -408,7 +419,7 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginWriteParamWrongTypeTest )
 
 BOOST_AUTO_TEST_CASE( FileWriterPluginWriteParamNoParamTest )
 {
-  FrameProcessor::HDF5File hdf5f;
+  FrameProcessor::HDF5File hdf5f(hdf5_error_definition);
 
   BOOST_REQUIRE_NO_THROW(hdf5f.create_file("/tmp/test_no_params.h5", 0, false, 1, 1));
 
@@ -439,7 +450,7 @@ BOOST_FIXTURE_TEST_SUITE(AcquisitionUnitTest, FileWriterPluginTestFixture);
 
 BOOST_AUTO_TEST_CASE( AcquisitionGetFileIndex )
 {
-  FrameProcessor::Acquisition acquisition;
+  FrameProcessor::Acquisition acquisition(hdf5_error_definition);
 
   acquisition.concurrent_rank_ = 0;
   acquisition.concurrent_processes_ = 4;
@@ -554,7 +565,7 @@ BOOST_AUTO_TEST_CASE( AcquisitionGetFileIndex )
 
 BOOST_AUTO_TEST_CASE( AcquisitionGetOffsetInFile )
 {
-  FrameProcessor::Acquisition acquisition;
+  FrameProcessor::Acquisition acquisition(hdf5_error_definition);
 
   acquisition.concurrent_rank_ = 0;
   acquisition.concurrent_processes_ = 4;
@@ -640,8 +651,7 @@ BOOST_AUTO_TEST_CASE( AcquisitionGetOffsetInFile )
 
 BOOST_AUTO_TEST_CASE( AcquisitionAdjustFrameOffset )
 {
-  FrameProcessor::Acquisition acquisition;
-
+  FrameProcessor::Acquisition acquisition(hdf5_error_definition);
   boost::shared_ptr<FrameProcessor::DataBlockFrame> frame = get_dummy_frame();
   frame->meta_data().set_frame_offset(0);
 
@@ -674,8 +684,7 @@ BOOST_AUTO_TEST_CASE( AcquisitionAdjustFrameOffset )
 
 BOOST_AUTO_TEST_CASE( AcquisitionFrameVerification )
 {
-  FrameProcessor::Acquisition acquisition;
-
+  FrameProcessor::Acquisition acquisition(hdf5_error_definition);
   FrameProcessor::DatasetDefinition dset_def;
   // Provide default values for the dataset
   dset_def.name = "raw";


### PR DESCRIPTION
This adds a timer around certain hdf5 calls to log the time taken and to print an error if it is not reset within a certain time (i.e. if the main thread is stuck in the hdf5 call).

There is also some not entirely related tidying up.

This does not yet publish the metrics over the meta channel. I think the meta needs some refactoring before doing this. I have made a start here https://github.com/dls-controls/odin-data/tree/meta-refactor on the C++ side, but stopped at the point that I also needed to change the python library.