### PR TITLE
Stats Publish

### DIFF
--- a/cpp/common/include/Json.h
+++ b/cpp/common/include/Json.h
@@ -34,6 +34,8 @@ public:
 
   void add(const std::string& key, const std::string&  json_value);
 
+  void add(const std::string& key, JsonDict& json_dict);
+
   /** Add a vector value to the underlying rapidjson::Document
    *
    * \param[in] key - The key of the item to add

--- a/cpp/common/include/Json.h
+++ b/cpp/common/include/Json.h
@@ -32,6 +32,8 @@ public:
     add(key, json_value);
   }
 
+  void add(const std::string& key, const long long json_value);
+
   void add(const std::string& key, const std::string&  json_value);
 
   void add(const std::string& key, JsonDict& json_dict);

--- a/cpp/common/src/Json.cpp
+++ b/cpp/common/src/Json.cpp
@@ -29,6 +29,11 @@ void JsonDict::add(const std::string& key, rapidjson::Value& json_value)
   document_.AddMember(json_key, json_value, document_.GetAllocator());
 }
 
+void JsonDict::add(const std::string& key, JsonDict& json_dict) {
+  rapidjson::Value json_key(key.c_str(), document_.GetAllocator());
+  document_.AddMember(json_key, json_dict.document_, this->document_.GetAllocator());
+}
+
 void JsonDict::add(const std::string& key, const std::string& value) {
   rapidjson::Value json_value;
   json_value.SetString(value.c_str(), value.length(), document_.GetAllocator());

--- a/cpp/common/src/Json.cpp
+++ b/cpp/common/src/Json.cpp
@@ -40,6 +40,11 @@ void JsonDict::add(const std::string& key, const std::string& value) {
   add(key, json_value);
 }
 
+void JsonDict::add(const std::string& key, const long long json_value) {
+  // Cast to avoid ambiguous rapidjson::Value constructor call
+  add(key, (int64_t) json_value);
+}
+
 /** Generate a string from the rapidjson::Document
  *
  * \return - The string

--- a/cpp/frameProcessor/include/CMakeLists.txt
+++ b/cpp/frameProcessor/include/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(HEADERS DataBlock.h
             BloscPlugin.h
             SumPlugin.h
             GapFillPlugin.h
+            ParameterPublishPlugin.h
             KafkaProducerPlugin.h)
 
 INSTALL(FILES ${HEADERS} DESTINATION include/frameProcessor)

--- a/cpp/frameProcessor/include/ParameterPublishPlugin.h
+++ b/cpp/frameProcessor/include/ParameterPublishPlugin.h
@@ -1,0 +1,63 @@
+/*
+ *  Created on: 22 Nov 2021
+ *      Author: Gary Yendell
+ */
+
+#ifndef PARAMETERPUBLISHPLUGIN_H
+#define PARAMETERPUBLISHPLUGIN_H
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "IpcChannel.h"
+
+#include "FrameProcessorPlugin.h"
+
+/**
+ * This plugin class looks for the configured parameters on a Frame and publishes them over ZMQ
+ */
+namespace FrameProcessor {
+
+  class ParameterPublishPlugin : public FrameProcessorPlugin {
+    public:
+      ParameterPublishPlugin();
+      ~ParameterPublishPlugin();
+
+      void process_frame(boost::shared_ptr<Frame> frame);
+      void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
+
+      int get_version_major();
+      int get_version_minor();
+      int get_version_patch();
+      std::string get_version_short();
+      std::string get_version_long();
+
+      // Config message keys
+      static const std::string CONFIG_ENDPOINT;
+      static const std::string CONFIG_ADD_PARAMETER;
+      // Data message keys
+      static const std::string DATA_FRAME_NUMBER;
+      static const std::string DATA_PARAMETERS;
+
+    private:
+      /** Pointer to logger */
+      LoggerPtr logger_;
+      /** Parameters to publish */
+      std::set<std::string> parameters_;
+      /** Configured endpoint messages are published on */
+      std::string channel_endpoint_;
+      /** IpcChannel for publishing messages */
+      OdinData::IpcChannel publish_channel_;
+
+      void setup_publish_channel(const std::string& endpoint);
+      void requestConfiguration(OdinData::IpcMessage& reply);
+  };
+
+} /* namespace FrameProcessor */
+
+#endif //PARAMETERPUBLISHPLUGIN_H

