### PR TITLE
Make adapters compatible with python 3

### DIFF
--- a/tools/python/odin_data/ipc_tornado_channel.py
+++ b/tools/python/odin_data/ipc_tornado_channel.py
@@ -8,6 +8,8 @@ Tim Nicholls, STFC Application Engineering Group
 """
 from zmq.eventloop.zmqstream import ZMQStream
 from zmq.utils.monitor import parse_monitor_message
+from zmq.utils.strtypes import unicode, cast_bytes
+
 from odin_data.ipc_channel import IpcChannel
 
 
@@ -48,6 +50,12 @@ class IpcTornadoChannel(IpcChannel):
 
         :param: data to send on channel
         """
+
+        # If the data are unicode (like all Python3 native strings), convert to a
+        # byte stream to be sent on the socket
+        if isinstance(data, unicode):
+            data = cast_bytes(data)
+
         # If a Stream is registered send the data out on the tornado IO Loop
         if self._stream:
             self._stream.send(data)
@@ -59,6 +67,11 @@ class IpcTornadoChannel(IpcChannel):
         Send data to the IpcChannel, in multiple parts.
         :param: data to send, as an iterable object
         """
+
+        for idx, part in enumerate(data):
+            if isinstance(part, unicode):
+                data[idx] = cast_bytes(part)
+
         if self._stream:
             self._stream.send_multipart(data)
         else:

--- a/tools/python/odin_data/odin_data_adapter.py
+++ b/tools/python/odin_data/odin_data_adapter.py
@@ -104,7 +104,7 @@ class OdinDataAdapter(ApiAdapter):
         # Check if the adapter type is being requested
         request_command = path.strip('/')
         if not request_command:
-            key_list = self._kwargs.keys()
+            key_list = list(self._kwargs.keys())
             for client in self._clients:
                 for key in client.parameters:
                     if key not in key_list:
@@ -463,7 +463,7 @@ class OdinDataAdapter(ApiAdapter):
             item_dict = param_set
             for item in uri_items:
                 item_dict = item_dict[item]
-        except KeyError, ex:
+        except KeyError as ex:
             item_dict = None
         return item_dict
 

--- a/tools/python/odin_data/util.py
+++ b/tools/python/odin_data/util.py
@@ -7,3 +7,22 @@ def remove_prefix(string, prefix):
 
 def remove_suffix(string, suffix):
     return re.sub("{}$".format(suffix), "", string)
+
+
+def convert_unicode_to_string(self, obj):
+    """
+    Convert all unicode parts of a dictionary or list to standard strings.
+
+    This method may not handle special characters well!
+    :param obj: the dictionary, list, or unicode string
+    :return: the same data type as obj, but with unicode strings converted to python strings.
+    """
+    if isinstance(obj, dict):
+        return {self.convert_unicode_to_string(key): self.convert_unicode_to_string(value)
+                for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [self.convert_unicode_to_string(element) for element in obj]
+    elif isinstance(obj, unicode):
+        return obj.encode('utf-8')
+
+    return obj


### PR DESCRIPTION
This PR implements the minimal changes required for the odin-data and live view adapters to be compatible with odin-control running under python 3.

It address #221 for the odin-data adapter and also provides minor fixes to the live view adapter to correctly coerce float NumPy data types and remove duplicated string conversion code.

This PR does not attempt the full refactor of the odin-data adapter proposed to make it utilise `ParameterTree`, which is still a WIP.