### PR TITLE
Add utilities to support camera and DPDK developments

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -153,6 +153,9 @@ include_directories(${CMAKE_BINARY_DIR}/include)
 # Add common/include directory to include path
 include_directories(${COMMON_DIR}/include)
 
+# Add the cmake subdirectory so that CMake finders are installed
+add_subdirectory(cmake)
+
 # Add the common subdirectory
 add_subdirectory(${COMMON_DIR})
 

--- a/cpp/cmake/CMakeLists.txt
+++ b/cpp/cmake/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB CMAKE_FILES *.cmake *.cmake.in)
+
+install(FILES ${CMAKE_FILES} DESTINATION cmake)

--- a/cpp/common/include/CMakeLists.txt
+++ b/cpp/common/include/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(HEADERS ClassLoader.h
         Json.h
         logging.h
         OdinDataException.h
+        ParamContainer.h
         SegFaultHandler.h
         SharedBufferManager.h
         stringparse.h)

--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -63,7 +63,7 @@ private:
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/error/en.h"
-
+#include "rapidjson/pointer.h"
 
 namespace OdinData
 {
@@ -121,13 +121,11 @@ public:
              MsgVal msg_val=MsgValIllegal,
              bool strict_validation=true);
 
-  //! Update parameters from another IPCMessage.
-  //!
-  //! This will iterate the parameters in the given IPCMessage and set them on this instance.
-  //!
-  //! \param other - IPCMessage to take parameters from
-
+  //! Updates parameters from another IPCMessage.
   void update(const IpcMessage& other);
+
+  //! Updates parameters from a rapidJSON object.
+  void update(const rapidjson::Value& param_val, std::string param_prefix="");
 
   //! Gets the value of a named parameter in the message.
   //!
@@ -310,6 +308,12 @@ public:
 
   //! Returns a JSON-encoded string of the message
   const char* encode(void);
+
+  //! Returns a JSON-encoded string of the message parameters at a specified path
+  const char* encode_params(const std::string& param_path = std::string());
+
+  //! Copies parameters at a specified into the specified JSON value object
+  void copy_params(rapidjson::Value& param_obj, const std::string& param_path = std::string());
 
   //! Overloaded equality relational operator
   friend bool operator ==(IpcMessage const& lhs_msg, IpcMessage const& rhs_msg);

