### PR TITLE
Add an option for setting HDF5 file postfix.

### DIFF
--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -41,6 +41,7 @@ public:
     size_t concurrent_processes,
     size_t frames_per_block,
     size_t blocks_per_file,
+    std::string file_postfix,
     std::string file_extension,
     bool use_earliest_hdf5,
     size_t alignment_threshold,
@@ -71,6 +72,8 @@ public:
   std::string filename_;
   /** Configured value to be used as the prefix to generate the filename. */
   std::string configured_filename_;
+  /** Configured value to be used as extra filename control if required. */
+  std::string file_postfix_;
   /** File extension to use */
   std::string file_extension_;
   /** Use the earliest version of hdf5 */

--- a/frameProcessor/include/Acquisition.h
+++ b/frameProcessor/include/Acquisition.h
@@ -41,6 +41,8 @@ public:
     size_t concurrent_processes,
     size_t frames_per_block,
     size_t blocks_per_file,
+    uint32_t starting_file_index,
+    bool use_file_numbers,
     std::string file_postfix,
     std::string file_extension,
     bool use_earliest_hdf5,
@@ -66,6 +68,10 @@ public:
   size_t frames_to_write_;
   /** Total number of frames in acquisition */
   size_t total_frames_;
+  /** Starting file index (default to 0 index based numbering) */
+  uint32_t starting_file_index_;
+  /** Do we use file numbers in the file name construction.  Defaults to true */
+  bool use_file_numbers_;
   /** Path of the file to write to */
   std::string file_path_;
   /** Name of the file to write to */

--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -85,6 +85,10 @@ private:
   static const std::string CONFIG_FILE;
   /** Configuration constant for file name */
   static const std::string CONFIG_FILE_NAME;
+  /** Configuration constant for using automatic file name numbering */
+  static const std::string CONFIG_FILE_USE_NUMBERS;
+  /** Configuration constant for starting file number if using numbering */
+  static const std::string CONFIG_FILE_NUMBER_START;
   /** Configuration constant for file name postfix (optional) */
   static const std::string CONFIG_FILE_POSTFIX;
   /** Configuration constant for file path */
@@ -183,6 +187,10 @@ private:
   bool timeout_thread_running_;
   /** The close file timeout thread */
   boost::thread timeout_thread_;
+  /** Starting file index (default to 0 index based numbering) */
+  uint32_t first_file_index_;
+  /** Do we use file numbers in the file name construction.  Defaults to true */
+  bool use_file_numbering_;
   /** The optional file postfix to add */
   std::string file_postfix_;
   /** The file extension to use */

--- a/frameProcessor/include/FileWriterPlugin.h
+++ b/frameProcessor/include/FileWriterPlugin.h
@@ -85,6 +85,8 @@ private:
   static const std::string CONFIG_FILE;
   /** Configuration constant for file name */
   static const std::string CONFIG_FILE_NAME;
+  /** Configuration constant for file name postfix (optional) */
+  static const std::string CONFIG_FILE_POSTFIX;
   /** Configuration constant for file path */
   static const std::string CONFIG_FILE_PATH;
   /** Configuration constant for file extension */
@@ -181,6 +183,8 @@ private:
   bool timeout_thread_running_;
   /** The close file timeout thread */
   boost::thread timeout_thread_;
+  /** The optional file postfix to add */
+  std::string file_postfix_;
   /** The file extension to use */
   std::string file_extension_;
   /** Name of master frame. When a master frame is received frame numbers increment */

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -50,6 +50,7 @@ Acquisition::Acquisition(const HDF5ErrorDefinition_t& hdf5_error_definition) :
         alignment_threshold_(1),
         alignment_value_(1),
         last_error_(""),
