### PR TITLE
Meta Writer Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /external
-/build*
-/prefix
+/*build*
+/*prefix/
 *.pyc
 /tools/python/venv/
 /.settings
@@ -23,3 +23,6 @@ tools/imagej/plugins/Odin-Data/build/**
 *.jar
 tools/imagej/odin-imagej
 tools/imagej/build/
+
+tools/python/build/
+tools/python/dist/

--- a/common/include/CMakeLists.txt
+++ b/common/include/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(HEADERS ClassLoader.h
         IpcMessage.h
         IpcReactor.h
         IVersionedObject.h
+        Json.h
         logging.h
         OdinDataException.h
         SegFaultHandler.h
@@ -18,4 +19,3 @@ SET(ZMQ_INCLUDE_DIR zmq)
 INSTALL(FILES ${HEADERS} DESTINATION include)
 INSTALL(DIRECTORY ${RAPIDJSON_INCLUDE_DIR} DESTINATION include)
 INSTALL(DIRECTORY ${ZMQ_INCLUDE_DIR} DESTINATION include)
-

--- a/common/include/Json.h
+++ b/common/include/Json.h
@@ -1,0 +1,67 @@
+/*
+ * Json.h
+ *
+ *  Created on: 10 Dec 2020
+ *      Author: Gary Yendell
+ */
+
+#ifndef JSON_H_
+#define JSON_H_
+
+#include <string>
+#include <vector>
+
+#include "rapidjson/document.h"
+
+namespace OdinData
+{
+
+class JsonDict
+{
+public:
+  JsonDict();
+
+  /** Add a scalar value to the underlying rapidjson::Document
+   *
+   * \param[in] key - The key of the item to add
+   * \param[in] value - The value of the item to add
+   */
+  template <typename T> void add(const std::string& key, T value)
+  {
+    rapidjson::Value json_value(value);
+    add(key, json_value);
+  }
+
+  void add(const std::string& key, const std::string&  json_value);
+
+  /** Add a vector value to the underlying rapidjson::Document
+   *
+   * \param[in] key - The key of the item to add
+   * \param[in] value - The value of the item to add
+   */
+  template <typename T> void add(const std::string& key, std::vector<T> value)
+  {
+    rapidjson::Value json_value;
+    json_value.SetArray();
+    typename std::vector<T>::iterator it;
+    for (it = value.begin(); it != value.end(); it++) {
+      json_value.PushBack(*it, document_.GetAllocator());
+    }
+    add(key, json_value);
+  }
+
+  /** Return a json representation of the dictionary
+   *
+   */
+  std::string str() const;
+
+private:
+  void add(const std::string& key, rapidjson::Value& json_value);
+
+  // RapidJSON document object
+  rapidjson::Document document_;
+};
+
+} /* namespace OdinData */
+
+#endif /* JSON_H_ */

--- a/common/src/Json.cpp
+++ b/common/src/Json.cpp
@@ -1,0 +1,54 @@
+/*
+ * Json.cpp
+ *
+ *  Created on: 10 Dec 2020
+ *      Author: Gary Yendell
+ */
+
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+
+#include "Json.h"
+
+namespace OdinData
+{
+
+JsonDict::JsonDict()
+{
+  document_.SetObject();
+}
+
+/** Add a key value pair to the underlying rapidjson::Document
+ *
+ * \param[in] key - The key of the item to add
+ * \param[in] value - The value of the item to add
+ */
+void JsonDict::add(const std::string& key, rapidjson::Value& json_value)
+{
+  rapidjson::Value json_key(key.c_str(), document_.GetAllocator());
+  document_.AddMember(json_key, json_value, document_.GetAllocator());
+}
+
+void JsonDict::add(const std::string& key, const std::string& value) {
+  rapidjson::Value json_value;
+  json_value.SetString(value.c_str(), value.length(), document_.GetAllocator());
+  add(key, json_value);
+}
+
+/** Generate a string from the rapidjson::Document
+ *
+ * \return - The string
+ */
+std::string JsonDict::str() const
+{
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> docWriter(buffer);
+  document_.Accept(docWriter);
+
+  // Return our own copy, as the original could be lost when it goes out of scope
+  std::string message(buffer.GetString());
+
+  return message;
+}
+
+} /* namespace OdinData */

--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -100,6 +100,10 @@ public:
   const HDF5ErrorDefinition_t& hdf5_error_definition_;
 
 private:
+  void add_uint64_to_document(const std::string& key, size_t value, rapidjson::Document* document) const;
+  void add_string_to_document(const std::string& key, const std::string& value, rapidjson::Document* document) const;
+  std::string document_to_string(rapidjson::Document& document) const;
+
   /** The current file that frames are being written to */
   boost::shared_ptr<HDF5File> current_file_;
   /** The previous file that frames were written to, held in case of late frames  */

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -137,7 +137,6 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame, HD
       document.SetObject();
       add_uint64_to_document(META_FRAME_KEY, (size_t) frame_no, &document);
       add_uint64_to_document(META_OFFSET_KEY, frame_offset, &document);
-      add_uint64_to_document(META_RANK_KEY, concurrent_rank_, &document);
       add_uint64_to_document(META_NUM_PROCESSES_KEY, concurrent_processes_, &document);
       add_uint64_to_document(META_WRITE_DURATION_KEY, call_durations.write.last_, &document);
       add_uint64_to_document(META_FLUSH_DURATION_KEY, call_durations.flush.last_, &document);
@@ -653,12 +652,13 @@ std::string Acquisition::get_create_meta_header() {
   rapidjson::Document document;
   document.SetObject();
   add_string_to_document(META_ACQID_KEY, acquisition_id_, &document);
+  add_uint64_to_document(META_RANK_KEY, concurrent_rank_, &document);
   add_uint64_to_document(META_NUM_FRAMES_KEY, total_frames_, &document);
 
   return document_to_string(document);
 }
 
-/** Create the standard header for a meta message containing the acquisition ID
+/** Create the standard header for a meta message
  *
  * \return - a string containing the json meta data header
  */
@@ -666,6 +666,7 @@ std::string Acquisition::get_meta_header() {
   rapidjson::Document document;
   document.SetObject();
   add_string_to_document(META_ACQID_KEY, acquisition_id_, &document);
+  add_uint64_to_document(META_RANK_KEY, concurrent_rank_, &document);
 
   return document_to_string(document);
 }

--- a/tools/python/odin_data/ipc_message.py
+++ b/tools/python/odin_data/ipc_message.py
@@ -77,6 +77,9 @@ class IpcMessage(object):
 
         return param_value
 
+    def get_params(self):
+        return self.attrs['params']
+
     def set_msg_type(self, msg_type):
         self.attrs['msg_type'] = msg_type
 

--- a/tools/python/odin_data/logconfig.py
+++ b/tools/python/odin_data/logconfig.py
@@ -13,6 +13,25 @@ import getpass
 import threading
 
 
