### PR TITLE
set the default acquid on frameProcessor's frames to '' again

### DIFF
--- a/frameProcessor/src/SharedMemoryController.cpp
+++ b/frameProcessor/src/SharedMemoryController.cpp
@@ -183,7 +183,7 @@ void SharedMemoryController::handleRxChannel()
           FrameProcessor::FrameMetaData frame_meta(frame_number,
                                                     "raw",
                                                     FrameProcessor::raw_64bit,
-                                                    "0",
+                                                    "",
                                                     std::vector<unsigned long long>());
 
           boost::shared_ptr<SharedBufferFrame> frame;


### PR DESCRIPTION
setting it to zero was probably done to account for a bug elsewhere; agreed in software meeting 12/3/20.