+        file_postfix_(""),
         hdf5_error_definition_(hdf5_error_definition)
 {
   this->logger_ = Logger::getLogger("FP.Acquisition");
@@ -339,6 +340,7 @@ bool Acquisition::start_acquisition(
     size_t concurrent_processes,
     size_t frames_per_block,
     size_t blocks_per_file,
+    std::string file_postfix,
     std::string file_extension,
     bool use_earliest_hdf5,
     size_t alignment_threshold,
@@ -354,6 +356,7 @@ bool Acquisition::start_acquisition(
   use_earliest_hdf5_ = use_earliest_hdf5;
   alignment_threshold_ = alignment_threshold;
   alignment_value_ = alignment_value;
+  file_postfix_ = file_postfix;
   file_extension_ = file_extension;
   master_frame_ = master_frame;
 
@@ -644,11 +647,11 @@ std::string Acquisition::generate_filename(size_t file_number) {
   snprintf(number_string, 7, "%06d", file_number + 1);
   if (!configured_filename_.empty())
   {
-    generated_filename << configured_filename_ << "_" << number_string << file_extension_;
+    generated_filename << configured_filename_ << file_postfix_ << "_" << number_string << file_extension_;
   }
   else if (!acquisition_id_.empty())
   {
-    generated_filename << acquisition_id_ << "_" << number_string << file_extension_;
+    generated_filename << acquisition_id_ << file_postfix_ << "_" << number_string << file_extension_;
   }
 
   return generated_filename.str();

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -661,14 +661,12 @@ std::string Acquisition::generate_filename(size_t file_number) {
   if (!configured_filename_.empty())
   {
     generated_filename << configured_filename_ << file_postfix_;
-    if (use_file_numbers_){
-      generated_filename << "_" << number_string;
-    }
-    generated_filename << file_extension_;
   }
   else if (!acquisition_id_.empty())
   {
     generated_filename << acquisition_id_ << file_postfix_;
+  }
+  if (!generated_filename.str().empty()){
     if (use_file_numbers_){
       generated_filename << "_" << number_string;
     }

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -30,6 +30,8 @@ const std::string FileWriterPlugin::CONFIG_PROCESS_ALIGNMENT_VALUE     = "alignm
 
 const std::string FileWriterPlugin::CONFIG_FILE                        = "file";
 const std::string FileWriterPlugin::CONFIG_FILE_NAME                   = "name";
+const std::string FileWriterPlugin::CONFIG_FILE_USE_NUMBERS            = "use_numbers";
+const std::string FileWriterPlugin::CONFIG_FILE_NUMBER_START           = "first_number";
 const std::string FileWriterPlugin::CONFIG_FILE_POSTFIX                = "postfix";
 const std::string FileWriterPlugin::CONFIG_FILE_PATH                   = "path";
 const std::string FileWriterPlugin::CONFIG_FILE_EXTENSION              = "extension";
@@ -73,6 +75,8 @@ FileWriterPlugin::FileWriterPlugin() :
         concurrent_rank_(0),
         frames_per_block_(1),
         blocks_per_file_(0),
+        first_file_index_(0),
+        use_file_numbering_(true),
         file_postfix_(""),
         file_extension_("h5"),
         use_earliest_hdf5_(false),
@@ -201,6 +205,8 @@ void FileWriterPlugin::start_writing()
         concurrent_processes_,
         frames_per_block_,
         blocks_per_file_,
+        first_file_index_,
+        use_file_numbering_,
         file_postfix_,
         file_extension_,
         use_earliest_hdf5_,
@@ -373,6 +379,8 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
   std::string file_str = get_name() + "/" + FileWriterPlugin::CONFIG_FILE + "/";
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_PATH, next_acquisition_->file_path_);
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_NAME, next_acquisition_->configured_filename_);
+  reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_USE_NUMBERS, use_file_numbering_);
+  reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_NUMBER_START, first_file_index_);
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_POSTFIX, file_postfix_);
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_EXTENSION, file_extension_);
   // Configure HDF5 call error durations