+class ColourFormatter(logging.Formatter):
+
+    BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
+    RESET_SEQ = "\033[0m"
+    COLOUR_SEQ = "\033[9{colour_code}m"
+    FORMATS = {
+        logging.DEBUG: COLOUR_SEQ.format(colour_code=GREEN),
+        logging.INFO: COLOUR_SEQ.format(colour_code=BLUE),
+        logging.WARNING: COLOUR_SEQ.format(colour_code=YELLOW),
+        logging.ERROR: COLOUR_SEQ.format(colour_code=RED),
+        logging.CRITICAL: COLOUR_SEQ.format(colour_code=MAGENTA)
+    }
+
+    def format(self, record):
+        record.colour = self.FORMATS.get(record.levelno)  # Replaces %(colour)
+        record.reset = self.RESET_SEQ  # Replaces %(reset)
+        return super(ColourFormatter, self).format(record)
+
+
 default_config = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -21,7 +40,9 @@ default_config = {
             "format": "%(message)s"
         },
         "extended": {
-            "format": "%(asctime)s - %(name)20s - %(levelname)7s - %(message)s"
+            "format": "%(colour)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(reset)s %(message)s",
+            "datefmt": "%y%m%d %H:%M:%S",
+            "()": ColourFormatter  # '()' is a special key to define the formatter class
         },
         "json": {
             "format": "name: %(name)s, level: %(levelname)s, time: %(asctime)s, message: %(message)s"

--- a/tools/python/odin_data/logconfig.py
+++ b/tools/python/odin_data/logconfig.py
@@ -152,6 +152,10 @@ def add_logger(logger_name, logger_description):
     default_config["loggers"][logger_name] = logger_description
 
 
+def set_log_level(level, logger="root"):
+    default_config[logger]["level"] = level
+
+
 def setup_logging(default_log_config=None,
                   default_level=logging.INFO,
                   env_key='LOG_CFG'):

--- a/tools/python/odin_data/meta_writer/hdf5dataset.py
+++ b/tools/python/odin_data/meta_writer/hdf5dataset.py
@@ -131,6 +131,15 @@ class HDF5Dataset(object):
         self._h5py_dataset.flush()
 
 
+class Int32HDF5Dataset(HDF5Dataset):
+    """Int32 HDF5Dataset"""
+
+    def __init__(self, name, shape=None, cache=True):
+        super(Int32HDF5Dataset, self).__init__(
+            name, dtype="int32", fillvalue=-1, shape=shape, cache=cache
+        )
+
+
 class Int64HDF5Dataset(HDF5Dataset):
     """Int64 HDF5Dataset"""
 

--- a/tools/python/odin_data/meta_writer/hdf5dataset.py
+++ b/tools/python/odin_data/meta_writer/hdf5dataset.py
@@ -6,12 +6,13 @@ import numpy as np
 class HDF5Dataset(object):
     """A wrapper of h5py.Dataset with a cache to reduce I/O"""
 
-    def __init__(self, name, dtype, fillvalue, shape=None, cache=True):
+    def __init__(self, name, dtype, fillvalue, rank=1, shape=None, cache=True):
         """
         Args:
             name(str): Name to pass to h5py.Dataset (and for log messages)
             dtype(str) Datatype to pass to h5py.Dataset
             fillvalue(value matching dtype): Fill value for h5py.Dataset
+            rank(int): The rank (number of dimensions) of the dataset
             shape(tuple(int)): Shape to pass to h5py.Dataset
             cache(bool): Whether to store a local cache of values
                          or write directly to file
@@ -20,8 +21,8 @@ class HDF5Dataset(object):
         self.name = name
         self.dtype = dtype
         self.fillvalue = fillvalue
-        self.shape = shape if shape is not None else (0,)
-        self.maxshape = shape if shape is not None else (None,)
+        self.shape = shape if shape is not None else (0,)*rank
+        self.maxshape = shape if shape is not None else (None,)*rank
 
         if cache:
             self._cache = np.full(shape, self.fillvalue, dtype=self.dtype)

--- a/tools/python/odin_data/meta_writer/hdf5dataset.py
+++ b/tools/python/odin_data/meta_writer/hdf5dataset.py
@@ -43,6 +43,10 @@ class HDF5Dataset(object):
         """
         self._h5py_dataset = dataset_handle
 
+        # Turn off the cache if the dataset_size is set to 0 (unlimited)
+        if dataset_size == 0:
+            self._cache = None
+
         if self._cache is not None and dataset_size is not None:
             self._cache = np.full(dataset_size, self.fillvalue, dtype=self.dtype)
             self._h5py_dataset.resize(dataset_size, axis=0)

--- a/tools/python/odin_data/meta_writer/hdf5dataset.py
+++ b/tools/python/odin_data/meta_writer/hdf5dataset.py
@@ -33,7 +33,7 @@ class HDF5Dataset(object):
 
         self._logger = logging.getLogger("HDF5Dataset")
 
-    def initialise(self, dataset_handle, dataset_size=None):
+    def initialise(self, dataset_handle, dataset_size):
         """Initialise _h5py_dataset handle and cache
 
         Args:
@@ -47,7 +47,7 @@ class HDF5Dataset(object):
         if dataset_size == 0:
             self._cache = None
 
-        if self._cache is not None and dataset_size is not None:
+        if self._cache is not None:
             self._cache = np.full(dataset_size, self.fillvalue, dtype=self.dtype)
             self._h5py_dataset.resize(dataset_size, axis=0)
 

--- a/tools/python/odin_data/meta_writer/hdf5dataset.py
+++ b/tools/python/odin_data/meta_writer/hdf5dataset.py
@@ -1,0 +1,111 @@
+import logging
+
+import numpy as np
+
+
+class HDF5Dataset(object):
+    """A wrapper of h5py.Dataset with a cache to reduce I/O"""
+
+    def __init__(self, name, dtype, fillvalue, shape=None, cache=True):
+        """
+        Args:
+            name(str): Name to pass to h5py.Dataset (and for log messages)
+            dtype(str) Datatype to pass to h5py.Dataset
+            fillvalue(value matching dtype): Fill value for h5py.Dataset
+            shape(tuple(int)): Shape to pass to h5py.Dataset
+            cache(bool): Whether to store a local cache of values
+                         or write directly to file
+
+        """
+        self.name = name
+        self.dtype = dtype
+        self.fillvalue = fillvalue
+        self.shape = shape if shape is not None else (0,)
+        self.maxshape = shape if shape is not None else (None,)
+
+        if cache:
+            self._cache = np.full(shape, self.fillvalue, dtype=self.dtype)
+        else:
+            self._cache = None
+
+        self._h5py_dataset = None  # h5py.Dataset
+
+        self._logger = logging.getLogger("HDF5Dataset")
+
+    def initialise(self, dataset_handle, dataset_size=None):
+        """Initialise _h5py_dataset handle and cache
+
+        Args:
+            dataset_handle(h5py.Dataset): Actual h5py Dataset object
+            dataset_size(int): Length of datasets
+
+        """
+        self._h5py_dataset = dataset_handle
+
+        if self._cache is not None and dataset_size is not None:
+            self._cache = np.full(dataset_size, self.fillvalue, dtype=self.dtype)
+            self._h5py_dataset.resize(dataset_size, axis=0)
+
+    def add_value(self, value, offset=None):
+        """Add a value at the given offset
+
+        If we are caching parameters, add the value to the cache, otherwise
+        extend the dataset and write it directly.
+
+        Args:
+            value(object matching dtype): Value to add to dataset
+            offset(int): Offset to insert value at in dataset
+
+        """
+        if self._cache is None:
+            self._h5py_dataset.resize(self._h5py_dataset.shape[0] + 1, axis=0)
+            self._h5py_dataset[-1] = value
+            return
+
+        if offset is not None and offset >= self._cache.size:
+            self._logger.error(
+                "%s | Cannot add value at offset %d, cache length = %d",
+                self.name,
+                offset,
+                len(self._cache),
+            )
+        else:
+            self._cache[offset] = value
+
+    def flush(self):
+        """Write cached values to file (if cache enabled) and call flush"""
+        if self._cache is not None:
+            self._logger.debug(
+                "%s | Writing cache to dataset: %s",
+                self.name,
+                np.array2string(self._cache, threshold=10),
+            )
+            self._h5py_dataset[...] = self._cache
+
+        self._h5py_dataset.flush()
+
+
+class Int64HDF5Dataset(HDF5Dataset):
+    """Int64 HDF5Dataset"""
+
+    def __init__(self, name, shape=None, cache=True):
+        super(Int64HDF5Dataset, self).__init__(
+            name, dtype="int64", fillvalue=-1, shape=shape, cache=cache
+        )
+
+
+class StringHDF5Dataset(HDF5Dataset):
+    """String HDF5Dataset"""
+
+    def __init__(self, name, shape=None, length=None, cache=True):
+        """
+        Args:
+            length(int): Maximum length of the string elements
+
+        """
+        # If a specific string length is given, specify it, else use str
+        dtype = "str" if length is None else "S{}".format(length)
+
+        super(StringHDF5Dataset, self).__init__(
+            name, dtype=dtype, fillvalue="", shape=shape, cache=cache
+        )

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -97,6 +97,10 @@ class MetaListener(object):
                 if sockets.get(ctrl_socket) == zmq.POLLIN:
                     self.handle_control_message(ctrl_socket)
 
+                # Delay handling data until we have a writer configured
+                if not self._writers:
+                    continue
+
                 for socket in data_sockets:
                     if sockets.get(socket) == zmq.POLLIN:
                         self.handle_data_message(socket)

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -250,7 +250,7 @@ class MetaListener(object):
                 stagnant = (
                     writer.active_process_count == 0
                     and writer.write_timeout_count > 10
-                    and writer.file_created
+                    and writer.file_open
                 )
                 if stagnant:
                     self._logger.info("Stopping stagnant writer %s", writer_name)
@@ -309,7 +309,7 @@ class MetaListener(object):
         """
         # First finish any writer that is queued up already but has not started
         for _writer_name, writer in self._writers.items():
-            if not writer.file_created:
+            if not writer.file_open:
                 self._logger.info("Stopping idle writer: %s", _writer_name)
                 writer.stop()
 

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -44,6 +44,7 @@ class MetaListener(object):
         """
         self._ctrl_port = ctrl_port
         self._data_endpoints = data_endpoints
+        self._process_count = len(data_endpoints)
         self._writer_module = writer_module
         self._writers = {}
         self._shutdown_requested = False
@@ -257,7 +258,7 @@ class MetaListener(object):
             else:
                 # TODO: This is bit of a hack...
                 stagnant = (
-                    writer.number_processes_running == 0
+                    writer.active_process_count == 0
                     and writer.write_timeout_count > 10
                     and writer.file_created
                 )
@@ -328,7 +329,9 @@ class MetaListener(object):
         self._logger.info("Creating new writer %s", writer_name)
         writer_class = self._load_writer_class()
         self._logger.debug("Loaded writer class: %s", writer_class)
-        self._writers[writer_name] = writer_class(writer_name, DEFAULT_DIRECTORY)
+        self._writers[writer_name] = writer_class(
+            writer_name, DEFAULT_DIRECTORY, self._process_count
+        )
 
         # Check if we have too many writers and delete any that are finished
         if len(self._writers) > 3:

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -341,7 +341,7 @@ class MetaListener(object):
         """
         self._logger.debug("Loading writer class: %s", writer)
 
-        module, class_name = writer.split(".", 1)
+        module, class_name = writer.rsplit(".", 1)
         module = importlib.import_module(module)
         writer_class = getattr(module, class_name)
 

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -330,6 +330,7 @@ class MetaListener(object):
         self._logger.info("Stopping all writers")
         for writer in self._writers.values():
             writer.stop()
+        self.clear_writers()
 
     def _load_writer(self, writer):
         """Import the writer class from the configured module

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -270,10 +270,7 @@ class MetaListener(object):
         self._logger.debug("Handling configure:\n%s", params)
 
         error = None
-        if WRITER in params:
-            self._logger.info("Setting writer module to %s", params[WRITER])
-            self._writer_module = params[WRITER]
-        elif "acquisition_id" in params:
+        if "acquisition_id" in params:
             # Read and remove acquisition ID from params - writer does not need it
             writer_name = params.pop("acquisition_id")
 

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -14,10 +14,7 @@ import zmq
 
 from odin_data.ipc_message import IpcMessage
 import odin_data._version as versioneer
-
-MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"
-MINOR_VER_REGEX = r"^[0-9]+[\\.-]([0-9]+).*|$"
-PATCH_VER_REGEX = r"^[0-9]+[\\.-][0-9]+[\\.-]([0-9]+).|$"
+from odin_data.util import construct_version_dict
 
 DEFAULT_ACQUISITION_ID = ""
 DEFAULT_DIRECTORY = "/tmp"
@@ -33,24 +30,24 @@ class MetaListener(object):
 
     """
 
-    def __init__(self, ctrl_port, data_endpoints, writer_module):
+    def __init__(self, ctrl_port, data_endpoints, writer):
         """
         Args:
             ctrl_port(int): The port to bind the control channel to
             data_endpoints(list(str)): List of endpoints to receive data on
-              e.g. ["tcp://127.0.0.1:5008", "tcp://127.0.0.1:5018"]
-            writer_module(str): Writer module to import
+                e.g. ["tcp://127.0.0.1:5008", "tcp://127.0.0.1:5018"]
+            writer(str): Full import path for writer class to load
 
         """
         self._ctrl_port = ctrl_port
         self._data_endpoints = data_endpoints
         self._process_count = len(data_endpoints)
-        self._writer_module = writer_module
         self._writers = {}
         self._shutdown_requested = False
 
         self._logger = logging.getLogger(self.__class__.__name__)
 
+        self._writer_class = self._load_writer(writer)
 
     @staticmethod
     def _construct_reply(msg_val, msg_id, error=None):
@@ -65,33 +62,28 @@ class MetaListener(object):
     def run(self):
         """Main application loop"""
         context = zmq.Context()
-        ctrl_socket = None
+        ctrl_endpoint = "tcp://*:{}".format(self._ctrl_port)
+        self._logger.info("Binding control address to %s", ctrl_endpoint)
+        ctrl_socket = context.socket(zmq.ROUTER)
+        ctrl_socket.bind(ctrl_endpoint)
+
         data_sockets = []
+        for endpoint in self._data_endpoints:
+            socket = context.socket(zmq.SUB)
+            socket.set_hwm(10000)
+            socket.connect(endpoint)
+            socket.setsockopt(zmq.SUBSCRIBE, "")
+            data_sockets.append(socket)
 
-        # TODO: Remove or uncomment try except
-        if True:
-            # try:
-            ctrl_endpoint = "tcp://*:{}".format(self._ctrl_port)
-            self._logger.info("Binding control address to %s", ctrl_endpoint)
-            ctrl_socket = context.socket(zmq.ROUTER)
-            ctrl_socket.bind(ctrl_endpoint)
+        poller = zmq.Poller()
+        poller.register(ctrl_socket, zmq.POLLIN)
+        for socket in data_sockets:
+            poller.register(socket, zmq.POLLIN)
 
-            for endpoint in self._data_endpoints:
-                socket = context.socket(zmq.SUB)
-                socket.set_hwm(10000)
-                socket.connect(endpoint)
-                socket.setsockopt(zmq.SUBSCRIBE, "")
-                data_sockets.append(socket)
-
-            poller = zmq.Poller()
-            poller.register(ctrl_socket, zmq.POLLIN)
-            for socket in data_sockets:
-                poller.register(socket, zmq.POLLIN)
-
-            self._logger.info(
-                "Listening for data messages on: %s", ", ".join(self._data_endpoints)
-            )
-
+        self._logger.info(
+            "Listening for data messages on: %s", ", ".join(self._data_endpoints)
+        )
+        try:
             while not self._shutdown_requested:
                 sockets = dict(poller.poll())
 
@@ -105,24 +97,22 @@ class MetaListener(object):
                 for socket in data_sockets:
                     if sockets.get(socket) == zmq.POLLIN:
                         self.handle_data_message(socket)
-
+        except KeyboardInterrupt:
+            self._logger.info("Received KeyboardInterrupt")
+        except:
+            self._logger.error("Unexpected exception - shutting down")
+            raise
+        else:
+            self._logger.info("Shutdown requested")
+        finally:
             self.stop_all_writers()
 
-            self._logger.info("Finished listening")
-        # except Exception as error:
-        #     self._logger.error(
-        #         "Unexpected Exception in application loop: %s",
-        #         self._format_error(error)
-        #     )
-
-        # Finished
-        for socket in data_sockets:
-            socket.close(linger=0)
-
-        if ctrl_socket is not None:
-            ctrl_socket.close(linger=100)
-
-        context.term()
+            self._logger.info("Closing sockets")
+            for socket in data_sockets:
+                socket.close(linger=0)
+            if ctrl_socket is not None:
+                ctrl_socket.close(linger=100)
+            context.term()
 
         self._logger.info("Finished")
 
@@ -246,7 +236,6 @@ class MetaListener(object):
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
         reply.set_param("acquisitions", status_dict)
 
-        # Now delete any finished writers, and stop any stagnant ones
         for writer_name, writer in self._writers.items():
             if writer.finished:
                 del self._writers[writer_name]
@@ -322,9 +311,7 @@ class MetaListener(object):
 
         # Now create new acquisition
         self._logger.info("Creating new writer %s", writer_name)
-        writer_class = self._load_writer_class()
-        self._logger.debug("Loaded writer class: %s", writer_class)
-        self._writers[writer_name] = writer_class(
+        self._writers[writer_name] = self._writer_class(
             writer_name, DEFAULT_DIRECTORY, self._process_count
         )
 
@@ -340,30 +327,23 @@ class MetaListener(object):
         for writer in self._writers.values():
             writer.stop()
 
-    def _load_writer_class(self):
+    def _load_writer(self, writer):
         """Import the writer class from the configured module
 
         Returns:
             class: The writer class to instantiate
 
         """
-        # TODO: Clarify use of class and module
-        if self._writer_module is None:
-            raise Exception("No writer class configured")
-
-        module_name = self._writer_module[: self._writer_module.rfind(".")]
-        class_name = self._writer_module[self._writer_module.rfind(".") + 1 :]
+        self._logger.debug("Loading writer class: %s", writer)
+        module_name = writer[: writer.rfind(".")]  # Everything up to last '.'
+        class_name = writer[writer.rfind(".") + 1 :]  # Everything after last '.'
         module = importlib.import_module(module_name)
         writer_class = getattr(module, class_name)
 
         return writer_class
 
     def _get_writer_version(self):
-        if self._writer_module is None:
-            raise Exception("No writer class configured")
-
-        writer_class = self._load_writer_class()
-        return writer_class.get_version()
+        return self._writer_class.get_version()
 
     def request_configuration(self, request):
         """Handle a configuration request message
@@ -377,17 +357,13 @@ class MetaListener(object):
         """
         self._logger.debug("Handling request configuration")
 
-        writer_dict = {}
-        for writer_name in self._writers:
-            writer = self._writers[writer_name]
-            writer_dict[writer_name] = {
-                "directory": writer.directory,
-                "flush_frame_frequency": writer.flush_frame_frequency,
-                "file_prefix": writer.file_prefix,
-            }
+        writer_config = dict(
+            (writer_name, writer.request_configuration())
+            for writer_name, writer in self._writers.items()
+        )
 
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
-        reply.set_param("acquisitions", writer_dict)
+        reply.set_param("acquisitions", writer_config)
         reply.set_param("data_endpoints", self._data_endpoints)
         reply.set_param("ctrl_port", self._ctrl_port)
         return reply
@@ -405,21 +381,11 @@ class MetaListener(object):
         self._logger.debug("Handling version request")
 
         version = versioneer.get_versions()["version"]
-        major_version = re.findall(MAJOR_VER_REGEX, version)[0]
-        minor_version = re.findall(MINOR_VER_REGEX, version)[0]
-        patch_version = re.findall(PATCH_VER_REGEX, version)[0]
-        short_version = major_version + "." + minor_version + "." + patch_version
 
-        odin_data_dict = {}
-        odin_data_dict["full"] = version
-        odin_data_dict["major"] = major_version
-        odin_data_dict["minor"] = minor_version
-        odin_data_dict["patch"] = patch_version
-        odin_data_dict["short"] = short_version
-
-        version_dict = {}
-        version_dict["odin-data"] = odin_data_dict
-        version_dict[WRITER] = self._get_writer_version()
+        version_dict = {
+            "odin-data": construct_version_dict(version),
+            WRITER: self._get_writer_version()
+        }
 
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
         reply.set_param("version", version_dict)

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -236,6 +236,12 @@ class MetaListener(object):
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
         reply.set_param("acquisitions", status_dict)
 
+        if len(self._writers) > 1:
+            self.clear_writers()
+
+        return reply
+
+    def clear_writers(self):
         for writer_name, writer in self._writers.items():
             if writer.finished:
                 del self._writers[writer_name]
@@ -249,8 +255,6 @@ class MetaListener(object):
                 if stagnant:
                     self._logger.info("Stopping stagnant writer %s", writer_name)
                     writer.stop()
-
-        return reply
 
     def configure(self, request):
         """Handle a configuration message
@@ -335,9 +339,9 @@ class MetaListener(object):
 
         """
         self._logger.debug("Loading writer class: %s", writer)
-        module_name = writer[: writer.rfind(".")]  # Everything up to last '.'
-        class_name = writer[writer.rfind(".") + 1 :]  # Everything after last '.'
-        module = importlib.import_module(module_name)
+
+        module, class_name = writer.split(".", 1)
+        module = importlib.import_module(module)
         writer_class = getattr(module, class_name)
 
         return writer_class

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -5,10 +5,12 @@ on to a MetaWriter to write. Also handles odin Ipc control messages.
 
 Matt Taylor, Diamond Light Source
 """
-import zmq
 import logging
 import re
+from json import loads
 import importlib
+
+import zmq
 
 from odin_data.ipc_message import IpcMessage
 import odin_data._version as versioneer
@@ -17,362 +19,420 @@ MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"
 MINOR_VER_REGEX = r"^[0-9]+[\\.-]([0-9]+).*|$"
 PATCH_VER_REGEX = r"^[0-9]+[\\.-][0-9]+[\\.-]([0-9]+).|$"
 
-class MetaListener:
-    """Meta Listener class.
+DEFAULT_ACQUISITION_ID = ""
+DEFAULT_DIRECTORY = "/tmp"
 
-    This class listens on ZeroMQ sockets for incoming cnotrol and meta data messages
+WRITER = "writer"
+
+
+class MetaListener(object):
+    """
+    This class listens on ZeroMQ sockets for incoming control messages for
+    configuration and gathers data messages from data endpoints to pass on to
+    the loaded writer class.
+
     """
 
-    def __init__(self, directory, inputs, ctrl, writer_module):
-        """Initalise the MetaListener object.
-
-        :param directory: Directory to create the meta file in
-        :param inputs: Comma separated list of input ZMQ addresses
-        :param ctrl: Port to use for control messages
-        :param writer_module: Detector writer class
+    def __init__(self, ctrl_port, data_endpoints, writer_module):
         """
-        self._inputs = inputs
-        self._directory = directory
-        self._ctrl_port = str(ctrl)
+        Args:
+            ctrl_port(int): The port to bind the control channel to
+            data_endpoints(list(str)): List of endpoints to receive data on
+              e.g. ["tcp://127.0.0.1:5008", "tcp://127.0.0.1:5018"]
+            writer_module(str): Writer module to import
+
+        """
+        self._ctrl_port = ctrl_port
+        self._data_endpoints = data_endpoints
         self._writer_module = writer_module
         self._writers = {}
-        self._kill_requested = False
+        self._shutdown_requested = False
 
-        # create logger
-        self.logger = logging.getLogger('meta_listener')
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+
+    @staticmethod
+    def _construct_reply(msg_val, msg_id, error=None):
+        reply = IpcMessage(IpcMessage.ACK, msg_val, id=msg_id)
+
+        if error is not None:
+            reply.set_msg_type(IpcMessage.NACK)
+            reply.set_param("error", error)
+
+        return reply
 
     def run(self):
-        """Main application loop."""
-        self.logger.info('Starting Meta listener...')
-
-        receiver_list = []
+        """Main application loop"""
         context = zmq.Context()
         ctrl_socket = None
+        data_sockets = []
 
-        try:
-            inputs_list = self._inputs.split(',')
-
-            # Control socket
-            ctrl_address = "tcp://*:" + self._ctrl_port
-            self.logger.info('Binding control address to ' + ctrl_address)
+        # TODO: Remove or uncomment try except
+        if True:
+            # try:
+            ctrl_endpoint = "tcp://*:{}".format(self._ctrl_port)
+            self._logger.info("Binding control address to %s", ctrl_endpoint)
             ctrl_socket = context.socket(zmq.ROUTER)
-            ctrl_socket.bind(ctrl_address)
+            ctrl_socket.bind(ctrl_endpoint)
 
-            # Socket to receive messages on
-            for x in inputs_list:
-                new_receiver = context.socket(zmq.SUB)
-                new_receiver.set_hwm(10000)
-                new_receiver.connect(x)
-                new_receiver.setsockopt(zmq.SUBSCRIBE, '')
-                receiver_list.append(new_receiver)
+            for endpoint in self._data_endpoints:
+                socket = context.socket(zmq.SUB)
+                socket.set_hwm(10000)
+                socket.connect(endpoint)
+                socket.setsockopt(zmq.SUBSCRIBE, "")
+                data_sockets.append(socket)
 
             poller = zmq.Poller()
-            for eachReceiver in receiver_list:
-                poller.register(eachReceiver, zmq.POLLIN)
-
             poller.register(ctrl_socket, zmq.POLLIN)
+            for socket in data_sockets:
+                poller.register(socket, zmq.POLLIN)
 
-            self.logger.info('Listening to inputs ' + str(inputs_list))
+            self._logger.info(
+                "Listening for data messages on: %s", ", ".join(self._data_endpoints)
+            )
 
-            while self._kill_requested == False:
-                socks = dict(poller.poll())
-                for receiver in receiver_list:
-                    if socks.get(receiver) == zmq.POLLIN:
-                        self.handle_message(receiver)
+            while not self._shutdown_requested:
+                sockets = dict(poller.poll())
 
-                if socks.get(ctrl_socket) == zmq.POLLIN:
+                if sockets.get(ctrl_socket) == zmq.POLLIN:
                     self.handle_control_message(ctrl_socket)
+
+                for socket in data_sockets:
+                    if sockets.get(socket) == zmq.POLLIN:
+                        self.handle_data_message(socket)
 
             self.stop_all_writers()
 
-            self.logger.info('Finished listening')
-        except Exception as err:
-            self.logger.error('Unexpected Exception: ' + str(err))
+            self._logger.info("Finished listening")
+        # except Exception as error:
+        #     self._logger.error(
+        #         "Unexpected Exception in application loop: %s",
+        #         self._format_error(error)
+        #     )
 
         # Finished
-        for receiver in receiver_list:
-            receiver.close(linger=0)
+        for socket in data_sockets:
+            socket.close(linger=0)
 
         if ctrl_socket is not None:
             ctrl_socket.close(linger=100)
 
         context.term()
 
-        self.logger.info("Finished run")
-        return
+        self._logger.info("Finished")
 
-    def handle_control_message(self, receiver):
-        """Handle control message.
+    def handle_data_message(self, socket):
+        """Handle a data message on the given socket
 
-        :param: receiver: ZeroMQ channel to receive message from
+        Args:
+            socket(zmq.Socket): The socket to receive a message on
+
         """
-        channel_id = receiver.recv()
-        message_val = ""
-        message_id = 0
+        self._logger.debug("Handling data message")
 
-        try:
-            message = IpcMessage(from_str=receiver.recv())
-            message_val = message.get_msg_val()
-            message_id = message.get_msg_id()
+        # Receive the first part of the two part message
+        # This is a json string with the following:
+        #   - header: Any control parameters that do not go into the data file
+        #       e.g. the total number of frames that will be written
+        #   - type: The type of the second part of the message
+        #   - parameter: The message type ID to determine how to handle it
+        #   - plugin: The source, e.g. the class name that sent the message
 
-            if message.get_msg_val() == 'status':
-                reply = self.handle_status_message(message_id)
-            elif message.get_msg_val() == 'request_configuration':
-                reply = self.handle_request_config_message(message_id)
-            elif message.get_msg_val() == 'request_version':
-                reply = self.handle_request_version_message(message_id)
-            elif message.get_msg_val() == 'configure':
-                self.logger.debug('handling control configure message')
-                self.logger.debug(message)
-                params = message.attrs['params']
-                reply = self.handle_configure_message(params, message_id)
+        header = socket.recv_json()
+        self._logger.debug("Header message:\n%s", header)
+
+        acquisition_id = header["header"].get("acqID", DEFAULT_ACQUISITION_ID)
+        if acquisition_id == DEFAULT_ACQUISITION_ID:
+            self._logger.debug("Using default acquisition ID")
+        if acquisition_id not in self._writers:
+            self._logger.debug(
+                "No writer configured for acquisition ID %s", acquisition_id
+            )
+            socket.recv()
+            return
+
+        writer = self._writers[acquisition_id]
+        if writer.finished:
+            self._logger.debug(
+                "Writer for acquisition ID %s already finished", acquisition_id
+            )
+            socket.recv()
+            return
+
+        # Receive the second part of the two part message
+        # This contains the actual meta data to be written to file
+        # The content could be:
+        #   - A json string with one or more meta data items
+        #   - A data blob - for example a pixel mask
+
+        if header["type"] == "raw":
+            data = socket.recv()
+            self._logger.debug("Data message part is a data blob")
+        else:
+            data = socket.recv()
+            if data:
+                try:
+                    data = loads(data)
+                except ValueError:
+                    self._logger.error("Failed to load json from message: %s", data)
+                    return
+                else:
+                    self._logger.debug("Data message:\n%s", data)
             else:
-                reply = IpcMessage(IpcMessage.NACK, message_val, id=message_id)
-                reply.set_param('error', 'Unknown message value type')
+                self._logger.debug("Data message empty")
 
-        except Exception as err:
-            self.logger.error('Unexpected Exception handling control message: ' + str(err))
-            reply = IpcMessage(IpcMessage.NACK, message_val, id=message_id)
-            reply.set_param('error', 'Error processing control message')
+        writer.process_message(header, data)
 
-        receiver.send(channel_id, zmq.SNDMORE)
-        receiver.send(reply.encode())
+    # Methods for handling the control channel
 
-    def handle_status_message(self, msg_id):
-        """Handle status message.
+    def handle_control_message(self, socket):
+        """Handle a control message on the given socket
 
-        :param: msg_id: message id to use for reply
+        Args:
+            socket(zmq.Socket): The socket to receive a message and reply on
+
         """
+        message_handlers = {
+            "status": self.status,
+            "configure": self.configure,
+            "request_configuration": self.request_configuration,
+            "request_version": self.version,
+            "shutdown": self.shutdown,
+        }
+
+        # The first message part is a channel ID
+        channel_id = socket.recv()
+
+        # The second message part is the IpcMessage
+        message = IpcMessage(from_str=socket.recv())
+        request_type = message.get_msg_val()
+
+        handler = message_handlers.get(request_type, None)
+        if handler is not None:
+            reply = handler(message)
+        else:
+            error = "Unknown request type: {}".format(request_type)
+            self._logger.error(error)
+            reply = self._construct_reply(
+                message.get_msg_val(), message.get_msg_id(), error
+            )
+
+        socket.send(channel_id, zmq.SNDMORE)
+        socket.send(reply.encode())
+
+    def status(self, request):
+        """Handle a status request message
+
+        Args:
+            request(IpcMessage): The request message
+
+        Returns:
+            reply(IpcMessage): Reply containing current status
+
+        """
+        self._logger.debug("Handling status request")
+
         status_dict = {}
-        for key in self._writers:
-            writer = self._writers[key]
-            status_dict[key] = {'filename': writer.full_file_name, 'num_processors': writer.number_processes_running,
-                                'written': writer.write_count, 'writing': writer.file_created and not writer.finished}
+        for writer_name in self._writers:
+            writer = self._writers[writer_name]
+            status_dict[writer_name] = {
+                "filename": writer.full_file_path,
+                "num_processors": writer.number_processes_running,
+                "written": writer.write_count,
+                "writing": writer.file_created and not writer.finished,
+            }
             writer.write_timeout_count = writer.write_timeout_count + 1
 
-        reply = IpcMessage(IpcMessage.ACK, 'status', id=msg_id)
-        reply.set_param('acquisitions', status_dict)
+        reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
+        reply.set_param("acquisitions", status_dict)
 
-        # Now delete any finished acquisitions, and stop any stagnant ones
-        for key, value in self._writers.items():
-            if value.finished:
-                del self._writers[key]
+        # Now delete any finished writers, and stop any stagnant ones
+        for writer_name, writer in self._writers.items():
+            if writer.finished:
+                del self._writers[writer_name]
             else:
-                if value.number_processes_running == 0 and value.write_timeout_count > 10 and value.file_created:
-                    self.logger.info('Force stopping stagnant acquisition: ' + str(key))
-                    value.stop()
+                # TODO: This is bit of a hack...
+                stagnant = (
+                    writer.number_processes_running == 0
+                    and writer.write_timeout_count > 10
+                    and writer.file_created
+                )
+                if stagnant:
+                    self._logger.info("Stopping stagnant writer %s", writer_name)
+                    writer.stop()
 
         return reply
 
-    def handle_request_config_message(self, msg_id):
-        """Handle request config message.
+    def configure(self, request):
+        """Handle a configuration message
 
-        :param: msg_id: message id to use for reply
+        Args:
+            request(IpcMessage): The request message
+
+        Returns:
+            reply(IpcMessage): Reply containing current configuration
+
         """
-        acquisitions_dict = {}
-        for key in self._writers:
-            writer = self._writers[key]
-            acquisitions_dict[key] = {'output_dir': writer.directory, 'flush': writer.flush_frequency,
-                                      'file_prefix': writer.file_prefix}
+        params = request.get_params()
+        self._logger.debug("Handling configure:\n%s", params)
 
-        reply = IpcMessage(IpcMessage.ACK, 'request_configuration', id=msg_id)
-        reply.set_param('acquisitions', acquisitions_dict)
-        reply.set_param('inputs', self._inputs)
-        reply.set_param('default_directory', self._directory)
-        reply.set_param('ctrl_port', self._ctrl_port)
+        error = None
+        if WRITER in params:
+            self._logger.info("Setting writer module to %s", params[WRITER])
+            self._writer_module = params[WRITER]
+        elif "acquisition_id" in params:
+            # Read and remove acquisition ID from params - writer does not need it
+            writer_name = params.pop("acquisition_id")
+
+            # Check for stop before anything else
+            if "stop" in params:
+                if writer_name is not None and writer_name in self._writers:
+                    self._writers[writer_name].stop()
+                else:
+                    # Stop without an acquisition ID stops all acquisitions
+                    self.stop_all_writers()
+            else:
+                if writer_name in self._writers:
+                    self._logger.debug("Configuring existing writer: %s", writer_name)
+                else:
+                    self.create_new_writer(writer_name)
+
+                self._logger.info(
+                    "Configuring writer %s with params: %s", writer_name, params
+                )
+                error = self._writers[writer_name].configure(params)
+
+        else:
+            error = "No params in config"
+
+        return self._construct_reply(request.get_msg_val(), request.get_msg_id(), error)
+
+    def create_new_writer(self, writer_name):
+        """Create a new writer to handle meta messages for a new acquisition
+
+        Args:
+            writer_name(str): Unique name to identify this writer
+
+        """
+        # First finish any writer that is queued up already but has not started
+        for _writer_name, writer in self._writers.items():
+            if not writer.file_created:
+                self._logger.info("Stopping idle writer: %s", _writer_name)
+                writer.stop()
+
+        # Now create new acquisition
+        self._logger.info("Creating new writer %s", writer_name)
+        writer_class = self._load_writer_class()
+        self._logger.debug("Loaded writer class: %s", writer_class)
+        self._writers[writer_name] = writer_class(writer_name, DEFAULT_DIRECTORY)
+
+        # Check if we have too many writers and delete any that are finished
+        if len(self._writers) > 3:
+            for writer_name, writer in self._writers.items():
+                if writer.finished:
+                    del self._writers[writer_name]
+
+    def stop_all_writers(self):
+        """Iterate all writers and call stop"""
+        self._logger.info("Stopping all writers")
+        for writer in self._writers.values():
+            writer.stop()
+
+    def _load_writer_class(self):
+        """Import the writer class from the configured module
+
+        Returns:
+            class: The writer class to instantiate
+
+        """
+        # TODO: Clarify use of class and module
+        if self._writer_module is None:
+            raise Exception("No writer class configured")
+
+        module_name = self._writer_module[: self._writer_module.rfind(".")]
+        class_name = self._writer_module[self._writer_module.rfind(".") + 1 :]
+        module = importlib.import_module(module_name)
+        writer_class = getattr(module, class_name)
+
+        return writer_class
+
+    def _get_writer_version(self):
+        if self._writer_module is None:
+            raise Exception("No writer class configured")
+
+        writer_class = self._load_writer_class()
+        return writer_class.get_version()
+
+    def request_configuration(self, request):
+        """Handle a configuration request message
+
+        Args:
+            request(IpcMessage): The request message
+
+        Returns:
+            reply(IpcMessage): Reply containing current configuration
+
+        """
+        self._logger.debug("Handling request configuration")
+
+        writer_dict = {}
+        for writer_name in self._writers:
+            writer = self._writers[writer_name]
+            writer_dict[writer_name] = {
+                "directory": writer.directory,
+                "flush_frame_frequency": writer.flush_frame_frequency,
+                "file_prefix": writer.file_prefix,
+            }
+
+        reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
+        reply.set_param("acquisitions", writer_dict)
+        reply.set_param("data_endpoints", self._data_endpoints)
+        reply.set_param("ctrl_port", self._ctrl_port)
         return reply
-        
-    def handle_request_version_message(self, msg_id):
-        """Handle request version message.
 
-        :param: msg_id: message id to use for reply
+    def version(self, request):
+        """Handle request version message
+
+        Args:
+            request(IpcMessage): The request message
+
+        Returns:
+            reply(IpcMessage): Reply containing version status
+
         """
-        reply = IpcMessage(IpcMessage.ACK, 'request_version', id=msg_id)
-        
-        version=versioneer.get_versions()["version"]
+        self._logger.debug("Handling version request")
+
+        version = versioneer.get_versions()["version"]
         major_version = re.findall(MAJOR_VER_REGEX, version)[0]
         minor_version = re.findall(MINOR_VER_REGEX, version)[0]
         patch_version = re.findall(PATCH_VER_REGEX, version)[0]
         short_version = major_version + "." + minor_version + "." + patch_version
-        
-        version_dict = {}
+
         odin_data_dict = {}
-        
         odin_data_dict["full"] = version
         odin_data_dict["major"] = major_version
         odin_data_dict["minor"] = minor_version
         odin_data_dict["patch"] = patch_version
         odin_data_dict["short"] = short_version
-        
+
+        version_dict = {}
         version_dict["odin-data"] = odin_data_dict
-        version_dict["writer"] = self.get_writer_version()
-        
-        reply.set_param('version', version_dict)
+        version_dict[WRITER] = self._get_writer_version()
+
+        reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())
+        reply.set_param("version", version_dict)
         return reply
 
-    def handle_configure_message(self, params, msg_id):
-        """Handle configure message.
+    def shutdown(self, request):
+        """Handle request shutdown message
 
-        :param: params: dictionary of configuration parameters
-        :param: msg_id: message id to use for reply
+        Args:
+            request(IpcMessage): The request message
+
+        Returns:
+            reply(IpcMessage): Reply confirming shutdown
+
         """
-        reply = IpcMessage(IpcMessage.NACK, 'configure', id=msg_id)
-        reply.set_param('error', 'Unable to process configure command')
-
-        if 'kill' in params:
-            self.logger.info('Kill requested')
-            reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-            self._kill_requested = True
-        elif 'writer' in params:
-            self.logger.info('Setting writer module to ' + str(params['writer']))
-            self._writer_module = params['writer']
-            reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-        elif 'acquisition_id' in params:
-            acquisition_id = params['acquisition_id']
-
-            if acquisition_id is not None:
-                if acquisition_id in self._writers:
-                    self.logger.debug('Writer is in writers for acq ' + str(acquisition_id))
-                else:
-                    self.logger.debug('Writer not in writers for acquisition [' + str(acquisition_id) + ']')
-                    self.logger.debug(
-                        'Creating new acquisition [' + str(acquisition_id) + '] with default directory ' + str(
-                            self._directory))
-                    self.create_new_acquisition(self._directory, acquisition_id)
-
-                if 'output_dir' in params:
-                    self.logger.debug('Setting acquisition [' + str(acquisition_id) + '] directory to ' + str(
-                        params['output_dir']))
-                    self._writers[acquisition_id].directory = params['output_dir']
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-
-                if 'file_prefix' in params:
-                    self.logger.debug('Setting acquisition [' + str(acquisition_id) + '] file_prefix to ' + str(
-                        params['file_prefix']))
-                    self._writers[acquisition_id].file_prefix = params['file_prefix']
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-
-                if 'flush' in params:
-                    self.logger.debug(
-                        'Setting acquisition [' + str(acquisition_id) + '] flush to ' + str(params['flush']))
-                    self._writers[acquisition_id].flush_frequency = int(params['flush'])
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-
-                if 'flush_timeout' in params:
-                    self.logger.debug('Setting acquisition [' + str(acquisition_id) + '] flush timeout to ' + str(
-                        params['flush_timeout']))
-                    self._writers[acquisition_id].flush_timeout = int(params['flush_timeout'])
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-
-                if 'stop' in params:
-                    self.logger.info('Stopping acquisition [' + str(acquisition_id) + ']')
-                    self._writers[acquisition_id].stop()
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-            else:
-                # If the command is to stop without an acqID then stop all acquisitions
-                if 'stop' in params:
-                    self.stop_all_writers()
-                    reply = IpcMessage(IpcMessage.ACK, 'configure', id=msg_id)
-                else:
-                    reply = IpcMessage(IpcMessage.NACK, 'configure', id=msg_id)
-                    reply.set_param('error', 'Acquisition ID was None')
-
-        else:
-            reply = IpcMessage(IpcMessage.NACK, 'configure', id=msg_id)
-            reply.set_param('error', 'No params in config')
-        return reply
-
-    def handle_message(self, receiver):
-        """Handle a meta data message.
-
-        :param: receiver: ZeroMQ channel to read message from
-        """
-        self.logger.debug('Handling message')
-
-        try:
-            message = receiver.recv_json()
-            self.logger.debug(message)
-            userheader = message['header']
-
-            if 'acqID' in userheader:
-                acquisition_id = userheader['acqID']
-            else:
-                self.logger.warn('Didnt have acquisition id in header')
-                acquisition_id = ''
-
-            if acquisition_id not in self._writers:
-                self.logger.error('No writer for acquisition [' + acquisition_id + ']')
-                receiver.recv()
-                return
-
-            writer = self._writers[acquisition_id]
-
-            if writer.finished:
-                self.logger.error('Writer finished for acquisition [' + acquisition_id + ']')
-                receiver.recv()
-                return
-
-            writer.process_message(message, userheader, receiver)
-
-        except Exception as err:
-            self.logger.error('Unexpected Exception handling message: ' + str(err))
-
-        return
-
-    def create_new_acquisition(self, directory, acquisition_id):
-        """Create a new writer to handle meta messages for a new acquisition.
-
-        :param: directory: Directory to create the meta file in
-        :param: acquisition_id: Acquisition ID of the new acquisition
-        """
-        # First finish any acquisition that is queued up already which hasn't started
-        for key, value in self._writers.items():
-            if value.finished == False and value.number_processes_running == 0 and value.file_created == False:
-                self.logger.info('Force finishing unused acquisition: ' + str(key))
-                value.finished = True
-
-        # Now create new acquisition
-        self.logger.info('Creating new acquisition [' + str(acquisition_id) + '] with directory ' + str(directory))
-        self._writers[acquisition_id] = self.create_new_writer(directory, acquisition_id)
-
-        # Then check if we have built up too many finished acquisitions and delete them if so
-        if len(self._writers) > 3:
-            for key, value in self._writers.items():
-                if value.finished:
-                    del self._writers[key]
-                    
-    def stop_all_writers(self):
-        """Force stop all writers."""
-        for key in self._writers:
-            self.logger.info('Forcing close of writer for acquisition: ' + str(key))
-            writer = self._writers[key]
-            writer.stop()
-
-    def create_new_writer(self, directory, acquisition_id):
-        """Create a the appropriate writer object.
-
-        :param: directory: Directory to create the meta file in
-        :param: acquisition_id: Acquisition ID of the new acquisition
-        """        
-        if self._writer_module is None:
-            raise Exception('No writer class configured')
-        
-        module_name = self._writer_module[:self._writer_module.rfind('.')]
-        class_name = self._writer_module[self._writer_module.rfind('.') + 1:]        
-        module = importlib.import_module(module_name, package=None)
-        writer_class = getattr(module, class_name)
-        writer_instance = writer_class(self.logger, directory, acquisition_id)
-        self.logger.debug(writer_instance)
-        return writer_instance
-
-    def get_writer_version(self):
-        """Get the version from the writer object."""
-        if self._writer_module is None:
-            raise Exception('No writer class configured')
-          
-        module_name = self._writer_module[:self._writer_module.rfind('.')]
-        class_name = self._writer_module[self._writer_module.rfind('.') + 1:]
-        module = importlib.import_module(module_name, package=None)
-        writer_class = getattr(module, class_name)
-        writer_version = writer_class.get_version()
-        return writer_version
+        self._logger.info("Handling shutdown request")
+        self._shutdown_requested = True
+        return self._construct_reply(request.get_msg_val(), request.get_msg_id())

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -240,12 +240,7 @@ class MetaListener(object):
         status_dict = {}
         for writer_name in self._writers:
             writer = self._writers[writer_name]
-            status_dict[writer_name] = {
-                "filename": writer.full_file_path,
-                "num_processors": writer.number_processes_running,
-                "written": writer.write_count,
-                "writing": writer.file_created and not writer.finished,
-            }
+            status_dict[writer_name] = writer.status()
             writer.write_timeout_count = writer.write_timeout_count + 1
 
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())

--- a/tools/python/odin_data/meta_writer/meta_listener.py
+++ b/tools/python/odin_data/meta_writer/meta_listener.py
@@ -344,9 +344,6 @@ class MetaListener(object):
 
         return writer_class
 
-    def _get_writer_version(self):
-        return self._writer_class.get_version()
-
     def request_configuration(self, request):
         """Handle a configuration request message
 
@@ -384,9 +381,10 @@ class MetaListener(object):
 
         version = versioneer.get_versions()["version"]
 
+        writer_repo, writer_version_dict = self._writer_class.get_version()
         version_dict = {
             "odin-data": construct_version_dict(version),
-            WRITER: self._get_writer_version()
+            writer_repo: writer_version_dict
         }
 
         reply = self._construct_reply(request.get_msg_val(), request.get_msg_id())

--- a/tools/python/odin_data/meta_writer/meta_writer.py
+++ b/tools/python/odin_data/meta_writer/meta_writer.py
@@ -292,6 +292,31 @@ class MetaWriter(object):
 
     # Methods for handling various message types
 
+    @property
+    def message_handlers(self):
+        """Dictionary of message type to handler method
+
+        This should be overridden by child classes to add additional handlers
+
+        Returns:
+            dict: message type handler methods
+
+        """
+        message_handlers = {
+            "startacquisition": self.handle_start_acquisition,
+            "createfile": self.handle_create_file,
+            "writeframe": self.handle_write_frame,
+            "closefile": self.handle_close_file,
+            "stopacquisition": self.handle_stop_acquisition,
+        }
+
+        message_handlers.update(self.detector_message_handlers)
+        return message_handlers
+
+    @property
+    def detector_message_handlers(self):
+        return {}
+
     def process_message(self, header, data):
         """Process a message from a data socket
 
@@ -311,15 +336,7 @@ class MetaWriter(object):
             data(str): The data message part (a json string or a data blob)
 
         """
-        message_handlers = {
-            "startacquisition": self.handle_start_acquisition,
-            "createfile": self.handle_create_file,
-            "writeframe": self.handle_write_frame,
-            "closefile": self.handle_close_file,
-            "stopacquisition": self.handle_stop_acquisition,
-        }
-
-        handler = message_handlers.get(header[MESSAGE_TYPE_ID], None)
+        handler = self.message_handlers.get(header[MESSAGE_TYPE_ID], None)
         if handler is not None:
             handler(header["header"], data)
         else:

--- a/tools/python/odin_data/meta_writer/meta_writer.py
+++ b/tools/python/odin_data/meta_writer/meta_writer.py
@@ -553,4 +553,4 @@ class MetaWriter(object):
 
     @staticmethod
     def get_version():
-        return construct_version_dict(versioneer.get_versions()["version"])
+        return "odin-data", construct_version_dict(versioneer.get_versions()["version"])

--- a/tools/python/odin_data/meta_writer/meta_writer.py
+++ b/tools/python/odin_data/meta_writer/meta_writer.py
@@ -13,7 +13,7 @@ import logging
 import numpy as np
 import h5py
 
-from .. import _version as versioneer
+from odin_data import _version as versioneer
 from .hdf5dataset import HDF5Dataset, Int64HDF5Dataset, StringHDF5Dataset
 
 MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"

--- a/tools/python/odin_data/meta_writer/meta_writer.py
+++ b/tools/python/odin_data/meta_writer/meta_writer.py
@@ -5,147 +5,421 @@ Will need to be subclassed by detector specific implementation.
 
 Matt Taylor, Diamond Light Source
 """
-import h5py
 import os
-import time
+from time import time
+import re
+import logging
+
+import numpy as np
+import h5py
+
+from .. import _version as versioneer
+from .hdf5dataset import HDF5Dataset, Int64HDF5Dataset, StringHDF5Dataset
+
+MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"
+MINOR_VER_REGEX = r"^[0-9]+[\\.-]([0-9]+).*|$"
+PATCH_VER_REGEX = r"^[0-9]+[\\.-][0-9]+[\\.-]([0-9]+).|$"
+
+# Data message parameters
+FRAME = "frame"
+OFFSET = "offset"
+CREATE_DURATION = "create_duration"
+WRITE_DURATION = "write_duration"
+FLUSH_DURATION = "flush_duration"
+CLOSE_DURATION = "close_duration"
+MESSAGE_TYPE_ID = "parameter"
+
+# Configuration items
+DIRECTORY = "directory"
+FILE_PREFIX = "file_prefix"
+FLUSH_FRAME_FREQUENCY = "flush_frame_frequency"
+FLUSH_TIMEOUT = "flush_timeout"
 
 
 class MetaWriter(object):
-    """Meta Writer class.
+    """This class handles meta data messages and writes parameters to disk"""
 
-    This class handles meta data messages and writes meta data to disk
-    """
+    FILE_SUFFIX = "_meta.h5"
+    CONFIGURE_PARAMETERS = [
+        DIRECTORY,
+        FILE_PREFIX,
+        FLUSH_FRAME_FREQUENCY,
+        FLUSH_TIMEOUT,
+    ]
+    DATASETS = [
+        Int64HDF5Dataset(FRAME),
+        Int64HDF5Dataset(OFFSET),
+        Int64HDF5Dataset(CREATE_DURATION, cache=False),
+        Int64HDF5Dataset(WRITE_DURATION),
+        Int64HDF5Dataset(FLUSH_DURATION),
+        Int64HDF5Dataset(CLOSE_DURATION, cache=False),
+    ]
+    # Detector-specific meta datasets
+    DETECTOR_DATASETS = []
+    # Detector-specific parameters received on per-frame meta message
+    DETECTOR_WRITE_FRAME_PARAMETERS = []
 
-    FILE_SUFFIX = '_meta.h5'
-
-    def __init__(self, logger, directory, acquisition_id):
-        """Initalise the MetaWriter object.
-
-        :param logger: Logger to use
-        :param directory: Directory to create the meta file in
-        :param acquisition_id: Acquisition ID of this acquisition
+    def __init__(self, name, directory):
         """
-        self._logger = logger
-        self._acquisition_id = acquisition_id
-        self._num_frames_to_write = -1
-        self.number_processes_running = 0
+        Args:
+            name(str): Unique name to construct file path and to include in
+                       log messages
+            directory(str): Directory to create the meta file in
+
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+        # Config
         self.directory = directory
         self.file_prefix = None
-        self.finished = False
-        self.write_count = 0
-        self.write_timeout_count = 0
-        self.flush_frequency = 100
-        self.flush_timeout = None
-        self._last_flushed = time.time()
+        self.flush_frame_frequency = 100
+        self.flush_timeout = 1
+
+        # Status
+        self.full_file_path = None
         self.file_created = False
+        self.number_processes_running = 0
+        self.write_count = 0
+        self.finished = False
+        self.write_timeout_count = 0
+
+        # Internal parameters
+        self._name = name
+        self._num_frames_to_write = -1
+        self._last_flushed = time()  # Seconds since epoch
         self._hdf5_file = None
-        self.full_file_name = None
+        self._datasets = dict(
+            (dataset.name, dataset)
+            for dataset in self.DATASETS + self.DETECTOR_DATASETS
+        )
+        # Child class parameters
+        self._frame_data_map = dict()  # Map of frame number to detector data
 
-        self._data_set_definition = {}
-        self._hdf5_datasets = {}
-        self._data_set_arrays = {}
-        
-    @staticmethod    
-    def get_version():
-        """Override to return the version of the writer class."""
-        return {}
-        
-    def start_new_acquisition(self):
-        """Override to perform actions needed when the acquisition is started."""
-        self._logger.warn("Parent start_new_acquisition has been called. Should be overridden")
-        return
+    def _generate_full_file_path(self):
+        prefix = self.file_prefix if self.file_prefix is not None else self._name
+        self.full_file_path = os.path.join(
+            self.directory, "{}{}".format(prefix, self.FILE_SUFFIX)
+        )
+        return self.full_file_path
 
-    def process_message(self, message, userheader, receiver):
-        """Override to perform actions needed when a message is received.
+    def _create_file(self, file_path, dataset_size):
+        self._logger.debug(
+            "%s | Opening file %s - Expecting %d frames",
+            self._name,
+            file_path,
+            dataset_size,
+        )
+        self._hdf5_file = h5py.File(file_path, "w", libver="latest")
+        self._create_datasets(dataset_size)
+        self._hdf5_file.swmr_mode = True
 
-        :param message: The message received
-        :param userheader: The user header of the message parsed from the original meta message
-        :param receiver: The ZeroMQ socket that the message was received on
+    def hdf5_file_open(self):
+        """Verify HDF5 file is open - Log the reason why if not"""
+        if self._hdf5_file is None:
+            if self.finished:
+                reason = "Already finished writing"
+            else:
+                reason = "Have not received startacquisition yet"
+
+            self._logger.info("%s | File not open - %s", self._name, reason)
+            return False
+
+        return True
+
+    def _close_file(self):
+        self._logger.info("%s | Closing file", self._name)
+        if not self.hdf5_file_open():
+            return
+
+        self._write_datasets()
+        self._hdf5_file.close()
+        self._hdf5_file = None
+
+    def _create_datasets(self, dataset_size):
+        """Add predefined datasets to HDF5 file and store handles
+
+        Args:
+            datasets(list(HDF5Dataset)): The datasets to add to the file
+
         """
-        self._logger.warn("Parent process_message has been called. Should be overridden")
-        self._logger.debug(message)
+        self._logger.debug("%s | Creating datasets", self._name)
+        if not self.hdf5_file_open():
+            return
 
-    def create_file(self):
-        """Create the meta file to write data into."""
-        if self.file_prefix:
-            meta_file_name = self.file_prefix + self.FILE_SUFFIX
-        else:
-            meta_file_name = self._acquisition_id + self.FILE_SUFFIX
-        self.full_file_name = os.path.join(self.directory, meta_file_name)
-        self._logger.info("Writing meta data to: %s" % self.full_file_name)
-        self._hdf5_file = h5py.File(self.full_file_name, "w", libver='latest')
-        self.create_datasets()
-        self.file_created = True
+        for dataset in self._datasets.values():
+            dataset_handle = self._hdf5_file.create_dataset(
+                name=dataset.name,
+                shape=dataset.shape,
+                maxshape=dataset.maxshape,
+                dtype=dataset.dtype,
+                fillvalue=dataset.fillvalue,
+            )
+            dataset.initialise(dataset_handle, dataset_size)
 
-    def create_datasets(self):
-        """Create datasets for each definition."""
-        for dset_name in self._data_set_definition:
-            dset = self._data_set_definition[dset_name]
-            self._data_set_arrays[dset_name] = []
-            self._hdf5_datasets[dset_name] = self._hdf5_file.create_dataset(dset_name,
-                                                                            dset['shape'],
-                                                                            maxshape=dset['maxshape'],
-                                                                            dtype=dset['dtype'],
-                                                                            fillvalue=dset['fillvalue'])
+    def _add_dataset(self, dataset_name, data, dataset_size=None):
+        """Add a new dataset with the given data
 
-    def create_dataset_with_data(self, dset_name, data, shape=None):
-        """Create a dataset using pre existing data.
+        Args:
+            dataset_name(str): Name of dataset
+            data(np.ndarray): Data to initialise HDF5 dataset with
+            dataset_size(int): Dataset size - required if more data will be added
 
-        :param dset_name: The dataset name
-        :param data: The data to write
-        :param shape: Shape of the data
         """
-        if shape is not None:
-            self._hdf5_datasets[dset_name] = self._hdf5_file.create_dataset(dset_name, shape, data=data)
-        else:
-            self._hdf5_datasets[dset_name] = self._hdf5_file.create_dataset(dset_name, data=data)
-        self._hdf5_datasets[dset_name].flush()
+        self._logger.debug("%s | Adding dataset %s", self._name, dataset_name)
+        if not self.hdf5_file_open():
+            return
 
-    def add_dataset_definition(self, dset_name, shape, maxshape, dtype, fillvalue):
-        """Add a dataset definition to the list.
+        if dataset_name in self._datasets:
+            self._logger.debug(
+                "%s | Dataset %s already created", self._name, dataset_name
+            )
+            return
 
-        :param dset_name: The dataset name
-        :param shape: Shape of the data
-        :param maxshape: The maximum shape of the data
-        :param dtype: The type of data
-        :param fillvalue: The fill value to use
+        self._logger.debug(
+            "%s | Creating dataset %s with data:\n%s", self._name, dataset_name, data
+        )
+        dataset = HDF5Dataset(dataset_name, dtype=None, fillvalue=None, cache=False)
+        dataset_handle = self._hdf5_file.create_dataset(name=dataset_name, data=data)
+        dataset.initialise(dataset_handle, dataset_size)
+
+        self._datasets[dataset_name] = dataset
+
+    def _add_value(self, dataset_name, value, offset=0):
+        """Append a value to the named dataset
+
+        Args:
+            dataset_name(str): Name of dataset
+            value(): The value to append
+            index(int): The offset to add the value to
+
         """
-        self._data_set_definition[dset_name] = {
-            'shape': shape,
-            'maxshape': maxshape,
-            'dtype': dtype,
-            'fillvalue': fillvalue
+        self._logger.debug("%s | Adding value to %s", self._name, dataset_name)
+        if not self.hdf5_file_open():
+            return
+
+        if dataset_name not in self._datasets:
+            self._logger.error("%s | No such dataset %s")
+            return
+
+        self._datasets[dataset_name].add_value(value, offset)
+
+    def _add_values(self, expected_parameters, data, offset):
+        """Take values of parameters from data and write to datasets at offset
+
+        Args:
+            expected_parameters(list(str)): Parameters to write
+            data(dict): Set of parameter values
+            offset(int): Offset to write parameters to in datasets
+
+        """
+        self._logger.debug("%s | Adding values to datasets", self._name)
+        if not self.hdf5_file_open():
+            return
+
+        for parameter in expected_parameters:
+            if parameter not in data:
+                self._logger.error(
+                    "%s | Expected parameter %s not found in %s",
+                    self._name,
+                    parameter,
+                    data,
+                )
+                continue
+
+            self._add_value(parameter, data[parameter], offset)
+
+    def _write_datasets(self):
+        self._logger.debug("%s | Writing datasets", self._name)
+        if not self.hdf5_file_open():
+            return
+
+        for dataset in self._datasets.values():
+            dataset.flush()
+
+    def stop(self):
+        self._close_file()
+        self.finished = True
+        self._logger.info("%s | Finished", self._name)
+
+    def configure(self, configuration):
+        """Configure the writer with a set of one or more parameters
+
+        Args:
+            writer_name(str): Name of writer to configure
+            configuration(dict): Paramters to configure with
+
+        Returns:
+            error(None/str): None if successful else an error message
+
+        """
+        error = None
+        for parameter, value in configuration.items():
+            if parameter in self.CONFIGURE_PARAMETERS:
+                self._logger.debug(
+                    "%s | Setting %s to %s", self._name, parameter, value
+                )
+                setattr(self, parameter, value)
+            else:
+                error = "Invalid parameter {}".format(parameter)
+                self._logger.error("%s | %s", self._name, error)
+
+        return error
+
+    def request_configuration(self):
+        """Return the current configuration
+
+        Returns:
+            configuration(dict): Dictionary of current configuration parameters
+
+        """
+        configuration = dict(
+            (parameter, getattr(self, parameter))
+            for parameter in self.CONFIGURE_PARAMETERS
+        )
+
+        return configuration
+
+    # Methods for handling various message types
+
+    def process_message(self, header, data):
+        """Process a message from a data socket
+
+        This is main entry point for handling any type of message and calling
+        the appropriate method.
+
+        Look up the appropriate message handler based on the message type and
+        call it.
+
+        Leading underscores on a handler function definition parameter mean it
+        does not use the argument.
+
+        This should be overridden by child classes to handle any additional messages.
+
+        Args:
+            header(str): The header message part
+            data(str): The data message part (a json string or a data blob)
+
+        """
+        message_handlers = {
+            "startacquisition": self.handle_start_acquisition,
+            "createfile": self.handle_create_file,
+            "writeframe": self.handle_write_frame,
+            "closefile": self.handle_close_file,
+            "stopacquisition": self.handle_stop_acquisition,
         }
 
-    def add_dataset_value(self, dset_name, value):
-        """Append a value to the named dataset array.
+        handler = message_handlers.get(header[MESSAGE_TYPE_ID], None)
+        if handler is not None:
+            handler(header["header"], data)
+        else:
+            self._logger.error(
+                "%s | Unknown message type: %s", self._name, header[MESSAGE_TYPE_ID]
+            )
 
-        :param dset_name: The dataset name
-        :param value: The value to append
-        """
-        self._data_set_arrays[dset_name].append(value)
+    def handle_start_acquisition(self, header, _data):
+        """Prepare the data file with the number of frames to write"""
+        self._logger.debug("%s | Handling start acquisition message", self._name)
+
+        self.number_processes_running = self.number_processes_running + 1
+
+        if self._num_frames_to_write == -1:
+            self._num_frames_to_write = header["totalFrames"]
+            self._create_file(
+                self._generate_full_file_path(), self._num_frames_to_write
+            )
+            self.file_created = True
+
+    def handle_create_file(self, _header, data):
+        self._logger.debug("%s | Handling create file message", self._name)
+
+        self._add_value(CREATE_DURATION, data[CREATE_DURATION])
+
+    def handle_write_frame(self, _header, data):
+        self._logger.debug("%s | Handling write frame message", self._name)
+
+        # TODO: Handle getting more frames than expected because of rewinding?
+        write_frame_parameters = [FRAME, OFFSET, WRITE_DURATION, FLUSH_DURATION]
+        self._add_values(write_frame_parameters, data, data[OFFSET])
+
+        # Here we keep track of whether we need to write to disk based on:
+        #   - Time since last write
+        #   - Number of write frame messages since last write
+
         # Reset timeout count to 0
         self.write_timeout_count = 0
 
-    def write_datasets(self):
-        """Override to perform actions needed to write the data to disk."""
-        self._logger.warn("Parent write_datasets has been called. Should be overridden")
-        for dset_name in self._data_set_definition:
-            self._logger.warn("Length of [%s] dataset: %d", dset_name, len(self._data_set_arrays[dset_name]))
-            self._hdf5_datasets[dset_name].resize((len(self._data_set_arrays[dset_name]),))
-            self._hdf5_datasets[dset_name][0:len(self._data_set_arrays[dset_name])] = self._data_set_arrays[dset_name]
+        self.write_count += 1
 
-    def close_file(self):
-        """Override to perform actions needed to close the file."""
-        self.write_datasets()
+        # Write detector meta data for this frame, now that we know the offset
+        self.write_detector_frame_data(data[FRAME], data[OFFSET])
 
-        if self._hdf5_file is not None:
-            self._logger.info('Closing file ' + self.full_file_name)
-            self._hdf5_file.close()
-            self._hdf5_file = None
+        write_data = False
+        if self.flush_timeout is not None:
+            if (time() - self._last_flushed) >= self.flush_timeout:
+                write_data = True
+        # TODO: This isn't technically doing the right thing:
+        if self.write_count % self.flush_frame_frequency == 0:
+            write_data = True
 
-        self.finished = True
+        if write_data:
+            self._write_datasets()
+            self._last_flushed = time()
 
-    def stop(self):
-        """Override to perform actions needed to stop writing."""
-        self.close_file()
+    def write_detector_frame_data(self, frame, offset):
+        """Write the frame data to at the given offset
+
+        Args:
+            frame(int): Frame to write
+            offset(int): Offset in datasets to write the frame data to
+
+        """
+        if not self.DETECTOR_WRITE_FRAME_PARAMETERS:
+            # No detector specific data to write
+            return
+
+        self._logger.debug("%s | Writing detector data for frame %d", self._name, frame)
+
+        if frame not in self._frame_data_map:
+            self._logger.error(
+                "%s | No detector meta data stored for frame %d", self._name, frame
+            )
+            return
+
+        data = self._frame_data_map[frame]
+        self._add_values(self.DETECTOR_WRITE_FRAME_PARAMETERS, data, offset)
+
+    def handle_close_file(self, _header, data):
+        self._logger.debug("%s | Handling close file message", self._name)
+
+        self._add_value(CLOSE_DURATION, data[CLOSE_DURATION])
+
+    def handle_stop_acquisition(self, header, _data):
+        """Register that a process has finished and stop if it is the last one"""
+        self._logger.debug("%s | Handling stop acquisition message", self._name)
+
+        if self.number_processes_running > 0:
+            self.number_processes_running = self.number_processes_running - 1
+
+        self._logger.debug("%s | Process rank %d stopped", self._name, header["rank"])
+
+        if self.number_processes_running == 0:
+            self._logger.info("%s | Last processor stopped", self._name)
+            self.stop()
+
+    # TODO: Do this properly
+    @staticmethod
+    def get_version():
+        full_version = versioneer.get_versions()["version"]
+        major_version = re.findall(MAJOR_VER_REGEX, full_version)[0]
+        minor_version = re.findall(MINOR_VER_REGEX, full_version)[0]
+        patch_version = re.findall(PATCH_VER_REGEX, full_version)[0]
+        short_version = major_version + "." + minor_version + "." + patch_version
+
+        version_dict = {}
+        version_dict["full"] = full_version
+        version_dict["major"] = major_version
+        version_dict["minor"] = minor_version
+        version_dict["patch"] = patch_version
+        version_dict["short"] = short_version
+
+        return version_dict

--- a/tools/python/odin_data/meta_writer/meta_writer.py
+++ b/tools/python/odin_data/meta_writer/meta_writer.py
@@ -246,6 +246,15 @@ class MetaWriter(object):
         self.finished = True
         self._logger.info("%s | Finished", self._name)
 
+    def status(self):
+        """Return current status parameters"""
+        return dict(
+            full_file_path=self.full_file_path,
+            num_processors=self.active_process_count,
+            written=self.write_count,
+            writing=self.file_created and not self.finished,
+        )
+
     def configure(self, configuration):
         """Configure the writer with a set of one or more parameters
 

--- a/tools/python/odin_data/util.py
+++ b/tools/python/odin_data/util.py
@@ -26,3 +26,23 @@ def convert_unicode_to_string(self, obj):
         return obj.encode('utf-8')
 
     return obj
+
+
+MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"
+MINOR_VER_REGEX = r"^[0-9]+[\\.-]([0-9]+).*|$"
+PATCH_VER_REGEX = r"^[0-9]+[\\.-][0-9]+[\\.-]([0-9]+).|$"
+
+
+def construct_version_dict(full_version):
+    major_version = re.findall(MAJOR_VER_REGEX, full_version)[0]
+    minor_version = re.findall(MINOR_VER_REGEX, full_version)[0]
+    patch_version = re.findall(PATCH_VER_REGEX, full_version)[0]
+    short_version = major_version + "." + minor_version + "." + patch_version
+
+    return dict(
+        full=full_version,
+        major=major_version,
+        minor_version=minor_version,
+        patch_version=patch_version,
+        short_version=short_version,
+    )

--- a/tools/python/odin_data/util.py
+++ b/tools/python/odin_data/util.py
@@ -42,7 +42,7 @@ def construct_version_dict(full_version):
     return dict(
         full=full_version,
         major=major_version,
-        minor_version=minor_version,
-        patch_version=patch_version,
-        short_version=short_version,
+        minor=minor_version,
+        patch=patch_version,
+        short=short_version,
     )

--- a/tools/python/odin_data/versioneer.py
+++ b/tools/python/odin_data/versioneer.py
@@ -1,0 +1,1822 @@
+
+# Version: 0.18
+
+"""The Versioneer - like a rocketeer, but for versions.
+
+The Versioneer
+==============
+
+* like a rocketeer, but for versions!
+* https://github.com/warner/python-versioneer
+* Brian Warner
+* License: Public Domain
+* Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, and pypy
+* [![Latest Version]
+(https://pypip.in/version/versioneer/badge.svg?style=flat)
+](https://pypi.python.org/pypi/versioneer/)
+* [![Build Status]
+(https://travis-ci.org/warner/python-versioneer.png?branch=master)
+](https://travis-ci.org/warner/python-versioneer)
+
+This is a tool for managing a recorded version number in distutils-based
+python projects. The goal is to remove the tedious and error-prone "update
+the embedded version string" step from your release process. Making a new
+release should be as easy as recording a new tag in your version-control
+system, and maybe making new tarballs.
+
+
+## Quick Install
+
+* `pip install versioneer` to somewhere to your $PATH
+* add a `[versioneer]` section to your setup.cfg (see below)
+* run `versioneer install` in your source tree, commit the results
+
+## Version Identifiers
+
+Source trees come from a variety of places:
+
+* a version-control system checkout (mostly used by developers)
+* a nightly tarball, produced by build automation
+* a snapshot tarball, produced by a web-based VCS browser, like github's
+  "tarball from tag" feature
+* a release tarball, produced by "setup.py sdist", distributed through PyPI
+
+Within each source tree, the version identifier (either a string or a number,
+this tool is format-agnostic) can come from a variety of places:
+
+* ask the VCS tool itself, e.g. "git describe" (for checkouts), which knows
+  about recent "tags" and an absolute revision-id
+* the name of the directory into which the tarball was unpacked
+* an expanded VCS keyword ($Id$, etc)
+* a `_version.py` created by some earlier build step
+
+For released software, the version identifier is closely related to a VCS
+tag. Some projects use tag names that include more than just the version
+string (e.g. "myproject-1.2" instead of just "1.2"), in which case the tool
+needs to strip the tag prefix to extract the version identifier. For
+unreleased software (between tags), the version identifier should provide
+enough information to help developers recreate the same tree, while also
+giving them an idea of roughly how old the tree is (after version 1.2, before
+version 1.3). Many VCS systems can report a description that captures this,
+for example `git describe --tags --dirty --always` reports things like
+"0.7-1-g574ab98-dirty" to indicate that the checkout is one revision past the
+0.7 tag, has a unique revision id of "574ab98", and is "dirty" (it has
+uncommitted changes.
+
+The version identifier is used for multiple purposes:
+
+* to allow the module to self-identify its version: `myproject.__version__`
+* to choose a name and prefix for a 'setup.py sdist' tarball
+
+## Theory of Operation
+
+Versioneer works by adding a special `_version.py` file into your source
+tree, where your `__init__.py` can import it. This `_version.py` knows how to
+dynamically ask the VCS tool for version information at import time.
+
+`_version.py` also contains `$Revision$` markers, and the installation
+process marks `_version.py` to have this marker rewritten with a tag name
+during the `git archive` command. As a result, generated tarballs will
+contain enough information to get the proper version.
+
+To allow `setup.py` to compute a version too, a `versioneer.py` is added to
+the top level of your source tree, next to `setup.py` and the `setup.cfg`
+that configures it. This overrides several distutils/setuptools commands to
+compute the version when invoked, and changes `setup.py build` and `setup.py
+sdist` to replace `_version.py` with a small static file that contains just
+the generated version data.
+
+## Installation
+
+See [INSTALL.md](./INSTALL.md) for detailed installation instructions.
+
+## Version-String Flavors
+
+Code which uses Versioneer can learn about its version string at runtime by
+importing `_version` from your main `__init__.py` file and running the
+`get_versions()` function. From the "outside" (e.g. in `setup.py`), you can
+import the top-level `versioneer.py` and run `get_versions()`.
+
+Both functions return a dictionary with different flavors of version
+information:
+
+* `['version']`: A condensed version string, rendered using the selected
+  style. This is the most commonly used value for the project's version
+  string. The default "pep440" style yields strings like `0.11`,
+  `0.11+2.g1076c97`, or `0.11+2.g1076c97.dirty`. See the "Styles" section
+  below for alternative styles.
+
+* `['full-revisionid']`: detailed revision identifier. For Git, this is the
+  full SHA1 commit id, e.g. "1076c978a8d3cfc70f408fe5974aa6c092c949ac".
+
+* `['date']`: Date and time of the latest `HEAD` commit. For Git, it is the
+  commit date in ISO 8601 format. This will be None if the date is not
+  available.
+
+* `['dirty']`: a boolean, True if the tree has uncommitted changes. Note that
+  this is only accurate if run in a VCS checkout, otherwise it is likely to
+  be False or None
+
+* `['error']`: if the version string could not be computed, this will be set
+  to a string describing the problem, otherwise it will be None. It may be
+  useful to throw an exception in setup.py if this is set, to avoid e.g.
+  creating tarballs with a version string of "unknown".
+
+Some variants are more useful than others. Including `full-revisionid` in a
+bug report should allow developers to reconstruct the exact code being tested
+(or indicate the presence of local changes that should be shared with the
+developers). `version` is suitable for display in an "about" box or a CLI
+`--version` output: it can be easily compared against release notes and lists
+of bugs fixed in various releases.
+
+The installer adds the following text to your `__init__.py` to place a basic
+version in `YOURPROJECT.__version__`:
+
+    from ._version import get_versions
+    __version__ = get_versions()['version']
+    del get_versions
+
+## Styles
+
+The setup.cfg `style=` configuration controls how the VCS information is
+rendered into a version string.
+
+The default style, "pep440", produces a PEP440-compliant string, equal to the
+un-prefixed tag name for actual releases, and containing an additional "local
+version" section with more detail for in-between builds. For Git, this is
+TAG[+DISTANCE.gHEX[.dirty]] , using information from `git describe --tags
+--dirty --always`. For example "0.11+2.g1076c97.dirty" indicates that the
+tree is like the "1076c97" commit but has uncommitted changes (".dirty"), and
+that this commit is two revisions ("+2") beyond the "0.11" tag. For released
+software (exactly equal to a known tag), the identifier will only contain the
+stripped tag, e.g. "0.11".
+
+Other styles are available. See [details.md](details.md) in the Versioneer
+source tree for descriptions.
+
+## Debugging
+
+Versioneer tries to avoid fatal errors: if something goes wrong, it will tend
+to return a version of "0+unknown". To investigate the problem, run `setup.py
+version`, which will run the version-lookup code in a verbose mode, and will
+display the full contents of `get_versions()` (including the `error` string,
+which may help identify what went wrong).
+
+## Known Limitations
+
+Some situations are known to cause problems for Versioneer. This details the
+most significant ones. More can be found on Github
+[issues page](https://github.com/warner/python-versioneer/issues).
+
+### Subprojects
+
+Versioneer has limited support for source trees in which `setup.py` is not in
+the root directory (e.g. `setup.py` and `.git/` are *not* siblings). The are
+two common reasons why `setup.py` might not be in the root:
+
+* Source trees which contain multiple subprojects, such as
+  [Buildbot](https://github.com/buildbot/buildbot), which contains both
+  "master" and "slave" subprojects, each with their own `setup.py`,
+  `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
+  distributions (and upload multiple independently-installable tarballs).
+* Source trees whose main purpose is to contain a C library, but which also
+  provide bindings to Python (and perhaps other langauges) in subdirectories.
+
+Versioneer will look for `.git` in parent directories, and most operations
+should get the right version string. However `pip` and `setuptools` have bugs
+and implementation details which frequently cause `pip install .` from a
+subproject directory to fail to find a correct version string (so it usually
+defaults to `0+unknown`).
+
+`pip install --editable .` should work correctly. `setup.py install` might
+work too.
+
+Pip-8.1.1 is known to have this problem, but hopefully it will get fixed in
+some later version.
+
+[Bug #38](https://github.com/warner/python-versioneer/issues/38) is tracking
+this issue. The discussion in
+[PR #61](https://github.com/warner/python-versioneer/pull/61) describes the
+issue from the Versioneer side in more detail.
+[pip PR#3176](https://github.com/pypa/pip/pull/3176) and
+[pip PR#3615](https://github.com/pypa/pip/pull/3615) contain work to improve
+pip to let Versioneer work correctly.
+
+Versioneer-0.16 and earlier only looked for a `.git` directory next to the
+`setup.cfg`, so subprojects were completely unsupported with those releases.
+
+### Editable installs with setuptools <= 18.5
+
+`setup.py develop` and `pip install --editable .` allow you to install a
+project into a virtualenv once, then continue editing the source code (and
+test) without re-installing after every change.
+
+"Entry-point scripts" (`setup(entry_points={"console_scripts": ..})`) are a
+convenient way to specify executable scripts that should be installed along
+with the python package.
+
+These both work as expected when using modern setuptools. When using
+setuptools-18.5 or earlier, however, certain operations will cause
+`pkg_resources.DistributionNotFound` errors when running the entrypoint
+script, which must be resolved by re-installing the package. This happens
+when the install happens with one version, then the egg_info data is
+regenerated while a different version is checked out. Many setup.py commands
+cause egg_info to be rebuilt (including `sdist`, `wheel`, and installing into
+a different virtualenv), so this can be surprising.
+
+[Bug #83](https://github.com/warner/python-versioneer/issues/83) describes
+this one, but upgrading to a newer version of setuptools should probably
+resolve it.
+
+### Unicode version strings
+
+While Versioneer works (and is continually tested) with both Python 2 and
+Python 3, it is not entirely consistent with bytes-vs-unicode distinctions.
+Newer releases probably generate unicode version strings on py2. It's not
+clear that this is wrong, but it may be surprising for applications when then
+write these strings to a network connection or include them in bytes-oriented
+APIs like cryptographic checksums.
+
+[Bug #71](https://github.com/warner/python-versioneer/issues/71) investigates
+this question.
+
+
+## Updating Versioneer
+
+To upgrade your project to a new release of Versioneer, do the following:
+
+* install the new Versioneer (`pip install -U versioneer` or equivalent)
+* edit `setup.cfg`, if necessary, to include any new configuration settings
+  indicated by the release notes. See [UPGRADING](./UPGRADING.md) for details.
+* re-run `versioneer install` in your source tree, to replace
+  `SRC/_version.py`
+* commit any changed files
+
+## Future Directions
+
+This tool is designed to make it easily extended to other version-control
+systems: all VCS-specific components are in separate directories like
+src/git/ . The top-level `versioneer.py` script is assembled from these
+components by running make-versioneer.py . In the future, make-versioneer.py
+will take a VCS name as an argument, and will construct a version of
+`versioneer.py` that is specific to the given VCS. It might also take the
+configuration arguments that are currently provided manually during
+installation by editing setup.py . Alternatively, it might go the other
+direction and include code from all supported VCS systems, reducing the
+number of intermediate scripts.
+
+
+## License
+
+To make Versioneer easier to embed, all its code is dedicated to the public
+domain. The `_version.py` that it creates is also in the public domain.
+Specifically, both are released under the Creative Commons "Public Domain
+Dedication" license (CC0-1.0), as described in
+https://creativecommons.org/publicdomain/zero/1.0/ .
+
+"""
+
+from __future__ import print_function
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+import errno
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+class VersioneerConfig:
+    """Container for Versioneer configuration parameters."""
+
+
+def get_root():
+    """Get the project root directory.
+
+    We require that all commands are run from the project root, i.e. the
+    directory that contains setup.py, setup.cfg, and versioneer.py .
+    """
+    root = os.path.realpath(os.path.abspath(os.getcwd()))
+    setup_py = os.path.join(root, "setup.py")
+    versioneer_py = os.path.join(root, "versioneer.py")
+    if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
+        # allow 'python path/to/setup.py COMMAND'
+        root = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
+        setup_py = os.path.join(root, "setup.py")
+        versioneer_py = os.path.join(root, "versioneer.py")
+    if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
+        err = ("Versioneer was unable to run the project root directory. "
+               "Versioneer requires setup.py to be executed from "
+               "its immediate directory (like 'python setup.py COMMAND'), "
+               "or in a way that lets it use sys.argv[0] to find the root "
+               "(like 'python path/to/setup.py COMMAND').")
+        raise VersioneerBadRootError(err)
+    try:
+        # Certain runtime workflows (setup.py install/develop in a setuptools
+        # tree) execute all dependencies in a single python process, so
+        # "versioneer" may be imported multiple times, and python's shared
+        # module-import table will cache the first one. So we can't use
+        # os.path.dirname(__file__), as that will find whichever
+        # versioneer.py was first imported, even in later projects.
+        me = os.path.realpath(os.path.abspath(__file__))
+        me_dir = os.path.normcase(os.path.splitext(me)[0])
+        vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
+        if me_dir != vsr_dir:
+            print("Warning: build in %s is using versioneer.py from %s"
+                  % (os.path.dirname(me), versioneer_py))
+    except NameError:
+        pass
+    return root
+
+
+def get_config_from_root(root):
+    """Read the project setup.cfg file to determine Versioneer config."""
+    # This might raise EnvironmentError (if setup.cfg is missing), or
+    # configparser.NoSectionError (if it lacks a [versioneer] section), or
+    # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+    # the top of versioneer.py for instructions on writing your setup.cfg .
+    setup_cfg = os.path.join(root, "setup.cfg")
+    parser = configparser.SafeConfigParser()
+    with open(setup_cfg, "r") as f:
+        parser.readfp(f)
+    VCS = parser.get("versioneer", "VCS")  # mandatory
+
+    def get(parser, name):
+        if parser.has_option("versioneer", name):
+            return parser.get("versioneer", name)
+        return None
+    cfg = VersioneerConfig()
+    cfg.VCS = VCS
+    cfg.style = get(parser, "style") or ""
+    cfg.versionfile_source = get(parser, "versionfile_source")
+    cfg.versionfile_build = get(parser, "versionfile_build")
+    cfg.tag_prefix = get(parser, "tag_prefix")
+    if cfg.tag_prefix in ("''", '""'):
+        cfg.tag_prefix = ""
+    cfg.parentdir_prefix = get(parser, "parentdir_prefix")
+    cfg.verbose = get(parser, "verbose")
+    return cfg
+
+
+class NotThisMethod(Exception):
+    """Exception raised if a method is not valid for the current scenario."""
+
+
+# these dictionaries contain VCS-specific tools
+LONG_VERSION_PY = {}
+HANDLERS = {}
+
+
+def register_vcs_handler(vcs, method):  # decorator
+    """Decorator to mark a method as the handler for a particular VCS."""
+    def decorate(f):
+        """Store f in HANDLERS[vcs][method]."""
+        if vcs not in HANDLERS:
+            HANDLERS[vcs] = {}
+        HANDLERS[vcs][method] = f
+        return f
+    return decorate
+
+
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
+                env=None):
+    """Call the given command(s)."""
+    assert isinstance(commands, list)
+    p = None
+    for c in commands:
+        try:
+            dispcmd = str([c] + args)
+            # remember shell=False, so use git.cmd on windows, not just git
+            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
+                                 stdout=subprocess.PIPE,
+                                 stderr=(subprocess.PIPE if hide_stderr
+                                         else None))
+            break
+        except EnvironmentError:
+            e = sys.exc_info()[1]
+            if e.errno == errno.ENOENT:
+                continue
+            if verbose:
+                print("unable to run %s" % dispcmd)
+                print(e)
+            return None, None
+    else:
+        if verbose:
+            print("unable to find command, tried %s" % (commands,))
+        return None, None
+    stdout = p.communicate()[0].strip()
+    if sys.version_info[0] >= 3:
+        stdout = stdout.decode()
+    if p.returncode != 0:
+        if verbose:
+            print("unable to run %s (error)" % dispcmd)
+            print("stdout was %s" % stdout)
+        return None, p.returncode
+    return stdout, p.returncode
+
+
+LONG_VERSION_PY['git'] = '''
+# This file helps to compute a version number in source trees obtained from
+# git-archive tarball (such as those provided by githubs download-from-tag
+# feature). Distribution tarballs (built by setup.py sdist) and build
+# directories (produced by setup.py build) will contain a much shorter file
+# that just contains the computed version number.
+
+# This file is released into the public domain. Generated by
+# versioneer-0.18 (https://github.com/warner/python-versioneer)
+
+"""Git implementation of _version.py."""
+
+import errno
+import os
+import re
+import subprocess
+import sys
+
+
+def get_keywords():
+    """Get the keywords needed to look up the version information."""
+    # these strings will be replaced by git during git-archive.
+    # setup.py/versioneer.py will grep for the variable names, so they must
+    # each be defined on a line of their own. _version.py will just call
+    # get_keywords().
+    git_refnames = "%(DOLLAR)sFormat:%%d%(DOLLAR)s"
+    git_full = "%(DOLLAR)sFormat:%%H%(DOLLAR)s"
+    git_date = "%(DOLLAR)sFormat:%%ci%(DOLLAR)s"
+    keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}
+    return keywords
+
+
+class VersioneerConfig:
+    """Container for Versioneer configuration parameters."""
+
+
+def get_config():
+    """Create, populate and return the VersioneerConfig() object."""
+    # these strings are filled in when 'setup.py versioneer' creates
+    # _version.py
+    cfg = VersioneerConfig()
+    cfg.VCS = "git"
+    cfg.style = "%(STYLE)s"
+    cfg.tag_prefix = "%(TAG_PREFIX)s"
+    cfg.parentdir_prefix = "%(PARENTDIR_PREFIX)s"
+    cfg.versionfile_source = "%(VERSIONFILE_SOURCE)s"
+    cfg.verbose = False
+    return cfg
+
+
+class NotThisMethod(Exception):
+    """Exception raised if a method is not valid for the current scenario."""
+
+
+LONG_VERSION_PY = {}
+HANDLERS = {}
+
+
+def register_vcs_handler(vcs, method):  # decorator
+    """Decorator to mark a method as the handler for a particular VCS."""
+    def decorate(f):
+        """Store f in HANDLERS[vcs][method]."""
+        if vcs not in HANDLERS:
+            HANDLERS[vcs] = {}
+        HANDLERS[vcs][method] = f
+        return f
+    return decorate
+
+
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
+                env=None):
+    """Call the given command(s)."""
+    assert isinstance(commands, list)
+    p = None
+    for c in commands:
+        try:
+            dispcmd = str([c] + args)
+            # remember shell=False, so use git.cmd on windows, not just git
+            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
+                                 stdout=subprocess.PIPE,
+                                 stderr=(subprocess.PIPE if hide_stderr
+                                         else None))
+            break
+        except EnvironmentError:
+            e = sys.exc_info()[1]
+            if e.errno == errno.ENOENT:
+                continue
+            if verbose:
+                print("unable to run %%s" %% dispcmd)
+                print(e)
+            return None, None
+    else:
+        if verbose:
+            print("unable to find command, tried %%s" %% (commands,))
+        return None, None
+    stdout = p.communicate()[0].strip()
+    if sys.version_info[0] >= 3:
+        stdout = stdout.decode()
+    if p.returncode != 0:
+        if verbose:
+            print("unable to run %%s (error)" %% dispcmd)
+            print("stdout was %%s" %% stdout)
+        return None, p.returncode
+    return stdout, p.returncode
+
+
+def versions_from_parentdir(parentdir_prefix, root, verbose):
+    """Try to determine the version from the parent directory name.
+
+    Source tarballs conventionally unpack into a directory that includes both
+    the project name and a version string. We will also support searching up
+    two directory levels for an appropriately named parent directory
+    """
+    rootdirs = []
+
+    for i in range(3):
+        dirname = os.path.basename(root)
+        if dirname.startswith(parentdir_prefix):
+            return {"version": dirname[len(parentdir_prefix):],
+                    "full-revisionid": None,
+                    "dirty": False, "error": None, "date": None}
+        else:
+            rootdirs.append(root)
+            root = os.path.dirname(root)  # up a level
+
+    if verbose:
+        print("Tried directories %%s but none started with prefix %%s" %%
+              (str(rootdirs), parentdir_prefix))
+    raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
+
+
+@register_vcs_handler("git", "get_keywords")
+def git_get_keywords(versionfile_abs):
+    """Extract version information from the given file."""
+    # the code embedded in _version.py can just fetch the value of these
+    # keywords. When used from setup.py, we don't want to import _version.py,
+    # so we do it with a regexp instead. This function is not used from
+    # _version.py.
+    keywords = {}
+    try:
+        f = open(versionfile_abs, "r")
+        for line in f.readlines():
+            if line.strip().startswith("git_refnames ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["refnames"] = mo.group(1)
+            if line.strip().startswith("git_full ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["full"] = mo.group(1)
+            if line.strip().startswith("git_date ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["date"] = mo.group(1)
+        f.close()
+    except EnvironmentError:
+        pass
+    return keywords
+
+
+@register_vcs_handler("git", "keywords")
+def git_versions_from_keywords(keywords, tag_prefix, verbose):
+    """Get version information from git keywords."""
+    if not keywords:
+        raise NotThisMethod("no keywords at all, weird")
+    date = keywords.get("date")
+    if date is not None:
+        # git-2.2.0 added "%%cI", which expands to an ISO-8601 -compliant
+        # datestamp. However we prefer "%%ci" (which expands to an "ISO-8601
+        # -like" string, which we must then edit to make compliant), because
+        # it's been around since git-1.5.3, and it's too difficult to
+        # discover which version we're using, or to work around using an
+        # older one.
+        date = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
+    refnames = keywords["refnames"].strip()
+    if refnames.startswith("$Format"):
+        if verbose:
+            print("keywords are unexpanded, not using")
+        raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
+    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
+    # just "foo-1.0". If we see a "tag: " prefix, prefer those.
+    TAG = "tag: "
+    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    if not tags:
+        # Either we're using git < 1.8.3, or there really are no tags. We use
+        # a heuristic: assume all version tags have a digit. The old git %%d
+        # expansion behaves like git log --decorate=short and strips out the
+        # refs/heads/ and refs/tags/ prefixes that would let us distinguish
+        # between branches and tags. By ignoring refnames without digits, we
+        # filter out many common branch names like "release" and
+        # "stabilization", as well as "HEAD" and "master".
+        tags = set([r for r in refs if re.search(r'\d', r)])
+        if verbose:
+            print("discarding '%%s', no digits" %% ",".join(refs - tags))
+    if verbose:
+        print("likely tags: %%s" %% ",".join(sorted(tags)))
+    for ref in sorted(tags):
+        # sorting will prefer e.g. "2.0" over "2.0rc1"
+        if ref.startswith(tag_prefix):
+            r = ref[len(tag_prefix):]
+            if verbose:
+                print("picking %%s" %% r)
+            return {"version": r,
+                    "full-revisionid": keywords["full"].strip(),
+                    "dirty": False, "error": None,
+                    "date": date}
+    # no suitable tags, so version is "0+unknown", but full hex is still there
+    if verbose:
+        print("no suitable tags, using unknown + full revision id")
+    return {"version": "0+unknown",
+            "full-revisionid": keywords["full"].strip(),
+            "dirty": False, "error": "no suitable tags", "date": None}
+
+
+@register_vcs_handler("git", "pieces_from_vcs")
+def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
+    """Get version from 'git describe' in the root of the source tree.
+
+    This only gets called if the git-archive 'subst' keywords were *not*
+    expanded, and _version.py hasn't already been rewritten with a short
+    version string, meaning we're inside a checked out source tree.
+    """
+    GITS = ["git"]
+    if sys.platform == "win32":
+        GITS = ["git.cmd", "git.exe"]
+
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
+                          hide_stderr=True)
+    if rc != 0:
+        if verbose:
+            print("Directory %%s not under git control" %% root)
+        raise NotThisMethod("'git rev-parse --git-dir' returned error")
+
+    # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
+    # if there isn't one, this yields HEX[-dirty] (no NUM)
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+                                          "--always", "--long",
+                                          "--match", "%%s*" %% tag_prefix],
+                                   cwd=root)
+    # --long was added in git-1.5.5
+    if describe_out is None:
+        raise NotThisMethod("'git describe' failed")
+    describe_out = describe_out.strip()
+    full_out, rc = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
+    if full_out is None:
+        raise NotThisMethod("'git rev-parse' failed")
+    full_out = full_out.strip()
+
+    pieces = {}
+    pieces["long"] = full_out
+    pieces["short"] = full_out[:7]  # maybe improved later
+    pieces["error"] = None
+
+    # parse describe_out. It will be like TAG-NUM-gHEX[-dirty] or HEX[-dirty]
+    # TAG might have hyphens.
+    git_describe = describe_out
+
+    # look for -dirty suffix
+    dirty = git_describe.endswith("-dirty")
+    pieces["dirty"] = dirty
+    if dirty:
+        git_describe = git_describe[:git_describe.rindex("-dirty")]
+
+    # now we have TAG-NUM-gHEX or HEX
+
+    if "-" in git_describe:
+        # TAG-NUM-gHEX
+        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        if not mo:
+            # unparseable. Maybe git-describe is misbehaving?
+            pieces["error"] = ("unable to parse git-describe output: '%%s'"
+                               %% describe_out)
+            return pieces
+
+        # tag
+        full_tag = mo.group(1)
+        if not full_tag.startswith(tag_prefix):
+            if verbose:
+                fmt = "tag '%%s' doesn't start with prefix '%%s'"
+                print(fmt %% (full_tag, tag_prefix))
+            pieces["error"] = ("tag '%%s' doesn't start with prefix '%%s'"
+                               %% (full_tag, tag_prefix))
+            return pieces
+        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+
+        # distance: number of commits since tag
+        pieces["distance"] = int(mo.group(2))
+
+        # commit: short hex revision ID
+        pieces["short"] = mo.group(3)
+
+    else:
+        # HEX: no tags
+        pieces["closest-tag"] = None
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
+                                    cwd=root)
+        pieces["distance"] = int(count_out)  # total number of commits
+
+    # commit date: see ISO-8601 comment in git_versions_from_keywords()
+    date = run_command(GITS, ["show", "-s", "--format=%%ci", "HEAD"],
+                       cwd=root)[0].strip()
+    pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
+
+    return pieces
+
+
+def plus_or_dot(pieces):
+    """Return a + if we don't already have one, else return a ."""
+    if "+" in pieces.get("closest-tag", ""):
+        return "."
+    return "+"
+
+
+def render_pep440(pieces):
+    """Build up version string, with post-release "local version identifier".
+
+    Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
+    get a tagged build and then dirty it, you'll get TAG+0.gHEX.dirty
+
+    Exceptions:
+    1: no tags. git_describe was just HEX. 0+untagged.DISTANCE.gHEX[.dirty]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += plus_or_dot(pieces)
+            rendered += "%%d.g%%s" %% (pieces["distance"], pieces["short"])
+            if pieces["dirty"]:
+                rendered += ".dirty"
+    else:
+        # exception #1
+        rendered = "0+untagged.%%d.g%%s" %% (pieces["distance"],
+                                          pieces["short"])
+        if pieces["dirty"]:
+            rendered += ".dirty"
+    return rendered
+
+
+def render_pep440_pre(pieces):
+    """TAG[.post.devDISTANCE] -- No -dirty.
+
+    Exceptions:
+    1: no tags. 0.post.devDISTANCE
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"]:
+            rendered += ".post.dev%%d" %% pieces["distance"]
+    else:
+        # exception #1
+        rendered = "0.post.dev%%d" %% pieces["distance"]
+    return rendered
+
+
+def render_pep440_post(pieces):
+    """TAG[.postDISTANCE[.dev0]+gHEX] .
+
+    The ".dev0" means dirty. Note that .dev0 sorts backwards
+    (a dirty tree will appear "older" than the corresponding clean one),
+    but you shouldn't be releasing software with -dirty anyways.
+
+    Exceptions:
+    1: no tags. 0.postDISTANCE[.dev0]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += ".post%%d" %% pieces["distance"]
+            if pieces["dirty"]:
+                rendered += ".dev0"
+            rendered += plus_or_dot(pieces)
+            rendered += "g%%s" %% pieces["short"]
+    else:
+        # exception #1
+        rendered = "0.post%%d" %% pieces["distance"]
+        if pieces["dirty"]:
+            rendered += ".dev0"
+        rendered += "+g%%s" %% pieces["short"]
+    return rendered
+
+
+def render_pep440_old(pieces):
+    """TAG[.postDISTANCE[.dev0]] .
+
+    The ".dev0" means dirty.
+
+    Eexceptions:
+    1: no tags. 0.postDISTANCE[.dev0]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += ".post%%d" %% pieces["distance"]
+            if pieces["dirty"]:
+                rendered += ".dev0"
+    else:
+        # exception #1
+        rendered = "0.post%%d" %% pieces["distance"]
+        if pieces["dirty"]:
+            rendered += ".dev0"
+    return rendered
+
+
+def render_git_describe(pieces):
+    """TAG[-DISTANCE-gHEX][-dirty].
+
+    Like 'git describe --tags --dirty --always'.
+
+    Exceptions:
+    1: no tags. HEX[-dirty]  (note: no 'g' prefix)
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"]:
+            rendered += "-%%d-g%%s" %% (pieces["distance"], pieces["short"])
+    else:
+        # exception #1
+        rendered = pieces["short"]
+    if pieces["dirty"]:
+        rendered += "-dirty"
+    return rendered
+
+
+def render_git_describe_long(pieces):
+    """TAG-DISTANCE-gHEX[-dirty].
+
+    Like 'git describe --tags --dirty --always -long'.
+    The distance/hash is unconditional.
+
+    Exceptions:
+    1: no tags. HEX[-dirty]  (note: no 'g' prefix)
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        rendered += "-%%d-g%%s" %% (pieces["distance"], pieces["short"])
+    else:
+        # exception #1
+        rendered = pieces["short"]
+    if pieces["dirty"]:
+        rendered += "-dirty"
+    return rendered
+
+
+def render(pieces, style):
+    """Render the given version pieces into the requested style."""
+    if pieces["error"]:
+        return {"version": "unknown",
+                "full-revisionid": pieces.get("long"),
+                "dirty": None,
+                "error": pieces["error"],
+                "date": None}
+
+    if not style or style == "default":
+        style = "pep440"  # the default
+
+    if style == "pep440":
+        rendered = render_pep440(pieces)
+    elif style == "pep440-pre":
+        rendered = render_pep440_pre(pieces)
+    elif style == "pep440-post":
+        rendered = render_pep440_post(pieces)
+    elif style == "pep440-old":
+        rendered = render_pep440_old(pieces)
+    elif style == "git-describe":
+        rendered = render_git_describe(pieces)
+    elif style == "git-describe-long":
+        rendered = render_git_describe_long(pieces)
+    else:
+        raise ValueError("unknown style '%%s'" %% style)
+
+    return {"version": rendered, "full-revisionid": pieces["long"],
+            "dirty": pieces["dirty"], "error": None,
+            "date": pieces.get("date")}
+
+
+def get_versions():
+    """Get version information or return default if unable to do so."""
+    # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
+    # __file__, we can work backwards from there to the root. Some
+    # py2exe/bbfreeze/non-CPython implementations don't do __file__, in which
+    # case we can only use expanded keywords.
+
+    cfg = get_config()
+    verbose = cfg.verbose
+
+    try:
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
+                                          verbose)
+    except NotThisMethod:
+        pass
+
+    try:
+        root = os.path.realpath(__file__)
+        # versionfile_source is the relative path from the top of the source
+        # tree (where the .git directory might live) to this file. Invert
+        # this to find the root from __file__.
+        for i in cfg.versionfile_source.split('/'):
+            root = os.path.dirname(root)
+    except NameError:
+        return {"version": "0+unknown", "full-revisionid": None,
+                "dirty": None,
+                "error": "unable to find root of source tree",
+                "date": None}
+
+    try:
+        pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
+        return render(pieces, cfg.style)
+    except NotThisMethod:
+        pass
+
+    try:
+        if cfg.parentdir_prefix:
+            return versions_from_parentdir(cfg.parentdir_prefix, root, verbose)
+    except NotThisMethod:
+        pass
+
+    return {"version": "0+unknown", "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to compute version", "date": None}
+'''
+
+
+@register_vcs_handler("git", "get_keywords")
+def git_get_keywords(versionfile_abs):
+    """Extract version information from the given file."""
+    # the code embedded in _version.py can just fetch the value of these
+    # keywords. When used from setup.py, we don't want to import _version.py,
+    # so we do it with a regexp instead. This function is not used from
+    # _version.py.
+    keywords = {}
+    try:
+        f = open(versionfile_abs, "r")
+        for line in f.readlines():
+            if line.strip().startswith("git_refnames ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["refnames"] = mo.group(1)
+            if line.strip().startswith("git_full ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["full"] = mo.group(1)
+            if line.strip().startswith("git_date ="):
+                mo = re.search(r'=\s*"(.*)"', line)
+                if mo:
+                    keywords["date"] = mo.group(1)
+        f.close()
+    except EnvironmentError:
+        pass
+    return keywords
+
+
+@register_vcs_handler("git", "keywords")
+def git_versions_from_keywords(keywords, tag_prefix, verbose):
+    """Get version information from git keywords."""
+    if not keywords:
+        raise NotThisMethod("no keywords at all, weird")
+    date = keywords.get("date")
+    if date is not None:
+        # git-2.2.0 added "%cI", which expands to an ISO-8601 -compliant
+        # datestamp. However we prefer "%ci" (which expands to an "ISO-8601
+        # -like" string, which we must then edit to make compliant), because
+        # it's been around since git-1.5.3, and it's too difficult to
+        # discover which version we're using, or to work around using an
+        # older one.
+        date = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
+    refnames = keywords["refnames"].strip()
+    if refnames.startswith("$Format"):
+        if verbose:
+            print("keywords are unexpanded, not using")
+        raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
+    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
+    # just "foo-1.0". If we see a "tag: " prefix, prefer those.
+    TAG = "tag: "
+    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    if not tags:
+        # Either we're using git < 1.8.3, or there really are no tags. We use
+        # a heuristic: assume all version tags have a digit. The old git %d
+        # expansion behaves like git log --decorate=short and strips out the
+        # refs/heads/ and refs/tags/ prefixes that would let us distinguish
+        # between branches and tags. By ignoring refnames without digits, we
+        # filter out many common branch names like "release" and
+        # "stabilization", as well as "HEAD" and "master".
+        tags = set([r for r in refs if re.search(r'\d', r)])
+        if verbose:
+            print("discarding '%s', no digits" % ",".join(refs - tags))
+    if verbose:
+        print("likely tags: %s" % ",".join(sorted(tags)))
+    for ref in sorted(tags):
+        # sorting will prefer e.g. "2.0" over "2.0rc1"
+        if ref.startswith(tag_prefix):
+            r = ref[len(tag_prefix):]
+            if verbose:
+                print("picking %s" % r)
+            return {"version": r,
+                    "full-revisionid": keywords["full"].strip(),
+                    "dirty": False, "error": None,
+                    "date": date}
+    # no suitable tags, so version is "0+unknown", but full hex is still there
+    if verbose:
+        print("no suitable tags, using unknown + full revision id")
+    return {"version": "0+unknown",
+            "full-revisionid": keywords["full"].strip(),
+            "dirty": False, "error": "no suitable tags", "date": None}
+
+
+@register_vcs_handler("git", "pieces_from_vcs")
+def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
+    """Get version from 'git describe' in the root of the source tree.
+
+    This only gets called if the git-archive 'subst' keywords were *not*
+    expanded, and _version.py hasn't already been rewritten with a short
+    version string, meaning we're inside a checked out source tree.
+    """
+    GITS = ["git"]
+    if sys.platform == "win32":
+        GITS = ["git.cmd", "git.exe"]
+
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
+                          hide_stderr=True)
+    if rc != 0:
+        if verbose:
+            print("Directory %s not under git control" % root)
+        raise NotThisMethod("'git rev-parse --git-dir' returned error")
+
+    # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
+    # if there isn't one, this yields HEX[-dirty] (no NUM)
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+                                          "--always", "--long",
+                                          "--match", "%s*" % tag_prefix],
+                                   cwd=root)
+    # --long was added in git-1.5.5
+    if describe_out is None:
+        raise NotThisMethod("'git describe' failed")
+    describe_out = describe_out.strip()
+    full_out, rc = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
+    if full_out is None:
+        raise NotThisMethod("'git rev-parse' failed")
+    full_out = full_out.strip()
+
+    pieces = {}
+    pieces["long"] = full_out
+    pieces["short"] = full_out[:7]  # maybe improved later
+    pieces["error"] = None
+
+    # parse describe_out. It will be like TAG-NUM-gHEX[-dirty] or HEX[-dirty]
+    # TAG might have hyphens.
+    git_describe = describe_out
+
+    # look for -dirty suffix
+    dirty = git_describe.endswith("-dirty")
+    pieces["dirty"] = dirty
+    if dirty:
+        git_describe = git_describe[:git_describe.rindex("-dirty")]
+
+    # now we have TAG-NUM-gHEX or HEX
+
+    if "-" in git_describe:
+        # TAG-NUM-gHEX
+        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        if not mo:
+            # unparseable. Maybe git-describe is misbehaving?
+            pieces["error"] = ("unable to parse git-describe output: '%s'"
+                               % describe_out)
+            return pieces
+
+        # tag
+        full_tag = mo.group(1)
+        if not full_tag.startswith(tag_prefix):
+            if verbose:
+                fmt = "tag '%s' doesn't start with prefix '%s'"
+                print(fmt % (full_tag, tag_prefix))
+            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
+                               % (full_tag, tag_prefix))
+            return pieces
+        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+
+        # distance: number of commits since tag
+        pieces["distance"] = int(mo.group(2))
+
+        # commit: short hex revision ID
+        pieces["short"] = mo.group(3)
+
+    else:
+        # HEX: no tags
+        pieces["closest-tag"] = None
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
+                                    cwd=root)
+        pieces["distance"] = int(count_out)  # total number of commits
+
+    # commit date: see ISO-8601 comment in git_versions_from_keywords()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
+                       cwd=root)[0].strip()
+    pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
+
+    return pieces
+
+
+def do_vcs_install(manifest_in, versionfile_source, ipy):
+    """Git-specific installation logic for Versioneer.
+
+    For Git, this means creating/changing .gitattributes to mark _version.py
+    for export-subst keyword substitution.
+    """
+    GITS = ["git"]
+    if sys.platform == "win32":
+        GITS = ["git.cmd", "git.exe"]
+    files = [manifest_in, versionfile_source]
+    if ipy:
+        files.append(ipy)
+    try:
+        me = __file__
+        if me.endswith(".pyc") or me.endswith(".pyo"):
+            me = os.path.splitext(me)[0] + ".py"
+        versioneer_file = os.path.relpath(me)
+    except NameError:
+        versioneer_file = "versioneer.py"
+    files.append(versioneer_file)
+    present = False
+    try:
+        f = open(".gitattributes", "r")
+        for line in f.readlines():
+            if line.strip().startswith(versionfile_source):
+                if "export-subst" in line.strip().split()[1:]:
+                    present = True
+        f.close()
+    except EnvironmentError:
+        pass
+    if not present:
+        f = open(".gitattributes", "a+")
+        f.write("%s export-subst\n" % versionfile_source)
+        f.close()
+        files.append(".gitattributes")
+    run_command(GITS, ["add", "--"] + files)
+
+
+def versions_from_parentdir(parentdir_prefix, root, verbose):
+    """Try to determine the version from the parent directory name.
+
+    Source tarballs conventionally unpack into a directory that includes both
+    the project name and a version string. We will also support searching up
+    two directory levels for an appropriately named parent directory
+    """
+    rootdirs = []
+
+    for i in range(3):
+        dirname = os.path.basename(root)
+        if dirname.startswith(parentdir_prefix):
+            return {"version": dirname[len(parentdir_prefix):],
+                    "full-revisionid": None,
+                    "dirty": False, "error": None, "date": None}
+        else:
+            rootdirs.append(root)
+            root = os.path.dirname(root)  # up a level
+
+    if verbose:
+        print("Tried directories %s but none started with prefix %s" %
+              (str(rootdirs), parentdir_prefix))
+    raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
+
+
+SHORT_VERSION_PY = """
+# This file was generated by 'versioneer.py' (0.18) from
+# revision-control system data, or from the parent directory name of an
+# unpacked source archive. Distribution tarballs contain a pre-generated copy
+# of this file.
+
+import json
+
+version_json = '''
+%s
+'''  # END VERSION_JSON
+
+
+def get_versions():
+    return json.loads(version_json)
+"""
+
+
+def versions_from_file(filename):
+    """Try to determine the version from _version.py if present."""
+    try:
+        with open(filename) as f:
+            contents = f.read()
+    except EnvironmentError:
+        raise NotThisMethod("unable to read _version.py")
+    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
+                   contents, re.M | re.S)
+    if not mo:
+        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
+                       contents, re.M | re.S)
+    if not mo:
+        raise NotThisMethod("no version_json in _version.py")
+    return json.loads(mo.group(1))
+
+
+def write_to_version_file(filename, versions):
+    """Write the given version number to the given _version.py file."""
+    os.unlink(filename)
+    contents = json.dumps(versions, sort_keys=True,
+                          indent=1, separators=(",", ": "))
+    with open(filename, "w") as f:
+        f.write(SHORT_VERSION_PY % contents)
+
+    print("set %s to '%s'" % (filename, versions["version"]))
+
+
+def plus_or_dot(pieces):
+    """Return a + if we don't already have one, else return a ."""
+    if "+" in pieces.get("closest-tag", ""):
+        return "."
+    return "+"
+
+
+def render_pep440(pieces):
+    """Build up version string, with post-release "local version identifier".
+
+    Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
+    get a tagged build and then dirty it, you'll get TAG+0.gHEX.dirty
+
+    Exceptions:
+    1: no tags. git_describe was just HEX. 0+untagged.DISTANCE.gHEX[.dirty]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += plus_or_dot(pieces)
+            rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
+            if pieces["dirty"]:
+                rendered += ".dirty"
+    else:
+        # exception #1
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
+                                          pieces["short"])
+        if pieces["dirty"]:
+            rendered += ".dirty"
+    return rendered
+
+
+def render_pep440_pre(pieces):
+    """TAG[.post.devDISTANCE] -- No -dirty.
+
+    Exceptions:
+    1: no tags. 0.post.devDISTANCE
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"]:
+            rendered += ".post.dev%d" % pieces["distance"]
+    else:
+        # exception #1
+        rendered = "0.post.dev%d" % pieces["distance"]
+    return rendered
+
+
+def render_pep440_post(pieces):
+    """TAG[.postDISTANCE[.dev0]+gHEX] .
+
+    The ".dev0" means dirty. Note that .dev0 sorts backwards
+    (a dirty tree will appear "older" than the corresponding clean one),
+    but you shouldn't be releasing software with -dirty anyways.
+
+    Exceptions:
+    1: no tags. 0.postDISTANCE[.dev0]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += ".post%d" % pieces["distance"]
+            if pieces["dirty"]:
+                rendered += ".dev0"
+            rendered += plus_or_dot(pieces)
+            rendered += "g%s" % pieces["short"]
+    else:
+        # exception #1
+        rendered = "0.post%d" % pieces["distance"]
+        if pieces["dirty"]:
+            rendered += ".dev0"
+        rendered += "+g%s" % pieces["short"]
+    return rendered
+
+
+def render_pep440_old(pieces):
+    """TAG[.postDISTANCE[.dev0]] .
+
+    The ".dev0" means dirty.
+
+    Eexceptions:
+    1: no tags. 0.postDISTANCE[.dev0]
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += ".post%d" % pieces["distance"]
+            if pieces["dirty"]:
+                rendered += ".dev0"
+    else:
+        # exception #1
+        rendered = "0.post%d" % pieces["distance"]
+        if pieces["dirty"]:
+            rendered += ".dev0"
+    return rendered
+
+
+def render_git_describe(pieces):
+    """TAG[-DISTANCE-gHEX][-dirty].
+
+    Like 'git describe --tags --dirty --always'.
+
+    Exceptions:
+    1: no tags. HEX[-dirty]  (note: no 'g' prefix)
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        if pieces["distance"]:
+            rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+    else:
+        # exception #1
+        rendered = pieces["short"]
+    if pieces["dirty"]:
+        rendered += "-dirty"
+    return rendered
+
+
+def render_git_describe_long(pieces):
+    """TAG-DISTANCE-gHEX[-dirty].
+
+    Like 'git describe --tags --dirty --always -long'.
+    The distance/hash is unconditional.
+
+    Exceptions:
+    1: no tags. HEX[-dirty]  (note: no 'g' prefix)
+    """
+    if pieces["closest-tag"]:
+        rendered = pieces["closest-tag"]
+        rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+    else:
+        # exception #1
+        rendered = pieces["short"]
+    if pieces["dirty"]:
+        rendered += "-dirty"
+    return rendered
+
+
+def render(pieces, style):
+    """Render the given version pieces into the requested style."""
+    if pieces["error"]:
+        return {"version": "unknown",
+                "full-revisionid": pieces.get("long"),
+                "dirty": None,
+                "error": pieces["error"],
+                "date": None}
+
+    if not style or style == "default":
+        style = "pep440"  # the default
+
+    if style == "pep440":
+        rendered = render_pep440(pieces)
+    elif style == "pep440-pre":
+        rendered = render_pep440_pre(pieces)
+    elif style == "pep440-post":
+        rendered = render_pep440_post(pieces)
+    elif style == "pep440-old":
+        rendered = render_pep440_old(pieces)
+    elif style == "git-describe":
+        rendered = render_git_describe(pieces)
+    elif style == "git-describe-long":
+        rendered = render_git_describe_long(pieces)
+    else:
+        raise ValueError("unknown style '%s'" % style)
+
+    return {"version": rendered, "full-revisionid": pieces["long"],
+            "dirty": pieces["dirty"], "error": None,
+            "date": pieces.get("date")}
+
+
+class VersioneerBadRootError(Exception):
+    """The project root directory is unknown or missing key files."""
+
+
+def get_versions(verbose=False):
+    """Get the project version from whatever source is available.
+
+    Returns dict with two keys: 'version' and 'full'.
+    """
+    if "versioneer" in sys.modules:
+        # see the discussion in cmdclass.py:get_cmdclass()
+        del sys.modules["versioneer"]
+
+    root = get_root()
+    cfg = get_config_from_root(root)
+
+    assert cfg.VCS is not None, "please set [versioneer]VCS= in setup.cfg"
+    handlers = HANDLERS.get(cfg.VCS)
+    assert handlers, "unrecognized VCS '%s'" % cfg.VCS
+    verbose = verbose or cfg.verbose
+    assert cfg.versionfile_source is not None, \
+        "please set versioneer.versionfile_source"
+    assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
+
+    versionfile_abs = os.path.join(root, cfg.versionfile_source)
+
+    # extract version from first of: _version.py, VCS command (e.g. 'git
+    # describe'), parentdir. This is meant to work for developers using a
+    # source checkout, for users of a tarball created by 'setup.py sdist',
+    # and for users of a tarball/zipball created by 'git archive' or github's
+    # download-from-tag feature or the equivalent in other VCSes.
+
+    get_keywords_f = handlers.get("get_keywords")
+    from_keywords_f = handlers.get("keywords")
+    if get_keywords_f and from_keywords_f:
+        try:
+            keywords = get_keywords_f(versionfile_abs)
+            ver = from_keywords_f(keywords, cfg.tag_prefix, verbose)
+            if verbose:
+                print("got version from expanded keyword %s" % ver)
+            return ver
+        except NotThisMethod:
+            pass
+
+    try:
+        ver = versions_from_file(versionfile_abs)
+        if verbose:
+            print("got version from file %s %s" % (versionfile_abs, ver))
+        return ver
+    except NotThisMethod:
+        pass
+
+    from_vcs_f = handlers.get("pieces_from_vcs")
+    if from_vcs_f:
+        try:
+            pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
+            ver = render(pieces, cfg.style)
+            if verbose:
+                print("got version from VCS %s" % ver)
+            return ver
+        except NotThisMethod:
+            pass
+
+    try:
+        if cfg.parentdir_prefix:
+            ver = versions_from_parentdir(cfg.parentdir_prefix, root, verbose)
+            if verbose:
+                print("got version from parentdir %s" % ver)
+            return ver
+    except NotThisMethod:
+        pass
+
+    if verbose:
+        print("unable to compute version")
+
+    return {"version": "0+unknown", "full-revisionid": None,
+            "dirty": None, "error": "unable to compute version",
+            "date": None}
+
+
+def get_version():
+    """Get the short version string for this project."""
+    return get_versions()["version"]
+
+
+def get_cmdclass():
+    """Get the custom setuptools/distutils subclasses used by Versioneer."""
+    if "versioneer" in sys.modules:
+        del sys.modules["versioneer"]
+        # this fixes the "python setup.py develop" case (also 'install' and
+        # 'easy_install .'), in which subdependencies of the main project are
+        # built (using setup.py bdist_egg) in the same python process. Assume
+        # a main project A and a dependency B, which use different versions
+        # of Versioneer. A's setup.py imports A's Versioneer, leaving it in
+        # sys.modules by the time B's setup.py is executed, causing B to run
+        # with the wrong versioneer. Setuptools wraps the sub-dep builds in a
+        # sandbox that restores sys.modules to it's pre-build state, so the
+        # parent is protected against the child's "import versioneer". By
+        # removing ourselves from sys.modules here, before the child build
+        # happens, we protect the child from the parent's versioneer too.
+        # Also see https://github.com/warner/python-versioneer/issues/52
+
+    cmds = {}
+
+    # we add "version" to both distutils and setuptools
+    from distutils.core import Command
+
+    class cmd_version(Command):
+        description = "report generated version string"
+        user_options = []
+        boolean_options = []
+
+        def initialize_options(self):
+            pass
+
+        def finalize_options(self):
+            pass
+
+        def run(self):
+            vers = get_versions(verbose=True)
+            print("Version: %s" % vers["version"])
+            print(" full-revisionid: %s" % vers.get("full-revisionid"))
+            print(" dirty: %s" % vers.get("dirty"))
+            print(" date: %s" % vers.get("date"))
+            if vers["error"]:
+                print(" error: %s" % vers["error"])
+    cmds["version"] = cmd_version
+
+    # we override "build_py" in both distutils and setuptools
+    #
+    # most invocation pathways end up running build_py:
+    #  distutils/build -> build_py
+    #  distutils/install -> distutils/build ->..
+    #  setuptools/bdist_wheel -> distutils/install ->..
+    #  setuptools/bdist_egg -> distutils/install_lib -> build_py
+    #  setuptools/install -> bdist_egg ->..
+    #  setuptools/develop -> ?
+    #  pip install:
+    #   copies source tree to a tempdir before running egg_info/etc
+    #   if .git isn't copied too, 'git describe' will fail
+    #   then does setup.py bdist_wheel, or sometimes setup.py install
+    #  setup.py egg_info -> ?
+
+    # we override different "build_py" commands for both environments
+    if "setuptools" in sys.modules:
+        from setuptools.command.build_py import build_py as _build_py
+    else:
+        from distutils.command.build_py import build_py as _build_py
+
+    class cmd_build_py(_build_py):
+        def run(self):
+            root = get_root()
+            cfg = get_config_from_root(root)
+            versions = get_versions()
+            _build_py.run(self)
+            # now locate _version.py in the new build/ directory and replace
+            # it with an updated value
+            if cfg.versionfile_build:
+                target_versionfile = os.path.join(self.build_lib,
+                                                  cfg.versionfile_build)
+                print("UPDATING %s" % target_versionfile)
+                write_to_version_file(target_versionfile, versions)
+    cmds["build_py"] = cmd_build_py
+
+    if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
+        from cx_Freeze.dist import build_exe as _build_exe
+        # nczeczulin reports that py2exe won't like the pep440-style string
+        # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
+        # setup(console=[{
+        #   "version": versioneer.get_version().split("+", 1)[0], # FILEVERSION
+        #   "product_version": versioneer.get_version(),
+        #   ...
+
+        class cmd_build_exe(_build_exe):
+            def run(self):
+                root = get_root()
+                cfg = get_config_from_root(root)
+                versions = get_versions()
+                target_versionfile = cfg.versionfile_source
+                print("UPDATING %s" % target_versionfile)
+                write_to_version_file(target_versionfile, versions)
+
+                _build_exe.run(self)
+                os.unlink(target_versionfile)
+                with open(cfg.versionfile_source, "w") as f:
+                    LONG = LONG_VERSION_PY[cfg.VCS]
+                    f.write(LONG %
+                            {"DOLLAR": "$",
+                             "STYLE": cfg.style,
+                             "TAG_PREFIX": cfg.tag_prefix,
+                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                             })
+        cmds["build_exe"] = cmd_build_exe
+        del cmds["build_py"]
+
+    if 'py2exe' in sys.modules:  # py2exe enabled?
+        try:
+            from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
+        except ImportError:
+            from py2exe.build_exe import py2exe as _py2exe  # py2
+
+        class cmd_py2exe(_py2exe):
+            def run(self):
+                root = get_root()
+                cfg = get_config_from_root(root)
+                versions = get_versions()
+                target_versionfile = cfg.versionfile_source
+                print("UPDATING %s" % target_versionfile)
+                write_to_version_file(target_versionfile, versions)
+
+                _py2exe.run(self)
+                os.unlink(target_versionfile)
+                with open(cfg.versionfile_source, "w") as f:
+                    LONG = LONG_VERSION_PY[cfg.VCS]
+                    f.write(LONG %
+                            {"DOLLAR": "$",
+                             "STYLE": cfg.style,
+                             "TAG_PREFIX": cfg.tag_prefix,
+                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                             })
+        cmds["py2exe"] = cmd_py2exe
+
+    # we override different "sdist" commands for both environments
+    if "setuptools" in sys.modules:
+        from setuptools.command.sdist import sdist as _sdist
+    else:
+        from distutils.command.sdist import sdist as _sdist
+
+    class cmd_sdist(_sdist):
+        def run(self):
+            versions = get_versions()
+            self._versioneer_generated_versions = versions
+            # unless we update this, the command will keep using the old
+            # version
+            self.distribution.metadata.version = versions["version"]
+            return _sdist.run(self)
+
+        def make_release_tree(self, base_dir, files):
+            root = get_root()
+            cfg = get_config_from_root(root)
+            _sdist.make_release_tree(self, base_dir, files)
+            # now locate _version.py in the new base_dir directory
+            # (remembering that it may be a hardlink) and replace it with an
+            # updated value
+            target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
+            print("UPDATING %s" % target_versionfile)
+            write_to_version_file(target_versionfile,
+                                  self._versioneer_generated_versions)
+    cmds["sdist"] = cmd_sdist
+
+    return cmds
+
+
+CONFIG_ERROR = """
+setup.cfg is missing the necessary Versioneer configuration. You need
+a section like:
+
+ [versioneer]
+ VCS = git
+ style = pep440
+ versionfile_source = src/myproject/_version.py
+ versionfile_build = myproject/_version.py
+ tag_prefix =
+ parentdir_prefix = myproject-
+
+You will also need to edit your setup.py to use the results:
+
+ import versioneer
+ setup(version=versioneer.get_version(),
+       cmdclass=versioneer.get_cmdclass(), ...)
+
+Please read the docstring in ./versioneer.py for configuration instructions,
+edit setup.cfg, and re-run the installer or 'python versioneer.py setup'.
+"""
+
+SAMPLE_CONFIG = """
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+#VCS = git
+#style = pep440
+#versionfile_source =
+#versionfile_build =
+#tag_prefix =
+#parentdir_prefix =
+
+"""
+
+INIT_PY_SNIPPET = """
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+"""
+
+
+def do_setup():
+    """Main VCS-independent setup function for installing Versioneer."""
+    root = get_root()
+    try:
+        cfg = get_config_from_root(root)
+    except (EnvironmentError, configparser.NoSectionError,
+            configparser.NoOptionError) as e:
+        if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
+            print("Adding sample versioneer config to setup.cfg",
+                  file=sys.stderr)
+            with open(os.path.join(root, "setup.cfg"), "a") as f:
+                f.write(SAMPLE_CONFIG)
+        print(CONFIG_ERROR, file=sys.stderr)
+        return 1
+
+    print(" creating %s" % cfg.versionfile_source)
+    with open(cfg.versionfile_source, "w") as f:
+        LONG = LONG_VERSION_PY[cfg.VCS]
+        f.write(LONG % {"DOLLAR": "$",
+                        "STYLE": cfg.style,
+                        "TAG_PREFIX": cfg.tag_prefix,
+                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        })
+
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
+                       "__init__.py")
+    if os.path.exists(ipy):
+        try:
+            with open(ipy, "r") as f:
+                old = f.read()
+        except EnvironmentError:
+            old = ""
+        if INIT_PY_SNIPPET not in old:
+            print(" appending to %s" % ipy)
+            with open(ipy, "a") as f:
+                f.write(INIT_PY_SNIPPET)
+        else:
+            print(" %s unmodified" % ipy)
+    else:
+        print(" %s doesn't exist, ok" % ipy)
+        ipy = None
+
+    # Make sure both the top-level "versioneer.py" and versionfile_source
+    # (PKG/_version.py, used by runtime code) are in MANIFEST.in, so
+    # they'll be copied into source distributions. Pip won't be able to
+    # install the package without this.
+    manifest_in = os.path.join(root, "MANIFEST.in")
+    simple_includes = set()
+    try:
+        with open(manifest_in, "r") as f:
+            for line in f:
+                if line.startswith("include "):
+                    for include in line.split()[1:]:
+                        simple_includes.add(include)
+    except EnvironmentError:
+        pass
+    # That doesn't cover everything MANIFEST.in can do
+    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # it might give some false negatives. Appending redundant 'include'
+    # lines is safe, though.
+    if "versioneer.py" not in simple_includes:
+        print(" appending 'versioneer.py' to MANIFEST.in")
+        with open(manifest_in, "a") as f:
+            f.write("include versioneer.py\n")
+    else:
+        print(" 'versioneer.py' already in MANIFEST.in")
+    if cfg.versionfile_source not in simple_includes:
+        print(" appending versionfile_source ('%s') to MANIFEST.in" %
+              cfg.versionfile_source)
+        with open(manifest_in, "a") as f:
+            f.write("include %s\n" % cfg.versionfile_source)
+    else:
+        print(" versionfile_source already in MANIFEST.in")
+
+    # Make VCS-specific changes. For git, this means creating/changing
+    # .gitattributes to mark _version.py for export-subst keyword
+    # substitution.
+    do_vcs_install(manifest_in, cfg.versionfile_source, ipy)
+    return 0
+
+
+def scan_setup_py():
+    """Validate the contents of setup.py against Versioneer's expectations."""
+    found = set()
+    setters = False
+    errors = 0
+    with open("setup.py", "r") as f:
+        for line in f.readlines():
+            if "import versioneer" in line:
+                found.add("import")
+            if "versioneer.get_cmdclass()" in line:
+                found.add("cmdclass")
+            if "versioneer.get_version()" in line:
+                found.add("get_version")
+            if "versioneer.VCS" in line:
+                setters = True
+            if "versioneer.versionfile_source" in line:
+                setters = True
+    if len(found) != 3:
+        print("")
+        print("Your setup.py appears to be missing some important items")
+        print("(but I might be wrong). Please make sure it has something")
+        print("roughly like the following:")
+        print("")
+        print(" import versioneer")
+        print(" setup( version=versioneer.get_version(),")
+        print("        cmdclass=versioneer.get_cmdclass(),  ...)")
+        print("")
+        errors += 1
+    if setters:
+        print("You should remove lines like 'versioneer.VCS = ' and")
+        print("'versioneer.versionfile_source = ' . This configuration")
+        print("now lives in setup.cfg, and should be removed from setup.py")
+        print("")
+        errors += 1
+    return errors
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1]
+    if cmd == "setup":
+        errors = do_setup()
+        errors += scan_setup_py()
+        if errors:
+            sys.exit(1)

