### PR TITLE
Require ZeroMQ version >= 4.1.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ find_package( Boost 1.41.0
 	      REQUIRED
 	      COMPONENTS program_options system filesystem unit_test_framework date_time thread regex)
 find_package(Log4CXX 0.10.0 REQUIRED)
-find_package(ZeroMQ 3.2.4 REQUIRED)
+find_package(ZEROMQ 4.1.4 REQUIRED)
 find_package(PCAP 1.4.0 REQUIRED)
 find_package(Blosc)
 find_package(Kafka)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following libraries and packages are required:
 
 * [CMake](http://www.cmake.org) : build management system (version >= 2.8)
 * [Boost](http://www.boost.org) : portable C++ utility libraries. The following components are used - program_options, unit_test_framework, date_time, interprocess, bimap (version >= 1.41)
-* [ZeroMQ](http://zeromq.org) : high-performance asynchronous messaging library (version >= 3.2.4)
+* [ZeroMQ](http://zeromq.org) : high-performance asynchronous messaging library (version >= 4.1.4)
 * [Log4CXX](http://logging.apache.org/log4cxx/): Configurable message logger (version >= 0.10.0)
 * [HDF5](https://www.hdfgroup.org/HDF5): __Optional:__ if found, the frame processor application will be built (version >= 1.8.14)
 * [Blosc](http://blosc.org)/[c-blosc](https://github.com/blosc/c-blosc): __Optional:__ if found, the frame processor plugin "BloscPlugin" will be built

--- a/cmake/FindZEROMQ.cmake
+++ b/cmake/FindZEROMQ.cmake
@@ -16,7 +16,7 @@
 #   ZEROMQ_LIBRARIES          The ZEROMQ libraries
 #   ZEROMQ_VERSION            The location of ZEROMQ headers
 #
- 
+
 #=============================================================================
 # Copyright 2013 Atif Mahmood <atif1996@gmail.com>
 # License: GNU LGPL v 3.0, see http://www.gnu.org/licenses/lgpl-3.0-standalone.html
@@ -25,7 +25,7 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the License for more information.
 #=============================================================================
- 
+
 message("\nLooking for ZeroMQ headers and libraries")
 
 if (ZEROMQ_ROOTDIR)
@@ -33,10 +33,10 @@ if (ZEROMQ_ROOTDIR)
 endif()
 
 if (UNIX)
-  find_package(PkgConfig)  
+  find_package(PkgConfig)
   pkg_search_module( zeromq_pkg libzmq)
 endif()
- 
+
 find_path(ZEROMQ_INCLUDE_DIRS
   zmq.h
   HINTS
@@ -47,6 +47,20 @@ find_path(ZEROMQ_INCLUDE_DIRS
   DOC
     "Include Directory for ZEROMQ"
   )
+
+function(extract_version_value value_name file_name value)
+  file(STRINGS ${file_name} val REGEX "${value_name} .")
+  string(FIND ${val} " " last REVERSE)
+  string(SUBSTRING ${val} ${last} -1 val)
+  string(STRIP ${val} val)
+  set(${value} ${val} PARENT_SCOPE)
+endfunction(extract_version_value)
+
+extract_version_value("ZMQ_VERSION_MAJOR" ${ZEROMQ_INCLUDE_DIRS}/zmq.h MAJOR)
+extract_version_value("ZMQ_VERSION_MINOR" ${ZEROMQ_INCLUDE_DIRS}/zmq.h MINOR)
+extract_version_value("ZMQ_VERSION_PATCH" ${ZEROMQ_INCLUDE_DIRS}/zmq.h PATCH)
+
+set(ZEROMQ_VERSION "${MAJOR}.${MINOR}.${PATCH}")
 
 set(ZEROMQ_ROOTDIR_LIB ${ZEROMQ_ROOTDIR}/lib)
 
@@ -67,16 +81,14 @@ if (ZEROMQ_LIB_DEB)
 else()
   set(ZEROMQ_LIBRARIES ${ZEROMQ_LIB_REL})
 endif()
- 
-include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(ZEROMQ 
-    DEFAULT_MSG  
-    ZEROMQ_LIBRARIES
-    ZEROMQ_INCLUDE_DIRS
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZEROMQ
+    REQUIRED_VARS ZEROMQ_LIBRARIES ZEROMQ_INCLUDE_DIRS
+    VERSION_VAR ZEROMQ_VERSION
 )
 
-mark_as_advanced( ZEROMQ_LIBRARIES ZEROMQ_INCLUDE_DIRS)
+mark_as_advanced( ZEROMQ_LIBRARIES ZEROMQ_INCLUDE_DIRS ZEROMQ_VERSION )
 
 if (ZEROMQ_FOUND)
   message(STATUS "Include directories: ${ZEROMQ_INCLUDE_DIRS}")


### PR DESCRIPTION
Resolves issue with unbinding ZeroMQ channels with wildcard endpoint specifier. Also fixes CMake rules for ZeroMQ to correctly detect and validate version.

Fixes #260