### PR TITLE
Implement frame objects containing multiple datasets in outer chunk dimension

### DIFF
--- a/frameProcessor/include/Frame.h
+++ b/frameProcessor/include/Frame.h
@@ -69,6 +69,12 @@ class Frame {
   /** Set the image offset */
   void set_image_offset(const int &offset);
 
+  /** Set the outer chunk size */
+  void set_outer_chunk_size(const int &size);
+
+  /** Set the outer chunk size */
+  int get_outer_chunk_size() const;
+
  protected:
 
   /** Pointer to logger */
@@ -85,6 +91,9 @@ class Frame {
 
   /** Offset from frame memory start to image data */
   int image_offset_;
+
+  /** Outer chunk size of this frame (number of images in this chunk) */
+  int outer_chunk_size_;
 
 };
 

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -150,7 +150,7 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame, HD
       // are true then increment the number of frames written.
       if (master_frame_.empty() || master_frame_ == frame_dataset_name) {
         size_t dataset_frames = current_file_->get_dataset_frames(frame_dataset_name);
-        frames_processed_++;
+        frames_processed_ += frame->get_outer_chunk_size();
         LOG4CXX_TRACE(logger_, "Master frame processed");
         size_t current_file_index = current_file_->get_file_index() / concurrent_processes_;
         size_t frames_written_to_previous_files = current_file_index * frames_per_block_ * blocks_per_file_;

--- a/frameProcessor/src/BloscPlugin.cpp
+++ b/frameProcessor/src/BloscPlugin.cpp
@@ -149,6 +149,7 @@ boost::shared_ptr<Frame> BloscPlugin::compress_frame(boost::shared_ptr<Frame> sr
 
 
   dest_frame->set_image_size(compressed_size);
+  dest_frame->set_outer_chunk_size(src_frame->get_outer_chunk_size());
 
   return dest_frame;
 }

--- a/frameProcessor/src/Frame.cpp
+++ b/frameProcessor/src/Frame.cpp
@@ -13,6 +13,7 @@ namespace FrameProcessor {
             data_size_(data_size),
             image_offset_(image_offset),
             image_size_(data_size-image_offset),
+            outer_chunk_size_(1),
             logger_(log4cxx::Logger::getLogger("FP.Frame")) {
     }
 
@@ -23,6 +24,7 @@ namespace FrameProcessor {
     Frame::Frame(const Frame &frame) {
       meta_data_ = frame.meta_data_;
       image_offset_ = frame.image_offset_;
+      outer_chunk_size_ = frame.outer_chunk_size_;
       logger_ = frame.logger_;
     }
 
@@ -34,6 +36,7 @@ namespace FrameProcessor {
     Frame &Frame::operator=(const Frame &frame) {
       meta_data_ = frame.meta_data_;
       image_offset_ = frame.image_offset_;
+      outer_chunk_size_ = frame.outer_chunk_size_;
       logger_ = frame.logger_;
       return *this;
     }
@@ -147,6 +150,22 @@ namespace FrameProcessor {
     void Frame::set_image_offset(const int &offset) {
       this->image_offset_ = offset;
       this->image_size_ = this->data_size_ - this->image_offset_;
+    }
+
+/** Set the outer chunk size of the frame (number of trigger acqs in chunk)
+ * @param size - outer_chunk_size
+ */
+    void Frame::set_outer_chunk_size(const int &size)
+    {
+      this->outer_chunk_size_ = size;
+    }
+
+/** Get the outer chunk size of the frame (number of trigger acqs in chunk)
+ * @return outer_chunk_size
+ */
+    int Frame::get_outer_chunk_size() const
+    {
+      return this->outer_chunk_size_;
     }
 
 }

--- a/frameProcessor/src/HDF5File.cpp
+++ b/frameProcessor/src/HDF5File.cpp
@@ -262,9 +262,10 @@ void HDF5File::write_frame(
   }
 #endif
 
-  // Set actual_dataset_size_ to the offset we just wrote to + 1 (Note: frame_offset is zero-indexed)
-  if (frame_offset + 1 > dset.actual_dataset_size_) {
-    dset.actual_dataset_size_ = frame_offset + 1;
+  // Check if the latest written frame has extended the dataset, and if it has then
+  // adjust the actual_dataset_size_ member of the dset structure to match the real size
+  if (offset[0] + frame.get_outer_chunk_size() > dset.actual_dataset_size_) {
+    dset.actual_dataset_size_ = offset[0] + frame.get_outer_chunk_size();
   }
 }
 


### PR DESCRIPTION
This PR provides a mechanism for writing frame objects that contain multiple dataset entries in the outer chunking dimension of the frame.
The specific case that requires this is for the Xspress detector which contains arrays of 4096 elements.  In the current codebase there are two options:
1) Write out chunks of 1x4096 elements
2) Create sudo frames of 256x4096 elements to write reasonable chunks but the resulting dataset would be <n>x256x4096
Neither of these options are appropriate for these datasets.

This PR allows a frame to have set its outer chunk dimension and therefore each frame object can contain multiple individual datasets (in our case 256x4096).  As these frames are written the dataset size jumps by the number of the outer chunking dimension which is a correct representation of the data.

The specific example for Xspress is below:
Previously as data is recorded the dataset would grow as follows:
1x256x4096
2x256x4096
3x256x4096 ...

With this change the dataset grows as follows:
256x4096
512x4096
768x4096 ...

The default behaviour of the frame objects is to have an outer chunk dimension of 1 which is the current implied hardcoded implementation.
