### PR TITLE
Fix RX thread startup wait loop under optimised release builds

### DIFF
--- a/frameReceiver/include/FrameReceiverRxThread.h
+++ b/frameReceiver/include/FrameReceiverRxThread.h
@@ -78,13 +78,12 @@ private:
   unsigned int           tick_period_ms_;      //!< Receiver thread tick timer period
 
   boost::shared_ptr<boost::thread> rx_thread_; //!< Pointer to RX thread
-  
   IpcChannel             rx_channel_;          //!< Channel for communication with the main thread
   std::vector<int>       recv_sockets_;        //!< List of receive socket file descriptors
 
   bool                   run_thread_;          //!< Flag signalling thread should run
-  bool                   thread_running_;      //!< Flag singalling if thread is running
-  bool                   thread_init_error_;   //!< Flag singalling thread initialisation error
+  volatile bool          thread_running_;      //!< Flag singalling if thread is running
+  volatile bool          thread_init_error_;   //!< Flag singalling thread initialisation error
   std::string            thread_init_msg_;     //!< Thread initialisation message
 
 };


### PR DESCRIPTION
The `FrameReceiverRxThread::start()` method has a wait loop which blocks until the thread is running and initialised. When compiled as a CMake release build, i.e. with -O3 optimisation, the loop was being optimised in such a way that the polling in the loop did not detect the thread state change. This has been fixed by modifying the loop to have a bounded timeout and a short sleep each on pass.

Resolves #248