### PR TITLE
Update to use improved h5py string support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,9 +10,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install odin-data
+      - name: Test odin-data
         run: |
           python3 -m venv venv && source venv/bin/activate && pip install --upgrade pip
           cd python
-          pip install .
+          pip install .[dev,meta_writer]
           python -c "from odin_data import __version__; print(__version__)"
+          pytest tests/test_hdf5dataset.py

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -34,7 +34,7 @@ meta_writer =
     h5py>=2.9.0
 # For development tests/docs
 dev =
-    pytest-asyncio
+    pytest
     # Docs
     sphinx-autobuild
     sphinx-external-toc

--- a/python/src/odin_data/meta_writer/hdf5dataset.py
+++ b/python/src/odin_data/meta_writer/hdf5dataset.py
@@ -1,6 +1,7 @@
 import logging
 from time import time
 
+import h5py as h5
 import numpy as np
 
 
@@ -392,7 +393,8 @@ class StringHDF5Dataset(HDF5Dataset):
     def __init__(
         self,
         name,
-        length,
+        length=None,
+        encoding="utf-8",
         shape=None,
         maxshape=None,
         cache=True,
@@ -402,12 +404,14 @@ class StringHDF5Dataset(HDF5Dataset):
     ):
         """
         Args:
-            length(int): Maximum length of the string elements
+            length(int): Length of string - None to store as variable-length objects
+            encoding(str): Encoding of string - either `"utf-8"` or `"ascii"`
 
         """
+        self.dtype = h5.string_dtype(encoding=encoding, length=length)
         super(StringHDF5Dataset, self).__init__(
             name,
-            dtype="S{}".format(length),
+            dtype=self.dtype,
             fillvalue="",
             shape=shape,
             maxshape=maxshape,
@@ -420,7 +424,11 @@ class StringHDF5Dataset(HDF5Dataset):
     def prepare_data(self, data):
         """Prepare data ready to write to hdf5 dataset
 
-        Convert data to raw strings to write to hdf5 dataset
+        Ensure data array contains the correct string dtype by converting first to bytes
+        and then to the specific string type. This initial conversion is required if
+        self.dtype is a variable-length string object data is not a string type because,
+        e.g., np.asarray(ndarray[int], object) leaves the data as int, but int cannot be
+        implicitly converted to an h5py dataset of dtype 'O' on write.
 
         Args:
             data(np.ndarray): Data to format
@@ -431,7 +439,12 @@ class StringHDF5Dataset(HDF5Dataset):
         """
         data = super(StringHDF5Dataset, self).prepare_data(data)
 
-        # Make sure data array contains str
-        data = np.array(data, dtype=str)
+        if self.dtype.kind == "O" and data.dtype.kind != "S":
+            # Ensure data is bytes before converting to variable-length object
+            data = np.asarray(data, dtype=bytes)
+
+        # Convert to specific string dtype - either variable-length object or
+        # fixed-length string. No copy is performed if the dtype already matches.
+        data = np.asarray(data, dtype=self.dtype)
 
         return data

--- a/python/src/odin_data/meta_writer/hdf5dataset.py
+++ b/python/src/odin_data/meta_writer/hdf5dataset.py
@@ -242,8 +242,8 @@ class HDF5Dataset(object):
                     "%s | Data shape %s does not match dataset shape %s"
                     " and resize failed:\n%s",
                     self.name,
-                    self.shape,
                     data.shape,
+                    self.shape,
                     exception
                 )
                 return

--- a/python/src/odin_data/meta_writer/hdf5dataset.py
+++ b/python/src/odin_data/meta_writer/hdf5dataset.py
@@ -13,7 +13,7 @@ class HDF5CacheBlock(object):
 
 
 class HDF5UnlimitedCache(object):
-    """ An object to represent a cache used by an HDF5Dataset """
+    """An object to represent a cache used by an HDF5Dataset"""
 
     def __init__(self, name, dtype, fillvalue, block_size, data_shape, block_timeout):
         """
@@ -157,7 +157,13 @@ class HDF5Dataset(object):
         self.fillvalue = fillvalue
         self.shape = shape if shape is not None else (0,) * rank
         self.chunks = chunks
-        self.maxshape = maxshape if maxshape is not None else shape if shape is not None else (None,) * rank
+        self.maxshape = (
+            maxshape
+            if maxshape is not None
+            else shape
+            if shape is not None
+            else (None,) * rank
+        )
         self._cache = None
 
         data_shape = self.shape[1:]  # The shape of each data element in dataset
@@ -244,7 +250,7 @@ class HDF5Dataset(object):
                     self.name,
                     data.shape,
                     self.shape,
-                    exception
+                    exception,
                 )
                 return
 

--- a/python/tests/test_hdf5dataset.py
+++ b/python/tests/test_hdf5dataset.py
@@ -1,8 +1,5 @@
 from unittest import TestCase
-import logging
-import pytest
 import numpy
-import os
 import time
 
 from odin_data.meta_writer.hdf5dataset import HDF5UnlimitedCache
@@ -32,7 +29,14 @@ class TestHDF5Dataset(TestCase):
         """verify that the cache functions as expected"""
 
         # Create a cache
-        cache = HDF5UnlimitedCache("test1", "int32", -2, 10, 1)
+        cache = HDF5UnlimitedCache(
+            name="test1",
+            dtype="int32",
+            fillvalue=-2,
+            block_size=10,
+            data_shape=(1,),
+            block_timeout=0.01,
+        )
 
         # Verify 1 block has been created, with a size of 10
         self.assertEqual(len(cache._blocks), 1)
@@ -100,8 +104,8 @@ class TestHDF5Dataset(TestCase):
         self.assertEqual(ds.values[1][8], -2)
         self.assertEqual(ds.values[1][9], -2)
 
-        # Now wait for 2 seconds
-        time.sleep(2.0)
+        # Now wait
+        time.sleep(0.1)
 
         # Now write another value into block[2] and then flush once again
         cache.add_value(3, 26)
@@ -132,7 +136,14 @@ class TestHDF5Dataset(TestCase):
         """verify that the cache functions as expected"""
 
         # Create a cache
-        cache = HDF5UnlimitedCache("test1", "int32", -2, 10, 1, shape=(2, 3))
+        cache = HDF5UnlimitedCache(
+            name="test1",
+            dtype="int32",
+            fillvalue=-2,
+            block_size=10,
+            data_shape=(2, 3),
+            block_timeout=0.01,
+        )
 
         # Verify 1 block has been created, with a size of 10x2x3
         self.assertEqual(len(cache._blocks), 1)
@@ -203,8 +214,8 @@ class TestHDF5Dataset(TestCase):
         self.assertEqual(ds.values[1][1][1][1], -2)
         self.assertEqual(ds.values[1][1][1][2], -2)
 
-        # Now wait for 2 seconds
-        time.sleep(2.0)
+        # Now wait
+        time.sleep(0.1)
 
         # Now write another value into block[2] and then flush once again
         cache.add_value(value, 26)


### PR DESCRIPTION
This allows users of StringHDF5Dataset to write data as fixed-length strings or as variable-length objects depending on whether `length` is passed. It handles various conversions including non-string types that can be converted to `bytes`.

The `encoding` parameter of `string_dtype` is exposed using the underlying default, `"utf-8"`. This can be overidden to encode as ascii.

It updates the CI to run the hdf5dataset tests and adds a new test for this feature. It also fixes an error message and some existing formatting issues.

