### PR TITLE
Allow setting hdf plugin frames to zero

### DIFF
--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -302,7 +302,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
 
     // Check to see if we are being told how many frames to write
     if (config.has_param(FileWriterPlugin::CONFIG_FRAMES) &&
-        config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES) > 0) {
+        config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES) >= 0) {
       size_t totalFrames = config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES);
       next_acquisition_->total_frames_ = totalFrames;
       next_acquisition_->frames_to_write_ = calc_num_frames(totalFrames);
@@ -822,7 +822,7 @@ bool FileWriterPlugin::reset_statistics()
  *  ii) this function has the side-effect of moving from the current-acq to
  *        the next-acq if that helps us match the frame.
  *
- *  The function will set an error if the frame does not match a writing acquisition. 
+ *  The function will set an error if the frame does not match a writing acquisition.
  * \param[in] frame - Pointer to the Frame object.
  */
 bool FileWriterPlugin::frame_in_acquisition(boost::shared_ptr<Frame> frame) {

--- a/cpp/frameProcessor/test/FrameProcessorTest.cpp
+++ b/cpp/frameProcessor/test/FrameProcessorTest.cpp
@@ -1011,6 +1011,31 @@ BOOST_AUTO_TEST_CASE( FileWriterPluginCalcNumFramesTest1000fpb )
 
 }
 
+BOOST_AUTO_TEST_CASE( FileWriterPluginZeroFrames )
+{
+  OdinData::IpcMessage reply;
+  FrameProcessor::FileWriterPlugin fwp;
+  fwp.set_name("hdf");
+  {
+    OdinData::IpcMessage cfg;
+    cfg.set_param("frames", 1);
+    fwp.configure(cfg, reply);
+
+    OdinData::IpcMessage reply2;
+    fwp.requestConfiguration(reply2);
+    BOOST_CHECK_EQUAL(1, reply2.get_param<int>("hdf/frames"));
+  }
+  {
+    OdinData::IpcMessage cfg;
+    cfg.set_param("frames", 0);
+    fwp.configure(cfg, reply);
+
+    OdinData::IpcMessage reply2;
+    fwp.requestConfiguration(reply2);
+    BOOST_CHECK_EQUAL(0, reply2.get_param<int>("hdf/frames"));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END(); //FileWriterPluginTest
 
 BOOST_AUTO_TEST_SUITE(SumPluginUnitTest);


### PR DESCRIPTION
This ensures that the hdf frame count can be changed from 0 and then changed back to 0 again for free-run mode.

Fixes #306 

Note: Added #354 during this work. This is why the call to `set_name` is required.