--- a/cpp/frameProcessor/include/SumPlugin.h
+++ b/cpp/frameProcessor/include/SumPlugin.h
@@ -1,6 +1,8 @@
-//
-// Created by hir12111 on 30/10/18.
-//
+/*
+ *  Created on: 30 Oct 2018
+ *      Authors: Emilio Perez Juarez,
+ *               Gary Yendell
+ */
 
 #ifndef SUMPLUGIN_H
 #define SUMPLUGIN_H
@@ -22,7 +24,70 @@ using namespace log4cxx::helpers;
  */
 namespace FrameProcessor {
 
-  static const std::string SUM_PARAM_NAME = "sum";
+  struct Sum;
+
+  /**
+   * A container representing a histogram consisting of a pair of bidirectional maps and a vector
+   *
+   * The keys/values of the maps are `std::string` (the name of a histogram bin) and `uint64_t` (the number of counts)
+   * a pixel must have to be placed in that bin.
+   *
+   * This struct enables:
+   *   - Lookup of uint64_t by std::string key
+   *   - Lookup of std::string by uint64_t key
+   *   - Random access of uint64_t values by index (in an ordered vector of uint64_t)
+   *
+   * It can store the histogram threshold definitions and increment the correct bin of a corresponding `Sum` struct
+   * according to those definitions and a given number of counts in a pixel.
+   *
+   * \param[in] index - Index of threshold to lookup
+   */
+  class Histogram {
+    public:
+      /**
+       * Constructor
+       */
+      Histogram() :
+        name_threshold_map_(),
+        threshold_name_map_(),
+        threshold_vector_()
+      {}
+
+      std::string& get_name_by_index(uint index);
+      const std::map<std::string, uint64_t>& get_name_threshold_map();
+      void add_bin(std::string& name, uint64_t& threshold);
+      void bin_pixel(Sum& sum, uint64_t counts);
+
+    private:
+      std::map<std::string, uint64_t> name_threshold_map_;
+      std::map<uint64_t, std::string> threshold_name_map_;
+      std::vector<uint64_t> threshold_vector_;
+
+      void _bin_pixel(Sum& sum, uint64_t counts, uint previous_index);
+  };
+
+  /**
+   * A container representing the total counts and a histogram of arbitrary bins of the data elements in a `Frame`
+   */
+  struct Sum {
+    uint64_t total_counts;
+    std::map<std::string, uint64_t> histogram;
+
+  /**
+   * Constructor
+   *
+   * Initialise `this->histogram` recreating the bins from given `histogram`, but setting the values to `0`
+   *
+   * \param[in] histogram - map of histogram name to histogram threshold
+   */
+    Sum(std::map<std::string, uint64_t> histogram) {
+      total_counts = 0;
+      std::map<std::string, uint64_t>::const_iterator bin;
+      for(bin = histogram.begin(); bin != histogram.end(); ++bin) {
+        this->histogram[bin->first] = 0;
+      }
+    }
+  };
 
   class SumPlugin : public FrameProcessorPlugin {
   public:
@@ -30,7 +95,11 @@ namespace FrameProcessor {
 
     ~SumPlugin();
 
-    void process_frame(boost::shared_ptr <Frame> frame);
+    void process_frame(boost::shared_ptr<Frame> frame);
+    template<class PixelType>
+    Sum calculate_sum(boost::shared_ptr<Frame> frame);
+    void add_data_to_frame(boost::shared_ptr<Frame> frame, Sum& sum);
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
 
     int get_version_major();
 
@@ -42,9 +111,19 @@ namespace FrameProcessor {
 
     std::string get_version_long();
 
+    // Parameter names on Frame
+    static const std::string SUM_PARAM_NAME;
+    // Config Strings
+    static const std::string CONFIG_HISTOGRAM;
+
   private:
     /** Pointer to logger */
     LoggerPtr logger_;
+    /** Container storing name and threshold of histogram bins */
+    Histogram histogram_;
+
+    void requestConfiguration(OdinData::IpcMessage& reply);
+
   };
 
 } /* namespace FrameProcessor */

--- a/cpp/frameProcessor/src/CMakeLists.txt
+++ b/cpp/frameProcessor/src/CMakeLists.txt
@@ -85,6 +85,11 @@ add_library(GapFillPlugin SHARED GapFillPlugin.cpp GapFillPluginLib.cpp)
 target_link_libraries(GapFillPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
 install(TARGETS GapFillPlugin DESTINATION lib)
 
+# Add library for Parameter Publish plugin
+add_library(ParameterPublishPlugin SHARED ParameterPublishPlugin.cpp ParameterPublishPluginLib.cpp)
+target_link_libraries(ParameterPublishPlugin ${LIB_PROCESSOR} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${COMMON_LIBRARY})
+install(TARGETS ParameterPublishPlugin DESTINATION lib)
+
 if (${KAFKA_FOUND})
     include_directories(${KAFKA_INCLUDE_DIR})
     # Add library for Kafka Producer plugin

--- a/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
+++ b/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
@@ -1,0 +1,155 @@
+/*
+ *  Created on: 22 Nov 2021
+ *      Author: Gary Yendell
+ */
+
+#include "DebugLevelLogger.h"
+#include "Json.h"
+#include "version.h"
+
+#include "ParameterPublishPlugin.h"
+
+namespace FrameProcessor {
+
+  const std::string ParameterPublishPlugin::CONFIG_ENDPOINT = "endpoint";
+  const std::string ParameterPublishPlugin::CONFIG_ADD_PARAMETER = "add_parameter";
+  const std::string ParameterPublishPlugin::DATA_FRAME_NUMBER = "frame_number";
+  const std::string ParameterPublishPlugin::DATA_PARAMETERS = "parameters";
+
+  /**
+   * The constructor sets up logging used within the class.
+   */
+  ParameterPublishPlugin::ParameterPublishPlugin() :
+    publish_channel_(ZMQ_PUB),
+    channel_endpoint_("")
+  {
+    // Setup logging for the class
+    logger_ = Logger::getLogger("FP.ParameterPublishPlugin");
+    LOG4CXX_INFO(logger_, "ParameterPublishPlugin version " << this->get_version_long() << " loaded");
+
+  }
+
+  /**
+   * Destructor.
+   */
+  ParameterPublishPlugin::~ParameterPublishPlugin()
+  {
+    LOG4CXX_TRACE(logger_, "ParameterPublishPlugin destructor.");
+  }
+
+  /**
+   * Publish the configured parameters if found on the frame
+   *
+   * \param[in] frame - Pointer to a Frame object.
+   */
+  void ParameterPublishPlugin::process_frame(boost::shared_ptr<Frame> frame)
+  {
+    OdinData::JsonDict json, parameters_json;
+    std::set<std::string>::iterator parameter;
+    for (parameter = this->parameters_.begin(); parameter != this->parameters_.end(); ++parameter) {
+      if (frame->meta_data().has_parameter(*parameter)) {
+        parameters_json.add(*parameter, frame->meta_data().get_parameter<uint64_t>(*parameter));
+      }
+    }
+    json.add(DATA_FRAME_NUMBER, frame->get_frame_number());
+    json.add(DATA_PARAMETERS, parameters_json);
+
+    this->publish_channel_.send(json.str().c_str());
+
+    this->push(frame);
+  }
+
+  /**
+   * Set configuration options for this Plugin.
+   *
+   * \param[in] config - IpcMessage containing configuration data.
+   * \param[out] reply - Response IpcMessage.
+   */
+  void ParameterPublishPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+  {
+    try {
+      if (config.has_param(CONFIG_ENDPOINT)) {
+        std::string endpoint = config.get_param<std::string>(CONFIG_ENDPOINT);
+        this->setup_publish_channel(endpoint);
+      }
+
+      if (config.has_param(CONFIG_ADD_PARAMETER)) {
+        std::string parameter = config.get_param<const rapidjson::Value&>(CONFIG_ADD_PARAMETER).GetString();
+        this->parameters_.insert(parameter);
+      }
+    }
+    catch (std::runtime_error& e) {
+      std::stringstream ss;
+      ss << "Bad ctrl msg: " << e.what();
+      this->set_error(ss.str());
+      throw;
+    }
+  }
+
+/**
+ * Get the configuration values for this plugin
+ *
+ * \param[out] reply - Response IpcMessage.
+ */
+void ParameterPublishPlugin::requestConfiguration(OdinData::IpcMessage& reply)
+{
+  reply.set_param(get_name() + "/" + CONFIG_ENDPOINT, this->channel_endpoint_);
+
+  // Create use a key with a `[]` suffix so that it appends to an array as we set it repeatedly
+  std::string parameters_key = get_name() + "/" + DATA_PARAMETERS + "[]";
+  std::set<std::string>::iterator it;
+  for (it = this->parameters_.begin(); it != this->parameters_.end(); ++it) {
+    reply.set_param(parameters_key, *it);
+  }
+}
+
+  /** Bind to endpoint and store for config reporting
+   *
+   * \param[in] endpoint - The endpoint to bind to
+   */
+  void ParameterPublishPlugin::setup_publish_channel(const std::string& endpoint)
+  {
+    if (!this->channel_endpoint_.empty()) {
+      throw std::runtime_error("Endpoint already bound");
+    }
+
+    try {
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "Connecting channel to endpoint: " << endpoint);
+      this->channel_endpoint_ = endpoint;
+      this->publish_channel_.bind(this->channel_endpoint_.c_str());
+    }
+    catch (zmq::error_t& e) {
+      throw std::runtime_error(e.what());
+    }
+  }
+
+  /** Version reporting
+   *
+   */
+
+  int ParameterPublishPlugin::get_version_major()
+  {
+    return ODIN_DATA_VERSION_MAJOR;
+  }
+
+  int ParameterPublishPlugin::get_version_minor()
+  {
+    return ODIN_DATA_VERSION_MINOR;
+  }
+
+  int ParameterPublishPlugin::get_version_patch()
+  {
+    return ODIN_DATA_VERSION_PATCH;
+  }
+
+  std::string ParameterPublishPlugin::get_version_short()
+  {
+    return ODIN_DATA_VERSION_STR_SHORT;
+  }
+
+  std::string ParameterPublishPlugin::get_version_long()
+  {
+    return ODIN_DATA_VERSION_STR;
+  }
+
+} /* namespace FrameProcessor */

--- a/cpp/frameProcessor/src/ParameterPublishPluginLib.cpp
+++ b/cpp/frameProcessor/src/ParameterPublishPluginLib.cpp
@@ -1,0 +1,12 @@
+#include "ParameterPublishPlugin.h"
+#include "ClassLoader.h"
+
+namespace FrameProcessor
+{
+  /**
+   * Registration of this plugin through the ClassLoader. This macro
+   * registers the class without needing to worry about name mangling
+   */
+  REGISTER(FrameProcessorPlugin, ParameterPublishPlugin, "ParameterPublishPlugin");
+
+}  // namespace FrameProcessor

--- a/cpp/frameProcessor/src/SumPlugin.cpp
+++ b/cpp/frameProcessor/src/SumPlugin.cpp
@@ -1,71 +1,243 @@
-//
-// Created by hir12111 on 30/10/18.
-//
+/*
+ *  Created on: 30 Oct 2018
+ *      Authors: Emilio Perez Juarez,
+ *               Gary Yendell
+ */
 
+#include "DebugLevelLogger.h"
 #include "SumPlugin.h"
 #include "version.h"
 
 namespace FrameProcessor {
 
-/**
- * The constructor sets up logging used within the class.
- */
-  SumPlugin::SumPlugin()
+  /**
+   * Get bin name corresponding to threshold
+   *
+   * \param[in] index - Threshold of bin to get name of
+   */
+  std::string& Histogram::get_name_by_index(uint index) {
+    return this->threshold_name_map_[this->threshold_vector_[index]];
+  }
+
+  /**
+   * Get read-only view of map of name -> threshold
+   */
+  const std::map<std::string, uint64_t>& Histogram::get_name_threshold_map() {
+    return this->name_threshold_map_;
+  }
+
+  /**
+   * Add a histogram bin
+   *
+   * \param[in] name - Name of bin to add
+   * \param[in] threshold - Threshold of bin to add
+   * \throw `std::runtime_error` if the name and/or threshold already exists
+   */
+  void Histogram::add_bin(std::string& name, uint64_t& threshold) {
+    // Check for clashes
+    std::map<std::string, uint64_t>::iterator bin;
+    for (bin = this->name_threshold_map_.begin(); bin != this->name_threshold_map_.end(); ++bin) {
+      if (threshold == bin->second) {
+        throw std::runtime_error("A histogram bin with given threshold already exists");
+      }
+    }
+
+    // Add to underlying containers
+    this->name_threshold_map_[name] = threshold;
+    this->threshold_name_map_[threshold] = name;
+    // - Recreate vector from sorted keys
+    this->threshold_vector_.clear();
+    std::map<uint64_t, std::string>::iterator ibin;
+    for (ibin = this->threshold_name_map_.begin(); ibin != this->threshold_name_map_.end(); ++ibin) {
+      this->threshold_vector_.push_back(ibin->first);
+    }
+  }
+
+  /**
+   * Increment the highest bin that the given pixel counts fit into, if any
+   *
+   * If `this` has no configured bins or if the counts are lower than all of them nothing is done
+   *
+   * \param[in] sum - `Sum` to increment `histogram` bin of
+   * \param[in] counts - Counts of pixel to find bin for
+   */
+  void Histogram::bin_pixel(Sum& sum, uint64_t counts) {
+    if (this->threshold_vector_.size() > 0 && counts > this->threshold_vector_[0]) {
+      this->_bin_pixel(sum, counts, 0);
+    }
+  }
+
+  /**
+   * Increment the highest bin that the given pixel counts fit into
+   *
+   * The caller must confirm that pixel at least fits into the lowest bin or this method could increment it
+   * incorrectly.
+   *
+   * Must be called with `previous_index` = `0` except for recursive calls of itself where it will be incremented
+   * until the highest bin is reached.
+   *
+   * This method calls recursively until it reaches the highest bin, or a bin that the pixel counts do not fit into
+   *
+   * \param[in] sum - `Sum` to increment `Histogram` of
+   * \param[in] counts - Counts of pixel to find bin for
+   * \param[in] previous_index - Previous index in array of thresholds
+   */
+  void Histogram::_bin_pixel(Sum& sum, uint64_t counts, uint previous_index) {
+    int index = previous_index + 1;
+    if (counts > this->threshold_vector_[index]) {
+      // Pixel fits in this bin or a higher one
+      if (index + 1 < this->threshold_vector_.size()) {
+        // Try next bin and increment this bin if it does not fit
+        this->_bin_pixel(sum, counts, index);
+      } else {
+        // No higher bins to check - increment this one
+        ++sum.histogram[this->get_name_by_index(index)];
+      }
+    } else {
+      // Pixel does not fit in this bin - increment previous one
+      ++sum.histogram[this->get_name_by_index(previous_index)];
+    }
+  }
+
+  const std::string SumPlugin::SUM_PARAM_NAME = "sum";
+  const std::string SumPlugin::CONFIG_HISTOGRAM = "histogram";
+
+  /**
+   * The constructor sets up logging used within the class.
+   */
+  SumPlugin::SumPlugin() :
+    histogram_()
   {
     // Setup logging for the class
     logger_ = Logger::getLogger("FP.SumPlugin");
     LOG4CXX_TRACE(logger_, "SumPlugin constructor.");
   }
 
-/**
- * Destructor.
- */
+  /**
+   * Destructor.
+   */
   SumPlugin::~SumPlugin()
   {
     LOG4CXX_TRACE(logger_, "SumPlugin destructor.");
   }
 
   template<class PixelType>
-  static uint64_t calculate_sum(boost::shared_ptr <Frame> frame)
+  Sum SumPlugin::calculate_sum(boost::shared_ptr<Frame> frame)
   {
-    uint64_t sum_value = 0;
     const PixelType *data = static_cast<const PixelType *>(frame->get_image_ptr());
     size_t elements_count = frame->get_image_size() / sizeof(data[0]);
 
+    Sum sum(this->histogram_.get_name_threshold_map());
     for (size_t pixel_index = 0; pixel_index < elements_count; pixel_index++) {
-      sum_value += data[pixel_index];
+      sum.total_counts += data[pixel_index];
+      this->histogram_.bin_pixel(sum, data[pixel_index]);
     }
 
-    return sum_value;
+    return sum;
   }
 
-/**
- * Calculate the sum of each pixel based on the data type
- *
- * \param[in] frame - Pointer to a Frame object.
- */
-  void SumPlugin::process_frame(boost::shared_ptr <Frame> frame)
+  /**
+   * Calculate the sum of each pixel based on the data type
+   *
+   * \param[in] frame - Pointer to a Frame object.
+   */
+  void SumPlugin::process_frame(boost::shared_ptr<Frame> frame)
   {
     LOG4CXX_TRACE(logger_, "Received a new frame...");
     switch (frame->get_meta_data().get_data_type()) {
       case raw_8bit:
-        frame->meta_data().set_parameter<uint64_t>(SUM_PARAM_NAME, calculate_sum<uint8_t>(frame));
+        {
+          Sum sum = this->calculate_sum<uint8_t>(frame);
+          this->add_data_to_frame(frame, sum);
+        }
         break;
       case raw_16bit:
-        frame->meta_data().set_parameter<uint64_t>(SUM_PARAM_NAME, calculate_sum<uint16_t>(frame));
+        {
+          Sum sum = this->calculate_sum<uint16_t>(frame);
+          this->add_data_to_frame(frame, sum);
+        }
         break;
       case raw_32bit:
-        frame->meta_data().set_parameter<uint64_t>(SUM_PARAM_NAME, calculate_sum<uint32_t>(frame));
+        {
+          Sum sum = this->calculate_sum<uint32_t>(frame);
+          this->add_data_to_frame(frame, sum);
+        }
         break;
       case raw_64bit:
-        frame->meta_data().set_parameter<uint64_t>(SUM_PARAM_NAME, calculate_sum<uint64_t>(frame));
+        {
+          Sum sum = this->calculate_sum<uint64_t>(frame);
+          this->add_data_to_frame(frame, sum);
+        }
         break;
       default:
-        LOG4CXX_ERROR(logger_, "SumPlugin doesn't support data type:"
-            << get_type_from_enum(static_cast<DataType>(frame->get_meta_data().get_data_type())));
+        LOG4CXX_ERROR(logger_,
+          "SumPlugin doesn't support data type:"
+            << get_type_from_enum(static_cast<DataType>(frame->get_meta_data().get_data_type()))
+        );
     }
     this->push(frame);
   }
+
+  /**
+   * Add calculated parameters to Frame
+   *
+   * \param[in] frame - Pointer to a Frame object.
+   * \param[in] sum - Sum object containing parameter values.
+   */
+  void SumPlugin::add_data_to_frame(boost::shared_ptr<Frame> frame, Sum& sum)
+  {
+    frame->meta_data().set_parameter<uint64_t>(SUM_PARAM_NAME, sum.total_counts);
+
+    std::map<std::string, uint64_t>::const_iterator bin;
+    for(bin = sum.histogram.begin(); bin != sum.histogram.end(); ++bin) {
+      frame->meta_data().set_parameter<uint64_t>(bin->first, bin->second);
+    }
+  }
+
+  /**
+   * Set configuration options for this Plugin.
+   *
+   * \param[in] config - IpcMessage containing configuration data.
+   * \param[out] reply - Response IpcMessage.
+   */
+  void SumPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+  {
+    try {
+      if (config.has_param(CONFIG_HISTOGRAM)) {
+        OdinData::IpcMessage histogram(config.get_param<const rapidjson::Value &>(CONFIG_HISTOGRAM));
+        std::vector<std::string> histogram_bins = histogram.get_param_names();
+
+        // Update histogram bins
+        std::vector<std::string>::iterator bin_name;
+        for (bin_name = histogram_bins.begin(); bin_name != histogram_bins.end(); ++bin_name) {
+          uint64_t bin_threshold = histogram.get_param<uint64_t>(*bin_name);
+          this->histogram_.add_bin(*bin_name, bin_threshold);
+          LOG4CXX_INFO(logger_, "Threshold " << *bin_name << " set to " << bin_threshold);
+        }
+      }
+    }
+    catch (std::runtime_error& e)
+    {
+      std::stringstream ss;
+      ss << "Bad ctrl msg: " << e.what();
+      this->set_error(ss.str());
+      throw;
+    }
+  }
+
+/**
+ * Get the configuration values for this plugin
+ *
+ * \param[out] reply - Response IpcMessage.
+ */
+void SumPlugin::requestConfiguration(OdinData::IpcMessage& reply)
+{
+  std::map<std::string, uint64_t> histogram_bins = this->histogram_.get_name_threshold_map();
+  std::map<std::string, uint64_t>::const_iterator bin;
+  for(bin = histogram_bins.begin(); bin != histogram_bins.end(); ++bin) {
+    reply.set_param(get_name() + "/" + CONFIG_HISTOGRAM + "/" + bin->first, bin->second);
+  }
+}
 
   int SumPlugin::get_version_major()
   {

--- a/cpp/frameProcessor/test/CMakeLists.txt
+++ b/cpp/frameProcessor/test/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(frameProcessorTest
         LiveViewPlugin
         SumPlugin
         GapFillPlugin
+        ParameterPublishPlugin
         ${COMMON_LIBRARY})
 
 # Link for BloscPlugin if Blosc is present
@@ -57,3 +58,7 @@ if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
 endif()
 
 install(TARGETS frameProcessorTest RUNTIME DESTINATION bin)
+
+add_executable(TestZMQSubscriber zmqSubscriber.c)
+target_link_libraries(TestZMQSubscriber ${ZEROMQ_LIBRARIES})
+install(TARGETS TestZMQSubscriber RUNTIME DESTINATION bin)

--- a/cpp/frameProcessor/test/FrameProcessorTest.cpp
+++ b/cpp/frameProcessor/test/FrameProcessorTest.cpp
@@ -1014,7 +1014,17 @@ BOOST_AUTO_TEST_SUITE(SumPluginUnitTest);
 BOOST_AUTO_TEST_CASE( SumFrame )
 {
   FrameProcessor::SumPlugin plugin;
-  unsigned short img[12] =  {
+
+  // Configure thresholds
+  OdinData::IpcMessage reply;
+  OdinData::IpcMessage cfg;
+  cfg.set_param("histogram/low2", 1);
+  cfg.set_param("histogram/low1", 5);
+  cfg.set_param("histogram/high1", 8);
+  cfg.set_param("histogram/high2", 10);
+  plugin.configure(cfg, reply);
+
+  uint16_t img[12] =  {
     1, 2, 3, 4,
     5, 6, 7, 8,
     9, 10, 11, 12
@@ -1022,36 +1032,55 @@ BOOST_AUTO_TEST_CASE( SumFrame )
   dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
 
   FrameProcessor::FrameMetaData frame_meta(
-          1, "raw", FrameProcessor::raw_16bit, "test", img_dims, FrameProcessor::no_compression
+    1, "raw", FrameProcessor::raw_16bit, "test", img_dims, FrameProcessor::no_compression
   );
 
   boost::shared_ptr<FrameProcessor::DataBlockFrame> frame(
-          new FrameProcessor::DataBlockFrame(frame_meta, static_cast<void*>(img), 24));
+    new FrameProcessor::DataBlockFrame(frame_meta, static_cast<void*>(img), 24)
+  );
 
   plugin.process_frame(frame);
 
-  BOOST_CHECK(frame->get_meta_data().has_parameter(FrameProcessor::SUM_PARAM_NAME));
+  BOOST_CHECK(frame->get_meta_data().has_parameter("sum"));
 
-  // check that the sum of each pixel is the correct value
-  BOOST_CHECK_EQUAL(78, frame->get_meta_data().get_parameter<uint64_t>(FrameProcessor::SUM_PARAM_NAME));
+  // Check that the sum of each pixel and the histogram is correct
+  BOOST_CHECK_EQUAL(78, frame->get_meta_data().get_parameter<uint64_t>("sum"));
+  BOOST_CHECK_EQUAL(4, frame->get_meta_data().get_parameter<uint64_t>("low2"));
+  BOOST_CHECK_EQUAL(3, frame->get_meta_data().get_parameter<uint64_t>("low1"));
+  BOOST_CHECK_EQUAL(2, frame->get_meta_data().get_parameter<uint64_t>("high1"));
+  BOOST_CHECK_EQUAL(2, frame->get_meta_data().get_parameter<uint64_t>("high2"));
 }
 
 BOOST_AUTO_TEST_CASE( SumEmptyFrame )
 {
   FrameProcessor::SumPlugin plugin;
 
+  // Configure thresholds
+  OdinData::IpcMessage reply;
+  OdinData::IpcMessage cfg;
+  cfg.set_param("histogram/low2", 1);
+  cfg.set_param("histogram/low1", 5);
+  cfg.set_param("histogram/high1", 8);
+  cfg.set_param("histogram/high2", 10);
+  plugin.configure(cfg, reply);
+
   dimensions_t dims(2, 0);
   FrameProcessor::FrameMetaData frame_meta(
-          0, "raw", FrameProcessor::raw_16bit, "test", dims, FrameProcessor::no_compression
+    0, "raw", FrameProcessor::raw_16bit, "test", dims, FrameProcessor::no_compression
   );
-  char dummy_data[2] = {0, 0};
+  uint16_t dummy_data[2] = {0, 0};
   boost::shared_ptr<FrameProcessor::DataBlockFrame> frame(
-          new FrameProcessor::DataBlockFrame(frame_meta, static_cast<void*>(dummy_data), 2));
+    new FrameProcessor::DataBlockFrame(frame_meta, static_cast<void*>(dummy_data), 4)
+  );
 
   plugin.process_frame(frame);
-  BOOST_CHECK(frame->get_meta_data().has_parameter(FrameProcessor::SUM_PARAM_NAME));
-  // check that a empty frame sum is zero
-  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>(FrameProcessor::SUM_PARAM_NAME));
+  BOOST_CHECK(frame->get_meta_data().has_parameter("sum"));
+  // Check that a empty frame sum is zero and all are below low2 threshold
+  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>("sum"));
+  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>("low2"));
+  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>("low1"));
+  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>("high1"));
+  BOOST_CHECK_EQUAL(0, frame->get_meta_data().get_parameter<uint64_t>("high2"));
 }
 
 BOOST_AUTO_TEST_CASE( SumNotSupportedDataType )
