### PR TITLE
Corrected pointer references in Live View Plugin

### DIFF
--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -2,7 +2,7 @@
  * LiveImageViewPlugin.cpp
  *
  *  Created on: 6 Sept 2018
- *      Author: Adam Neaves - wbd45595
+ *      Author: Ashley Neaves
  */
 
 #include "LiveViewPlugin.h"
@@ -204,7 +204,7 @@ void LiveViewPlugin::requestConfiguration(OdinData::IpcMessage& reply)
  */
 void LiveViewPlugin::pass_live_frame(boost::shared_ptr<Frame> frame)
 {
-  void* frame_data_copy = (void*)frame->get_data_ptr();
+  void* frame_data_copy = (void*)frame->get_image_ptr();
 
   const FrameMetaData meta_data = frame->get_meta_data();
 
@@ -212,7 +212,7 @@ void LiveViewPlugin::pass_live_frame(boost::shared_ptr<Frame> frame)
   std::string aqqID = meta_data.get_acquisition_ID();
   dimensions_t dim = meta_data.get_dimensions();
   std::string type = get_type_from_enum((DataType)meta_data.get_data_type());
-  std::size_t size = frame->get_data_size();
+  std::size_t size = frame->get_image_size();
   std::string compress = get_compress_from_enum((CompressionType)meta_data.get_compression_type());
   std::string dataset = meta_data.get_dataset_name();
 

--- a/frameProcessor/src/LiveViewPluginLib.cpp
+++ b/frameProcessor/src/LiveViewPluginLib.cpp
@@ -2,7 +2,7 @@
  * LiveViewPluginLib.cpp
  *
  *  Created on: 11 Sept 2018
- *      Author: Adam Neaves - wbd45595
+ *      Author: Ashley Neaves
  */
 
 #include "LiveViewPlugin.h"

--- a/frameProcessor/test/LiveViewUnitTest.cpp
+++ b/frameProcessor/test/LiveViewUnitTest.cpp
@@ -2,7 +2,7 @@
  * LiveViewUnitTest.cpp
  *
  *  Created on: 28 Sep 2018
- *      Author: Adam Neaves - wbd45595
+ *      Author: Ashley Neaves
  */
 
 #include <boost/test/unit_test.hpp>

--- a/tools/imagej/src/LiveViewSocket.java
+++ b/tools/imagej/src/LiveViewSocket.java
@@ -14,7 +14,7 @@ import org.json.*;
 
 /**
  * Class that contains the ZMQ subscriber socket and logic for what to do with an image when it arrives.
- * @author Adam Neaves
+ * @author Ashley Neaves
  * @version 0.1.0
  */
 public class LiveViewSocket 

--- a/tools/imagej/src/Live_View.java
+++ b/tools/imagej/src/Live_View.java
@@ -19,7 +19,7 @@ import org.zeromq.ZMQException;
 
 /**
  * This is an ImageJ Plugin that allows ImageJ to receive and display images from the Odin Data Live View Plugin.
- * @author Adam Neaves
+ * @author Ashley Neaves
  * @version 0.1.0
  */
 public class Live_View extends PlugInFrame implements ActionListener, Observer

--- a/tools/imagej/src/plugins.config
+++ b/tools/imagej/src/plugins.config
@@ -1,5 +1,5 @@
 # Name: Live_View
-# Author: Adam Neaves
+# Author: Ashley Neaves
 # Version: 0.1
 # Date: 2018/11/22
 # Requires: ImageJ 1.31s

--- a/tools/python/odin_data/live_view_adapter.py
+++ b/tools/python/odin_data/live_view_adapter.py
@@ -5,7 +5,7 @@ view images to users.
 
 Created on 8th October 2018
 
-:author: Adam Neaves, STFC Application Engineering Gruop
+:author: Ashley Neaves, STFC Application Engineering Gruop
 """
 
 import logging

--- a/tools/python/odin_data/live_view_proxy_adapter.py
+++ b/tools/python/odin_data/live_view_proxy_adapter.py
@@ -6,7 +6,7 @@ into a single ZMQ stream.
 
 Created on 28th January 2019
 
-:author: Adam Neaves, STFC Application Engineering Group
+:author: Ashley Neaves, STFC Application Engineering Group
 """
 import logging
 from queue import PriorityQueue


### PR DESCRIPTION
Live view plugin was using the data pointer within frames, rather than the offset image pointer. This caused an issue if a header struct remained within the frame's datablock for whatever reason.


(Additionally, this PR removes all references to my old name. It's been 19 months since I used that name, it's about time really.)