### PR TITLE
removing dependency on blosc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package( Boost 1.41.0
 find_package(Log4CXX 0.10.0 REQUIRED)
 find_package(ZeroMQ 3.2.4 REQUIRED)
 find_package(PCAP 1.4.0 REQUIRED)
-find_package(Blosc REQUIRED)
+find_package(Blosc)
 find_package(Kafka)
 
 # find package HDF5

--- a/frameProcessor/include/FrameProcessorDefinitions.h
+++ b/frameProcessor/include/FrameProcessorDefinitions.h
@@ -156,6 +156,12 @@ namespace FrameProcessor
     bool create_low_high_indexes;
   };
 
+  /**
+   * BLOSC_VERSION_FORMAT in blosc.h tells you the blosc-format
+   * in the blosc library. We fix on 2 because we've always used that.
+   */
+  static const int BLOSC_FORMAT_ODIN_USES = 2;
+
 } /* namespace FrameProcessor */
 
 #endif /* FRAMEPROCESSOR_FrameProcessorDefinitions_H_ */

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -11,14 +11,18 @@
 #include <DebugLevelLogger.h>
 #include "DataBlockFrame.h"
 
+#include <boost/static_assert.hpp>
+
 namespace FrameProcessor
 {
+
+BOOST_STATIC_ASSERT_MSG(BLOSC_VERSION_FORMAT==BLOSC_FORMAT_ODIN_USES, "Error: Wrong version of blosc library");
+
 
 const std::string BloscPlugin::CONFIG_BLOSC_COMPRESSOR = "compressor";
 const std::string BloscPlugin::CONFIG_BLOSC_THREADS    = "threads";
 const std::string BloscPlugin::CONFIG_BLOSC_LEVEL      = "level";
 const std::string BloscPlugin::CONFIG_BLOSC_SHUFFLE    = "shuffle";
-
 
   /**
  * cd_values[7] meaning (see blosc.h):

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -8,7 +8,6 @@
 #include "HDF5File.h"
 
 #include <hdf5_hl.h>
-#include <blosc.h>
 #include "logging.h"
 #include "DebugLevelLogger.h"
 
@@ -427,7 +426,7 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
     unsigned int cd_values[7] = {0, 0, 0, 0, 0, 0, 0};
     size_t cd_values_length = 7;
     cd_values[0] = 2;                                          // Blosc filter version: 2 (multiple compressors since Blosc 1.3)
-    cd_values[1] = BLOSC_VERSION_FORMAT;                       // Blosc buffer format version
+    cd_values[1] = BLOSC_FORMAT_ODIN_USES;                     // Blosc buffer format version
     cd_values[2] = static_cast<unsigned int>(pixel_type_size); // type size
     cd_values[3] = frame_num_pixels * pixel_type_size;         // uncompressed size
     cd_values[4] = definition.blosc_level;                     // compression level


### PR DESCRIPTION
i) to test this, I ran cmake -DBLOSC_ROOT_DIR=/garbagesdkfjs/prefix and then make, and it built ok.
ii) Note that the enum for compression type is in FrameProcessorDefinitions.h:24, and the compression-type is set in the frame's metadata in the compression plugin. It should still be valid without blosc being installed.