@@ -1061,7 +1090,7 @@ BOOST_AUTO_TEST_CASE( SumNotSupportedDataType )
   boost::shared_ptr<FrameProcessor::DataBlockFrame> frame = get_dummy_frame();
   frame->meta_data().set_data_type(FrameProcessor::raw_float);
   plugin.process_frame(frame);
-  BOOST_CHECK(!frame->get_meta_data().has_parameter(FrameProcessor::SUM_PARAM_NAME));
+  BOOST_CHECK(!frame->get_meta_data().has_parameter("sum"));
 
 }
 

--- a/cpp/frameProcessor/test/FrameProcessorTest.cpp
+++ b/cpp/frameProcessor/test/FrameProcessorTest.cpp
@@ -23,6 +23,7 @@ using namespace log4cxx::xml;
 #include "OffsetAdjustmentPlugin.h"
 #include "LiveViewPlugin.h"
 #include "SumPlugin.h"
+#include "ParameterPublishPlugin.h"
 #include "FrameProcessorDefinitions.h"
 #include "TestHelperFunctions.h"
 
@@ -1064,4 +1065,49 @@ BOOST_AUTO_TEST_CASE( SumNotSupportedDataType )
 
 }
 
-BOOST_AUTO_TEST_SUITE_END(); //SumPluginUnitTest
+BOOST_AUTO_TEST_SUITE_END(); //ParameterPublishPluginUnitTest
+
+BOOST_AUTO_TEST_SUITE(ParameterPublishPluginUnitTest);
+
+BOOST_AUTO_TEST_CASE( Publish )
+{
+  FrameProcessor::ParameterPublishPlugin plugin;
+
+  // Configure thresholds
+  OdinData::IpcMessage reply;
+  OdinData::IpcMessage cfg;
+  cfg.set_param(std::string("add_parameter"), std::string("low1"));
+  plugin.configure(cfg, reply);
+  cfg.set_param(std::string("add_parameter"), std::string("low2"));
+  plugin.configure(cfg, reply);
+  cfg.set_param(std::string("add_parameter"), std::string("high1"));
+  plugin.configure(cfg, reply);
+  cfg.set_param(std::string("endpoint"), std::string("tcp://*:10000"));
+  cfg.set_param(std::string("add_parameter"), std::string("high2"));
+  plugin.configure(cfg, reply);
+
+  usleep(200000); // Give the listener a chance to connect
+
+  uint16_t img[12] =  {
+    1, 2, 3, 4,
+    5, 6, 7, 8,
+    9, 10, 11, 12
+  };
+  dimensions_t img_dims(2); img_dims[0] = 3; img_dims[1] = 4;
+
+  FrameProcessor::FrameMetaData frame_meta(
+    1, "raw", FrameProcessor::raw_16bit, "test", img_dims, FrameProcessor::no_compression
+  );
+  frame_meta.set_parameter<uint64_t>("low2", 1);
+  frame_meta.set_parameter<uint64_t>("low1", 4);
+  frame_meta.set_parameter<uint64_t>("high1", 2);
+  frame_meta.set_parameter<uint64_t>("high2", 3);
+
+  boost::shared_ptr<FrameProcessor::DataBlockFrame> frame(
+    new FrameProcessor::DataBlockFrame(frame_meta, static_cast<void*>(img), 24)
+  );
+
+  plugin.process_frame(frame);
+}
+
+BOOST_AUTO_TEST_SUITE_END(); //ParameterPublishPluginUnitTest

