### PR TITLE
Improving logging consistency

### DIFF
--- a/tools/python/odin_data/logconfig.py
+++ b/tools/python/odin_data/logconfig.py
@@ -98,9 +98,6 @@ def add_graylog_handler(host, port, level="INFO", static_fields=None):
 
     Returns: None
     """
-    app_name = sys.argv[0]
-    if '/' in app_name:
-        app_name = app_name.split('/')[-1]
     graylog_config = {
         "class": "pygelf.GelfUdpHandler",
         "level": level,
@@ -113,7 +110,7 @@ def add_graylog_handler(host, port, level="INFO", static_fields=None):
         "include_extra_fields": True,
         "username": getpass.getuser(),
         "process_id": os.getpid(),
-        "application_name": app_name
+        "application_name": os.path.split(sys.argv[0])[1]
     }
     if static_fields is not None:
         graylog_config.update(static_fields)

--- a/tools/python/odin_data/logconfig.py
+++ b/tools/python/odin_data/logconfig.py
@@ -6,6 +6,7 @@ extending the default configuration simple.
 """
 
 import os
+import sys
 import json
 import logging.config
 import getpass
@@ -97,6 +98,9 @@ def add_graylog_handler(host, port, level="INFO", static_fields=None):
 
     Returns: None
     """
+    app_name = sys.argv[0]
+    if '/' in app_name:
+        app_name = app_name.split('/')[-1]
     graylog_config = {
         "class": "pygelf.GelfUdpHandler",
         "level": level,
@@ -108,7 +112,8 @@ def add_graylog_handler(host, port, level="INFO", static_fields=None):
         #  The following custom fields will be disabled if setting this False
         "include_extra_fields": True,
         "username": getpass.getuser(),
-        "pid": os.getpid()
+        "process_id": os.getpid(),
+        "application_name": app_name
     }
     if static_fields is not None:
         graylog_config.update(static_fields)


### PR DESCRIPTION
Update python logging name from pid to process_id to match the log entries from frameProcessor and frameReceiver applications.
Added python logging of the application_name to provide the same entry as frameProcessor and frameReceiver applications.
