### PR TITLE
Make frames_per_file calculation in create_file respect outer chunk dimension

### DIFF
--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -258,7 +258,7 @@ void Acquisition::create_file(size_t file_number, HDF5CallDurations_t& call_dura
     // Calculate the number of frames required for this dataset in the case that
     // the acquisition is using block mode.
     int wrap = (file_number/concurrent_processes_)+1;
-    int frames_per_file = blocks_per_file_ * frames_per_block_;
+    int frames_per_file = blocks_per_file_ * frames_per_block_ * dset_def.chunks[0];
     if (frames_per_file > 1){
       if (wrap * frames_per_file > frames_to_write_){
         // This is the final file creation which may contain less than a full block of frames


### PR DESCRIPTION
This PR addresses issue #360 , where the file writer plugin errors when attempting to write output files for datasets with outer chunk dimension > 1 over multiple files with a fixed total number of frames. This is fixed by making the `frames_per_file` calculation in `Acquisition::create_file` include the outer chunk dimension. 

Fixes #360 
