### PR TITLE
Updated frame writing timeout from an info log message to an error condition.

### DIFF
--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -792,7 +792,7 @@ void FileWriterPlugin::run_close_file_timeout()
           LOG4CXX_DEBUG_LEVEL(1, logger_, "Close file Timeout timed out");
           boost::lock_guard<boost::recursive_mutex> lock(mutex_);
           if (writing_ && timeout_active_) {
-            LOG4CXX_INFO(logger_, "Timed out waiting for frames, stopping writing");
+            set_error("Timed out waiting for frames, stopping writing");
             stop_acquisition();
           }
           timeout_active_ = false;


### PR DESCRIPTION
A timeout should put the file writer into an error state to ensure somebody notices it and has to clear the error.  Currently it only logged an info message which is quite missable.  JIRA ticket BC-1266.