### PR TITLE
Add support for warning messages in status reporting for timed out h5 calls

### DIFF
--- a/cpp/frameProcessor/include/FrameProcessorPlugin.h
+++ b/cpp/frameProcessor/include/FrameProcessorPlugin.h
@@ -38,9 +38,11 @@ public:
   void set_name(const std::string& name);
   std::string get_name();
   void set_error(const std::string& msg);
+  void set_warning(const std::string& msg);
   void clear_errors();
   virtual bool reset_statistics();
   std::vector<std::string> get_errors();
+  std::vector<std::string> get_warnings();
   virtual void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   virtual void requestConfiguration(OdinData::IpcMessage& reply);
   virtual void status(OdinData::IpcMessage& status);
@@ -79,6 +81,8 @@ private:
   std::map<std::string, boost::shared_ptr<IFrameCallback> > blocking_callbacks_;
   /** Error message array */
   std::vector<std::string> error_messages_;
+  /** Warning message array */
+  std::vector<std::string> warning_messages_;
   /** Mutex to make accessing error_messages_ threadsafe */
   boost::mutex mutex_;
   /** process_frame performance stats */

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -98,7 +98,7 @@ FileWriterPlugin::FileWriterPlugin() :
   hdf5_error_definition_.write_duration = 0;
   hdf5_error_definition_.flush_duration = 0;
   hdf5_error_definition_.close_duration = 0;
-  hdf5_error_definition_.callback = boost::bind(&FileWriterPlugin::set_error, this, _1);
+  hdf5_error_definition_.callback = boost::bind(&FileWriterPlugin::set_warning, this, _1);
 }
 
 /**

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -274,7 +274,7 @@ void FrameProcessorController::callback(boost::shared_ptr<Frame> frame) {
 void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply)
 {
   // Error messages
-  std::vector<std::string> error_messages;
+  std::vector<std::string> error_messages, warning_messages;
 
   // Request status information from the shared memory controller
   if (sharedMemController_) {
@@ -292,10 +292,17 @@ void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply)
     // Read error level
     std::vector<std::string> plugin_errors = iter->second->get_errors();
     error_messages.insert(error_messages.end(), plugin_errors.begin(), plugin_errors.end());
+    // Read warning level
+    std::vector<std::string> plugin_warnings = iter->second->get_warnings();
+    warning_messages.insert(warning_messages.end(), plugin_warnings.begin(), plugin_warnings.end());
   }
   std::vector<std::string>::iterator error_iter;
   for (error_iter = error_messages.begin(); error_iter != error_messages.end(); ++error_iter) {
     reply.set_param("error[]", *error_iter);
+  }
+  std::vector<std::string>::iterator warning_iter;
+  for (warning_iter = warning_messages.begin(); warning_iter != warning_messages.end(); ++warning_iter) {
+    reply.set_param("warning[]", *warning_iter);
   }
 
 }

--- a/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -78,15 +78,39 @@ void FrameProcessorPlugin::set_error(const std::string& msg)
   }
 }
 
-/** Clear any error state.
+/** Set the warning state.
  *
- * Clears any messages that have previously been set
+ * Sets an warning for this plugin
+ *
+ * \param[in] msg - std::string warning message.
+ */
+void FrameProcessorPlugin::set_warning(const std::string& msg)
+{
+  // Take lock to access warning_messages_
+  boost::lock_guard<boost::mutex> lock(mutex_);
+
+  // Loop over warning messages, if this is a new message then add it
+  std::vector<std::string>::iterator iter;
+  bool found_warning = false;
+  for (iter = warning_messages_.begin(); iter != warning_messages_.end(); ++iter){
+    if (msg == *iter){
+      found_warning = true;
+    }
+  }
+  if (!found_warning){
+    warning_messages_.push_back(msg);
+    LOG4CXX_WARN(logger_, msg);
+  }
+}
+
+/** Clear error and warning messages.
  */
 void FrameProcessorPlugin::clear_errors()
 {
   // Take lock to access error_messages_
   boost::lock_guard<boost::mutex> lock(mutex_);
   error_messages_.clear();
+  warning_messages_.clear();
 }
 
 /** Reset any statistics.
@@ -107,6 +131,16 @@ std::vector<std::string> FrameProcessorPlugin::get_errors()
   // Take lock to access error_messages_
   boost::lock_guard<boost::mutex> lock(mutex_);
   return error_messages_;
+}
+
+/** Return the current warning message.
+ *
+ */
+std::vector<std::string> FrameProcessorPlugin::get_warnings()
+{
+  // Take lock to access warning_messages_
+  boost::lock_guard<boost::mutex> lock(mutex_);
+  return warning_messages_;
 }
 
     /** Configure the plugin.


### PR DESCRIPTION
Currently h5 call timeouts are reported as an error, but this is premature as the acquisition may still complete successfully without any lost data.

This adds an equivalent array of messages representing warnings to the status of `FrameProcessorPlugin` that can be populated with a new `set_warning` call and updates the `FileWriterPlugin` to use `set_warning` for timed out h5 calls instead of `set_error`.