### PR TITLE
Fix a bug that was stopping the message type and value propagating

### DIFF
--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -458,7 +458,9 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> >::iterator iter;
   for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
     if (config.has_param(iter->first)) {
-      OdinData::IpcMessage subConfig(config.get_param<const rapidjson::Value&>(iter->first));
+      OdinData::IpcMessage subConfig(config.get_param<const rapidjson::Value&>(iter->first),
+                                     config.get_msg_type(),
+                                     config.get_msg_val());
       iter->second->configure(subConfig, reply);
     }
   }


### PR DESCRIPTION
Finally decided to fix this, it's been bugging people for ages...

The message type and value is no longer logged as illegal by every plugin on every configure message after this fix.  Whoop whoop.
