### PR TITLE
Fix elapsed time calculation in live view rate settiing.

### DIFF
--- a/frameProcessor/include/LiveViewPlugin.h
+++ b/frameProcessor/include/LiveViewPlugin.h
@@ -80,7 +80,9 @@ private:
 
 
   /**time between frames in milliseconds, calculated from the per_second config*/
-  int32_t time_between_frames_;
+  //int32_t time_between_frames_;
+  boost::posix_time::time_duration time_between_frames_;
+
   /**time the last frame was shown*/
   boost::posix_time::ptime time_last_frame_;
 


### PR DESCRIPTION
The elapsed time calcuation relies on truncating a posix_time duration to milliseconds as an int_32, which can fail with an incorrect value on the initial frame, or if the frame processor has been idling for long periods. To resolve this, the time since last frame variable is now stored and compared as a time_duration.

Also tidied up the live view decision logic so that the elapsed time is only calculated if the per_second rate setting is active