--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,6 +1,6 @@
 posix_ipc>=1.0.0
 pysnmp>=4.3.0
-numpy>=1.9.1
+numpy>=1.14.0
 h5py>=2.9.0
 pyzmq>=16.0.2
 pygelf>=0.3.1


### PR DESCRIPTION
This is a PR of two parts:

- Update the frameProcessor to publish file writing metrics over the meta data channel
- A big refactor of the meta writer application to
    - Make the base class fully functional and handle the file writing metrics with no detector version required
    - Allow it to be easily extended for detector-specific meta data

Most of the logic has been moved out of EigerMetaWriter into the base class. There is an accompanying eiger-detector PR here: https://github.com/dls-controls/eiger-detector/pull/8

The application can be run without specifying a writer class and the base class will be used instead. This will listen for messages from the FileWriterPlugin (the file writing metrics). If it does get detector specific messages it will ignore them.

I think this is pretty much ready, but there are a few outstanding questions and more things that could either be resolved in this PR or afterwards:
- It might need to be extended to fulfill requirements for tristan, which I believe has some more exotic meta data
- There are two TODOs that I don't think are urgent: 
    - Fixed in 79a9b89 ~~There is some logic to count the number of status requests before deleting an acquisition - this is to make sure that a client (our areaDetector driver) sees the acquisition in the finished state and updates accordingly. I think this is messy and it would be better to have some kind of command to clear the old acquisitions out, but this might cause problems if there are multiple clients for some reason. EDIT: I think this can be fixed by only removing finished acquisitions if there is more than one. This is a fix I patched on VMXi for a problem with the meta seemingly hanging acquisitions less than a second in duration because the IOC status wouldn't update in time to see it had finished.~~
    - It does not support rewinding. I don't think it will be a big change to make this work, but I don't know if it is required.
- I would have liked to add some tests, but they are not currently built into the module and implementing this would require some further discussion
- In the version information (shown below) there is no way to tell what actual detector module is. Should it use (e.g.) eiger-detector as the key so that this is clearer? Also, if the base class MetaWriter class is used, the writer dict will just be a duplication of odin-data.

```
"odin-data": {
    "full": "1.4.0+88.g5a4838a.dirty",
    "major": "1",
    "minor_version": "4",
    "patch_version": "0",
    "short_version": "1.4.0"
},
"writer": {
    "full": "1-7-1+3.g59eaaff.dirty",
    "major": "1",
    "minor": "7",
    "patch": "1",
    "short": "1.7.1"
}
```
- I am not sure now if I needed to copy in that versioneer file
- I have updated the numpy version requirement to 1.14+. Hopefully this is OK. If not I could work around it.
- I think the parameter names in the meta messages from FrameProcessorController to MetaWriter should be renamed to match what they are currently being used for. E.g. `parameter` stores the unique message type, `plugin` stores the class name that created the message.