@@ -577,6 +585,14 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
   if (config.has_param(FileWriterPlugin::CONFIG_FILE_NAME)) {
     this->next_acquisition_->configured_filename_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_NAME);
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Next file name changed to " << this->next_acquisition_->configured_filename_);
+  }
+  if (config.has_param(FileWriterPlugin::CONFIG_FILE_USE_NUMBERS)) {
+    this->use_file_numbering_ = config.get_param<bool>(FileWriterPlugin::CONFIG_FILE_USE_NUMBERS);
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "File name 'use file numbers' changed to " << this->use_file_numbering_);
+  }
+  if (config.has_param(FileWriterPlugin::CONFIG_FILE_NUMBER_START)) {
+    this->first_file_index_ = config.get_param<int>(FileWriterPlugin::CONFIG_FILE_NUMBER_START);
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "File name first index number changed to " << this->first_file_index_);
   }
   if (config.has_param(FileWriterPlugin::CONFIG_FILE_POSTFIX)) {
     this->file_postfix_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_POSTFIX);

--- a/frameProcessor/src/FileWriterPlugin.cpp
+++ b/frameProcessor/src/FileWriterPlugin.cpp
@@ -30,6 +30,7 @@ const std::string FileWriterPlugin::CONFIG_PROCESS_ALIGNMENT_VALUE     = "alignm
 
 const std::string FileWriterPlugin::CONFIG_FILE                        = "file";
 const std::string FileWriterPlugin::CONFIG_FILE_NAME                   = "name";
+const std::string FileWriterPlugin::CONFIG_FILE_POSTFIX                = "postfix";
 const std::string FileWriterPlugin::CONFIG_FILE_PATH                   = "path";
 const std::string FileWriterPlugin::CONFIG_FILE_EXTENSION              = "extension";
 
@@ -72,6 +73,7 @@ FileWriterPlugin::FileWriterPlugin() :
         concurrent_rank_(0),
         frames_per_block_(1),
         blocks_per_file_(0),
+        file_postfix_(""),
         file_extension_("h5"),
         use_earliest_hdf5_(false),
         alignment_threshold_(1),
@@ -199,6 +201,7 @@ void FileWriterPlugin::start_writing()
         concurrent_processes_,
         frames_per_block_,
         blocks_per_file_,
+        file_postfix_,
         file_extension_,
         use_earliest_hdf5_,
         alignment_threshold_,
@@ -370,6 +373,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
   std::string file_str = get_name() + "/" + FileWriterPlugin::CONFIG_FILE + "/";
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_PATH, next_acquisition_->file_path_);
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_NAME, next_acquisition_->configured_filename_);
+  reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_POSTFIX, file_postfix_);
   reply.set_param(file_str + FileWriterPlugin::CONFIG_FILE_EXTENSION, file_extension_);
   // Configure HDF5 call error durations
   reply.set_param(file_str + FileWriterPlugin::CREATE_ERROR_DURATION, hdf5_error_definition_.create_duration);
@@ -573,6 +577,10 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
   if (config.has_param(FileWriterPlugin::CONFIG_FILE_NAME)) {
     this->next_acquisition_->configured_filename_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_NAME);
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Next file name changed to " << this->next_acquisition_->configured_filename_);
+  }
+  if (config.has_param(FileWriterPlugin::CONFIG_FILE_POSTFIX)) {
+    this->file_postfix_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_POSTFIX);
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "File name postfix changed to " << this->file_postfix_);
   }
   if (config.has_param(FileWriterPlugin::CONFIG_FILE_EXTENSION)) {
     this->file_extension_ = config.get_param<std::string>(FileWriterPlugin::CONFIG_FILE_EXTENSION);

--- a/test/integrationTest/config/dummyUDP-fp.json
+++ b/test/integrationTest/config/dummyUDP-fp.json
@@ -77,7 +77,8 @@
 	    },
 	    "file":
 	    {
-		"path":""
+		"path":"",
+		"first_number":1
 	    },
 	    "frames":10,
 	    "acquisition_id":"test_1",


### PR DESCRIPTION
For a case where data is stored into file with geographical separation instead of round robin of frames it makes sense for the file names to be labelled with slightly different names and all retain the same numbering (e.g.):
file_A_000001.h5
file_B_000001.h5
This change allows the specification of a file postfix (_A or _B in the example above) placed before the automatic numbering.