--- a/cpp/common/include/ParamContainer.h
+++ b/cpp/common/include/ParamContainer.h
@@ -1,0 +1,309 @@
+/*!
+ * ParamContainer.h - abstract parameter container class with JSON encoding/decoding
+ *
+ * Created on: Oct 7, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#ifndef PARAMCONTAINER_H_
+#define PARAMCONTAINER_H_
+
+#include <map>
+#include <vector>
+#include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
+
+namespace OdinData
+{
+
+//! ParamContainerException - custom exception class for ParamContainer implementing "what" for
+//! error string
+class ParamContainerException : public std::exception
+{
+public:
+
+  //! Create ParamContainerException with no message
+  ParamContainerException(void) throw() :
+      what_("")
+  { };
+
+  //! Create ParamContainerException with informational message
+  ParamContainerException(const std::string what) throw() :
+      what_(what)
+  {};
+
+  //! Return the content of the informational message
+  virtual const char* what(void) const throw()
+  {
+    return what_.c_str();
+  };
+
+  //! Destructor
+  ~ParamContainerException(void) throw() {};
+
+private:
+
+  // Member variables
+  const std::string what_;  //!< Informational message about the exception
+
+};
+
+} // namespace OdinData
+
+// Override RapidJSON assertion mechanism before including appropriate headers
+#ifdef RAPIDJSON_ASSERT
+#undef RAPIDJSON_ASSERT
+#endif
+#define RAPIDJSON_ASSERT(x) if (!(x)) throw OdinData::ParamContainerException("rapidjson assertion thrown");
+#include "rapidjson/document.h"
+#include "rapidjson/pointer.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/error/en.h"
+
+namespace OdinData
+{
+
+//! ParamContainer - parameter container with JSON encoding/decoding
+class ParamContainer
+{
+
+    //! Parameter setter function type definition
+    typedef boost::function<void(rapidjson::Value&)> SetterFunc;
+    //! Parameter setter function map type definition
+    typedef std::map<std::string, SetterFunc> SetterFuncMap;
+    //! Parameter getter function type definition
+    typedef boost::function<void(rapidjson::Value&)> GetterFunc;
+    //! Parameter getter function map type definition
+    typedef std::map<std::string, GetterFunc> GetterFuncMap;
+
+    public:
+
+        //! Use the RapidJSON Document and Value types throughout
+        typedef rapidjson::Document Document;
+        typedef rapidjson::Value Value;
+
+        //! Default constructor
+        ParamContainer() {};
+
+        //! Copy constructor
+        ParamContainer(const ParamContainer& container);
+
+        //! Encode the parameter container to a JSON-formatted string
+        std::string encode(void);
+
+        //! Encode the parameter container into an existing document, using the specified path
+        //! as a prefix for all parameter paths
+        void encode(ParamContainer::Document& doc_obj, std::string prefix_path = std::string()) const;
+
+        //! Update the values of parameters from the specified JSON-formatted string
+        void update(std::string json);
+
+        //! Update the values of the parameters from the specified JSON-formatted character array
+        void update(const char* json);
+
+        //! Update the values of the parameters from the specified parameter container
+        void update(const ParamContainer& container);
+
+        //! Update the values of the parameters from the specified value object
+        void update(const ParamContainer::Value& value_obj);
+
+        //! Update the values of the parameters from the specified JSON document
+        void update(ParamContainer::Document& doc_obj);
+
+    protected:
+
+        //! Bind a parameter to a path in the container.
+        //!
+        //! This template method binds the specified parameter to the specified path in the
+        //! container, allowing the value of the parameter to be read or updated from an appropriate
+        //! JSON message.
+        //!
+        //! \param param - reference to the parameter to bind
+        //! \param path - JSON pointer-like path to bind the parameter to
+
+        template<typename T>
+        void bind_param(T& param, const std::string& path)
+        {
+            // Bind the parameter into the setter function map
+            setter_map_[path] = boost::bind(
+                &ParamContainer::param_set<T>, this, boost::ref(param), boost::placeholders::_1
+            );
+
+            // Bind the parameter into the getter function map
+            getter_map_[path] = boost::bind(
+                &ParamContainer::param_get<T>, this, boost::ref(param), boost::placeholders::_1
+            );
+
+        }
+
+        //! Bind a vector parameter to a path in the container.
+        //!
+        //! This template method binds the specified vector parameter of a given type to the
+        //! specified path in the parameter container, allowing the value of the parameter to be
+        //! read or updated from an appropriate JSON message.
+        //!
+        //! \param param - reference to the vector parameter to bind
+        //! \param path - JSON pointer-like path to bind the parameter to
+
+        template<typename T>
+        void bind_vector_param(std::vector<T>& param, const std::string& path)
+        {
+            // Bind the vector parameter into the setter function map
+            setter_map_[path] = boost::bind(
+                &ParamContainer::vector_param_set<T>, this, boost::ref(param),
+                boost::placeholders::_1
+            );
+
+            // Bind the vector parameter into the getter function map
+            getter_map_[path] = boost::bind(
+                &ParamContainer::vector_param_get<T>, this, boost::ref(param),
+                boost::placeholders::_1
+            );
+        }
+
+        //! Set the value of a parameter in the container.
+        //!
+        //! This template method sets the value of of a parameter in the container to the value
+        //! given the JSON object passed as an argument. This method is bound into the setter
+        //! function map of the container and invoked by the update method. The type-specific
+        //! set_value method is used to update the parameter value from the JSON object.
+        //!
+        //! \param param - reference to the parameter to update
+        //! \param value_obj - reference to a RapidJSON value object containing the value to set
+
+        template<typename T>
+        void param_set(T& param, rapidjson::Value& value_obj)
+        {
+            set_value<T>(param, value_obj);
+        }
+
+        //! Get the value of a parameter in the container.
+        //!
+        //! This template method gets the value of a parameter in the container, setting that value
+        //! in the JSON object passed as an argument. This method is bound into the getter
+        //! function map of the container and invoked by the encode method. The type-specific
+        //! get_value method is used to udpate the JSON object with the parameter value.
+        //!
+        //! \param param - reference to the parameter to retrieve
+        //! \param value_obj - reference to a RapidJSON value object to be set with the value
+
+        template<typename T> const
+        void param_get(T& param, rapidjson::Value& value_obj)
+        {
+            get_value<T>(param, value_obj);
+        }
+
+        //! Set the value of a vector parameter in the container.
+        //!
+        //! This template method sets the value of of a vector parameter in the container to the
+        //! values given the JSON object passed as an argument. This method is bound into the setter
+        //! function map of the container and invoked by the update method. The type-specific
+        //! set_value method is used to update the parameter values from the JSON object.
+        //!
+        //! \param param - reference to the vector parameter to update
+        //! \param value_obj - reference to a RapidJSON value object containing the value to set
+
+       template<typename T>
+        void vector_param_set(std::vector<T>& param, rapidjson::Value& value_obj)
+        {
+            // Clear the existing values in the parameter vector
+            param.clear();
+
+            // Iterate through the values of the parameter in the value object and add to the
+            // parameter vector
+            for (rapidjson::Value::ValueIterator itr = value_obj.Begin();
+                itr != value_obj.End(); ++itr)
+            {
+                T val;
+                set_value<T>(val, *itr);
+                param.push_back(val);
+            }
+        }
+
+        //! Get the value of a vector parameter in the container.
+        //!
+        //! This template method gets the value of a vector parameter in the container, setting
+        //! those values in the JSON object passed as an argument. This method is bound into the
+        //! getter function map of the container and invoked by the encode method. The type-specific
+        //! get_value method is used to udpate the JSON object with the parameter values.
+        //!
+        //! \param param - reference to the vector parameter to retrieve
+        //! \param value_obj - reference to a RapidJSON value object to be set with the values
+
+        template<typename T>
+        void vector_param_get(std::vector<T>& param, rapidjson::Value& value_obj)
+        {
+            // Create a new JSON array object to hold the parameter values using RapidJSON swap
+            // semantics
+            rapidjson::Document::AllocatorType& allocator = doc_.GetAllocator();
+            rapidjson::Value vec_obj(rapidjson::kArrayType);
+            value_obj.Swap(vec_obj);
+
+            // Iterate through the values in the parameter vector and add to the value object
+            for (typename std::vector<T>::iterator itr = param.begin(); itr != param.end(); ++itr)
+            {
+                rapidjson::Value val;
+                get_value<T>(*itr, val);
+                value_obj.PushBack(val, allocator);
+            }
+        }
+
+    private:
+
+        //! Bind parameters - virtual method which must be defined in derived classes
+        virtual void bind_params(void) = 0;
+
+        //! Set the value of a parameter.
+        //!
+        //! This private template method is used by the param_set method to set the value of a
+        //! parameter from the specified JSON object. Explicit specialisations of this method
+        //! are provided, mapping each of the RapidJSON types onto the appropriate parameter types,
+        //! which is returned as a value.
+        //!
+        //! \param value_obj - reference to a RapidJSON value object containing the value
+        //! \return the value of the appropriate type
+
+        template<typename T> void set_value(T& param, rapidjson::Value& value_obj) const;
+
+        //! Get the value of a parameter.
+        //!
+        //! This private template method is used by the param_get method to get the value of a
+        //! parameter and place it in the specified JSON object. Explicit specialisations of this
+        //! method are provided, mapping each of the parameter types on the appropriate RapidJSON
+        //! types.
+        //!
+        //! \param param - reference to the parameter to get the value of
+        //! \param value_obj - RapidJSON value object to update with the value of the parameter
+
+        template<typename T> void get_value(T& param, rapidjson::Value& value_obj) const;
+
+        //! Construct a valid JSON pointer path.
+        //!
+        //! This private utility method is used to construct a valid JSON pointer path, ensuring
+        //! that the leading / prefix is present.
+        //!
+        //! \param path - reference to path string
+        //! \return valid pointer path string
+
+        inline const std::string pointer_path(const std::string& path) const
+        {
+            // Set the pointer to the specified path
+            std::string pointer_path(path);
+
+            // If the pointer is not prefixed with the required slash, insert it
+            if (*pointer_path.begin() != '/')
+            {
+                pointer_path.insert(0, "/");
+            }
+            return pointer_path;
+        }
+
+        SetterFuncMap setter_map_;      //!< Paramter setter function map
+        GetterFuncMap getter_map_;      //!< Parameter getter function map
+        ParamContainer::Document doc_;  //!< JSON document object used for encoding
+};
+
+} // namespace OdinData
+
+#endif // PARAMCONTAINER_H_

--- a/cpp/common/src/ParamContainer.cpp
+++ b/cpp/common/src/ParamContainer.cpp
@@ -1,0 +1,298 @@
+/*!
+ * ParamContainer.cpp - parameter container class with JSON encoding/decoding
+ *
+ * This class implements a simple parameter container with JSON encoding/decoding, allowing
+ * applications to maintain e.g. configuration and status parameters with easy integration
+ * with external client control via JSON message payloads (e.g IpcMessage).
+ *
+ * Created on: Oct 7, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#include <sstream>
+#include "ParamContainer.h"
+
+namespace OdinData
+{
+
+//! Copy constructor
+//!
+//! This copy constructor implements a shallow copy of an existing parameter container. Note that
+//! it is NOT possible for the copy constructor to copy the setter and getter maps for parameters
+//! bound by derived classes, since base class constructors are called first. In order to implement
+//! a deep copy, the derived classes should implement bind_params (which is pure virtual) and call
+//! it from their own copy constructor before calling update() with the copied container.
+//!
+//! \param container - const reference to container to be copied
+
+ParamContainer::ParamContainer(const ParamContainer& container)
+{
+    // Explicilty copy the container JSON document
+    doc_.CopyFrom(container.doc_, doc_.GetAllocator());
+}
+
+//! Encode the parameter container to a JSON-formatted string
+//!
+//! This method encodes the parameter container to a JSON-formatted string. The values of
+//! all bound parameters in the container are encoded into return JSON string.
+//!
+//! \return JSON-encoded string of all bound parameters in the container
+
+std::string ParamContainer::encode(void)
+{
+    doc_.SetObject();
+    encode(doc_);
+
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<> > writer(sb);
+
+    doc_.Accept(writer);
+
+    std::string encoded(sb.GetString());
+    return encoded;
+}
+
+//! Encode the parameter container into an existing document
+//!
+//! This method encodes the parameter container into a JSON document, using the specified path
+//! as a prefix for all parameter paths. The values of all bound parameters are encoded into
+//! the document.
+//!
+//! \param doc_obj - reference to the JSON document to encode parameters into
+//! \param prefix_path - string to prefix to the path of all bound parameters
+
+void ParamContainer::encode(ParamContainer::Document& doc_obj, std::string prefix_path) const
+{
+    // Construct the JSON pointer prefix based on the prefix path
+    std::string pointer_prefix = pointer_path("");
+    if (!prefix_path.empty())
+    {
+        pointer_prefix += prefix_path;
+
+        // Ensure that the pointer prefix is correctly terminated with a trailing slash.
+        if (*pointer_prefix.rbegin() != '/')
+        {
+            pointer_prefix += "/";
+        }
+    }
+
+    // Iterate through all the bound parameters in the getter map, retreiving their current
+    // values and setting in the JSON document. The first element of each map entry returned
+    // by the iterator is the path of the parameter and the second is the bound getter method.
+    for (GetterFuncMap::const_iterator it = getter_map_.begin(); it != getter_map_.end(); ++it)
+    {
+        rapidjson::Value value_obj;
+        (*it).second(value_obj);
+        std::string path = pointer_prefix + (*it).first;
+        rapidjson::Pointer(path.c_str()).Set(doc_obj, value_obj);
+    }
+}
+
+//! Update the values of parameters from the specified JSON-formatted string
+//!
+//! This method updates the values of the parameters from the specfied JSON-formatted string.
+//! Parameters in the string that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - JSON-formatted string to update parameters from
+
+void ParamContainer::update(std::string json)
+{
+    update(json.c_str());
+}
+
+//! Update the values of parameters from the specified JSON-formatted character array
+//!
+//! This method updates the values of the parameters from the specfied JSON-formatted character.
+//! array. Parameters in the array that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - pointer to a JSON-formatted character array to update parameters from
+
+void ParamContainer::update(const char* json)
+{
+    // Parse the JSON argument into the document
+    doc_.Parse(json);
+
+    // Throw an informative exception of parse errors were encountered
+    if (doc_.HasParseError())
+    {
+        std::stringstream ss;
+        ss << "JSON parse error updating configuration from string at offset "
+            << doc_.GetErrorOffset() ;
+        ss << " : " << rapidjson::GetParseError_En(doc_.GetParseError());
+        throw ParamContainerException(ss.str());
+    }
+
+    // Update parameters in the container from the parsed JSON document
+    update(doc_);
+}
+
+//! Update the values of the parameters from the specified parameter container
+//!
+//! This method updates the values of parameters from the specifed parameter container. Parameters
+//! in the container that do not correspond to bound parameters in this container are ignore
+//!
+//! \param container - reference to a ParamContainer object to update parameters from
+
+void  ParamContainer::update(const ParamContainer& container)
+{
+    // Create a new param container document and encode the new container into it
+    ParamContainer::Document doc;
+    container.encode(doc);
+
+    // Update parametes in the container from the encoded document
+    update(doc);
+}
+
+//! Update the values of the parameters from the specified value object
+//!
+//! This method updates the values of parameters from the specifed value object. Parameters in the
+//! container that do not correspond to bound parameters in this container are ignored.
+//!
+//! \param container - reference to a ParamContainer object to update parameters from
+void ParamContainer::update(const ParamContainer::Value& value_obj)
+{
+    // Create a new param container document and and copy the value object into it
+    ParamContainer::Document doc;
+    doc.CopyFrom(value_obj, doc.GetAllocator());
+
+    // Update parametes in the container from the document
+    update(doc);
+}
+
+//! Update the values of the parameters from the specified JSON document
+//!
+//! This method updates the values of the parameters from the specfied JSON document object.
+//! Parameters in the document that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - reference to a JSON document obhect to update paramters from
+
+void ParamContainer::update(ParamContainer::Document& doc_obj)
+{
+
+    // Iterate through all bound parameters in the setter function map. The first element of each
+    // map entry returned by the iterator is the path of the parameter and the second is the bound
+    // getter method.
+    for (SetterFuncMap::iterator it = setter_map_.begin(); it != setter_map_.end(); ++it)
+    {
+        // If the path of the bound parameter is found in the JSON document, call the setter
+        // function to update the value of the parameter
+        if (rapidjson::Value* value_ptr = rapidjson::Pointer(
+            pointer_path((*it).first).c_str()).Get(doc_obj)
+        )
+        {
+            (*it).second(*value_ptr);
+        }
+    }
+}
+
+// Explicit specialisations of the set_value and get_value methods, mapping native attribute types
+// to the appropriate RapidJSON storage type.
+
+template<> void ParamContainer::set_value(int& param, rapidjson::Value& value_obj) const
+{
+    param = value_obj.GetInt();
+}
+
+template<> void ParamContainer::get_value(int& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetInt(param);
+}
+
+template<> void ParamContainer::set_value(unsigned int& param, rapidjson::Value& value_obj) const
+{
+    param = value_obj.GetUint();
+}
+
+template<> void ParamContainer::get_value(unsigned int& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetUint(param);
+}
+
+template<> void ParamContainer::set_value(uint16_t& param, rapidjson::Value& value_obj) const
+{
+    param = value_obj.GetUint();
+}
+
+template<> void ParamContainer::get_value(uint16_t& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetUint(param);
+}
+
+#ifdef __APPLE__
+// The MacOS clang compiler seems to base uint64 on a different base type than gcc on Linux, causing
+// linker errors with templated specialisations of get_value and set_value for unsigned long.
+template<> void ParamContainer::set_value(unsigned long& param rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetUint64();
+}
+
+template<> void ParamContainer::get_value(unsigned long& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetUint64(param);
+}
+#endif
+
+template<> void ParamContainer::set_value(int64_t& param, rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetInt64();
+}
+
+template<> void ParamContainer::get_value(int64_t& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetInt64(param);
+}
+
+template<> void ParamContainer::set_value(uint64_t& param, rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetUint64();
+}
+
+template<> void ParamContainer::get_value(uint64_t& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetUint64(param);
+}
+
+template<> void ParamContainer::set_value(double& param, rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetDouble();
+}
+
+template<> void ParamContainer::get_value(double& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetDouble(param);
+}
+
+template<> void ParamContainer::set_value(std::string& param, rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetString();
+}
+
+template<> void ParamContainer::get_value(std::string& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetString(rapidjson::StringRef(param.c_str()));
+}
+
+template<> void ParamContainer::set_value(bool& param, rapidjson::Value& value_obj) const
+{
+  param = value_obj.GetBool();
+}
+
+template<> void ParamContainer::get_value(bool& param, rapidjson::Value& value_obj) const
+{
+    value_obj.SetBool(param);
+}
+
+template<> void ParamContainer::set_value(ParamContainer::Document& param, rapidjson::Value& value_obj) const
+{
+    param.CopyFrom(value_obj, param.GetAllocator());
+}
+
+template<> void ParamContainer::get_value(ParamContainer::Document& param, rapidjson::Value& value_obj) const
+{
+    value_obj.CopyFrom(param, param.GetAllocator());
+}
+
+} // namespace OdinData


### PR DESCRIPTION
This PR adds support to odin-data to facilitate external camera-based and DPDK-accelerated FP plugin development. This includes:

- installation of CMake finders into the install tree to avoid duplication across repositories
- Addition of a `ParamContainer` class to the common library, to allow simple parameter handling for e.g. camera configuration
- Addition of non-breaking convenience methods to `IpcMessage` to allow serialisation/deserialisation of ParmContainer parameters to/from IPC messages