### PR TITLE
IpcMessage Nack

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -278,6 +278,9 @@ public:
     }
   }
 
+  //! Sets the nack message type with a reason parameter
+  void set_nack(const std::string& reason);
+
   //! Indicates if message has necessary attributes with legal values
   bool is_valid(void);
 

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -213,6 +213,20 @@ bool IpcMessage::has_param(const std::string& param_name) const
   return param_found;
 }
 
+
+//! Sets the message type to not acknowledged and sets an appropriate rejection message
+//!
+//! This method can be used to set this IpcMessage up as a rejection (nack) message.
+//! A reason is supplied and set as a parameter called 'rejetion'
+//!
+//! \return void
+
+void IpcMessage::set_nack(const std::string& reason)
+{
+  this->set_msg_type(MsgTypeNack);
+  this->set_param("rejection", reason);
+}
+
 //! Indicates if message has necessary attributes with legal values.
 //!
 //! This method indicates if the message is valid, i.e. that all required attributes

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -224,7 +224,7 @@ bool IpcMessage::has_param(const std::string& param_name) const
 void IpcMessage::set_nack(const std::string& reason)
 {
   this->set_msg_type(MsgTypeNack);
-  this->set_param("rejection", reason);
+  this->set_param("error", reason);
 }
 
 //! Indicates if message has necessary attributes with legal values.

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -217,7 +217,7 @@ bool IpcMessage::has_param(const std::string& param_name) const
 //! Sets the message type to not acknowledged and sets an appropriate rejection message
 //!
 //! This method can be used to set this IpcMessage up as a rejection (nack) message.
-//! A reason is supplied and set as a parameter called 'rejetion'
+//! A reason is supplied and set as a parameter called 'error'
 //!
 //! \return void
 


### PR DESCRIPTION
Related to #227 I will remove these commits from the specific File Writing check PR.
This PR adds the IpcMessage set_nack method which allows an IpcMessage to have its type set to nack with an appropriate error message.