### PR TITLE
Allow targeting of frames for specific plugin chains

### DIFF
--- a/frameProcessor/include/FrameProcessorPlugin.h
+++ b/frameProcessor/include/FrameProcessorPlugin.h
@@ -54,6 +54,7 @@ public:
 
 protected:
   void push(boost::shared_ptr<Frame> frame);
+  void push(const std::string& plugin_name, boost::shared_ptr<Frame> frame);
 
 private:
   /** Pointer to logger */

--- a/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -341,6 +341,27 @@ void FrameProcessorPlugin::push(boost::shared_ptr<Frame> frame)
   }
 }
 
+/** Push the supplied frame to a specifically named registered callback.
+ *
+ * This method calls the named blocking callback directly or places the frame
+ * pointer on the named worker queue (see IFrameCallback).
+ *
+ * \param[in] plugin_name - Name of the plugin to send the frame to.
+ * \param[in] frame - Pointer to the frame.
+ */
+void FrameProcessorPlugin::push(const std::string& plugin_name, boost::shared_ptr<Frame> frame)
+{
+  if (!frame->get_end_of_acquisition() && !frame->is_valid()){
+    throw std::runtime_error("FrameProcessorPlugin::push Invalid frame pushed onto plugin chain");
+  }
+  if (blocking_callbacks_.find(plugin_name) != blocking_callbacks_.end()){
+    blocking_callbacks_[plugin_name]->callback(frame);
+  }
+  if (callbacks_.find(plugin_name) != callbacks_.end()){
+    callbacks_[plugin_name]->getWorkQueue()->add(frame);
+  }
+}
+
 /** Perform any end of acquisition cleanup.
  *
  * This default implementation does nothing.  Any plugins that want to perform


### PR DESCRIPTION
Reason:
Xspress detector batches spectra into blocks of 256.  This single "frame" is written to HDF5.  However, the individual incoming MCAs need to be pushed to the live view plugin as they arrive.  We do not want to push them to the FileWriter plugin because the FP will drop into an error state as these individual frames are not expected.

Solution:
Overload the push method and allow a plugin to target a chain for a specific frame or frames.  This could be useful also for sending differing types of frames to different processing plugin chains.