--- a/cpp/frameProcessor/test/zmqSubscriber.c
+++ b/cpp/frameProcessor/test/zmqSubscriber.c
@@ -1,0 +1,29 @@
+// A test application to receive the message published in FrameProcessorTest
+#include <assert.h>
+#include <stdio.h>
+
+#include <zmq.h>
+
+int main(int argc, char** argv)
+{
+    void* context = zmq_ctx_new();
+    void* subscriber = zmq_socket(context, ZMQ_SUB);
+    int rc = zmq_connect(subscriber, argv[1]);
+    assert(rc == 0);
+    rc = zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0);
+    assert(rc == 0);
+
+    printf("Listening on %s\n", argv[1]);
+
+    // Receive one message
+    int LENGTH = 100;
+    char message[LENGTH];
+    rc = zmq_recv(subscriber, message, LENGTH, 0);
+    assert(rc != -1);
+    printf("Received '%s'\n", message);
+
+    zmq_close(subscriber);
+    zmq_ctx_destroy(context);
+
+    return 0;
+}


### PR DESCRIPTION
These are two somewhat isolated changes to allow odin to complete a control loop between a motion controller moving some attenuators and the exposure on a detector. These are:
- Extend SumPlugin to calculate a histogram as well as total counts
- Create ParameterPublishPlugin to publish any parameters on a frame as json over ZeroMQ

I imagine these two features could be useful for other things.

- [x] Waiting on #301 