### PR TITLE
Add total buffer count to FR

### DIFF
--- a/frameReceiver/include/FrameReceiverController.h
+++ b/frameReceiver/include/FrameReceiverController.h
@@ -117,6 +117,7 @@ namespace FrameReceiver
 
     IpcReactor reactor_;                  //!< Reactor for multiplexing all communications
 
+    unsigned int total_buffers_;          //!< Record the total number of buffers in the system
     unsigned int frames_received_;        //!< Counter for frames received
     unsigned int frames_released_;        //!< Counter for frames released
 

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -629,6 +629,9 @@ void FrameReceiverController::configure_buffer_manager(OdinData::IpcMessage& con
       LOG4CXX_DEBUG_LEVEL(1, logger_, "Configured frame buffer manager of total size " <<
           max_buffer_mem << " with " << buffer_manager_->get_num_buffers() << " buffers");
 
+      // Record the total number of buffers in the system here
+      total_buffers_ = buffer_manager_->get_num_buffers();
+
       // Register buffer manager with the frame decoder
       frame_decoder_->register_buffer_manager(buffer_manager_);
 
@@ -1102,6 +1105,7 @@ void FrameReceiverController::get_status(OdinData::IpcMessage& status_reply)
     }
   }
 
+  status_reply.set_param("buffers/total", total_buffers_);
   status_reply.set_param("buffers/empty", empty_buffers);
   status_reply.set_param("buffers/mapped", mapped_buffers);
 

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -626,11 +626,11 @@ void FrameReceiverController::configure_buffer_manager(OdinData::IpcMessage& con
           shared_buffer_name, max_buffer_mem,frame_decoder_->get_frame_buffer_size(), true)
       );
 
-      LOG4CXX_DEBUG_LEVEL(1, logger_, "Configured frame buffer manager of total size " <<
-          max_buffer_mem << " with " << buffer_manager_->get_num_buffers() << " buffers");
-
       // Record the total number of buffers in the system here
       total_buffers_ = buffer_manager_->get_num_buffers();
+
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "Configured frame buffer manager of total size " <<
+          max_buffer_mem << " with " << total_buffers_ << " buffers");
 
       // Register buffer manager with the frame decoder
       frame_decoder_->register_buffer_manager(buffer_manager_);

--- a/tools/python/odin_data/frame_processor_adapter.py
+++ b/tools/python/odin_data/frame_processor_adapter.py
@@ -214,11 +214,13 @@ class FrameProcessorAdapter(OdinDataAdapter):
                     try:
                         frames_dropped = fr['frames']['dropped']
                         empty_buffers = fr['buffers']['empty']
-                        mapped_buffers = fr['buffers']['mapped']
+                        total_buffers = fr['buffers']['total']
                         if frames_dropped > 0:
                             valid_check = False
                             reason = "Frames dropped [{}] on at least one FR".format(frames_dropped)
-                        pct_free = float(empty_buffers) / (float(empty_buffers+mapped_buffers)) * 100.0
+                        pct_free = 0.0
+                        if total_buffers > 0:
+                            pct_free = float(empty_buffers) / float(total_buffers) * 100.0
                         if pct_free < self._fr_pct_buffer_threshold:
                             valid_check = False
                             reason = "There are only {}% free buffers left on at least one FR".format(pct_free)


### PR DESCRIPTION
It turns out that the mapped buffer count I was using to calculate the pct free was not counting the buffers in the FP applications as I had thought.
I have added a new total buffers item to the status and I am using that to calculate the percentage of free buffers.
I've added a check for dividing by 0 in the calculation.