### PR TITLE
Add start/stop writing commands to FileWriterPlugin

### DIFF
--- a/cpp/frameProcessor/include/FileWriterPlugin.h
+++ b/cpp/frameProcessor/include/FileWriterPlugin.h
@@ -45,6 +45,8 @@ public:
   void stop_writing();
   void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void requestConfiguration(OdinData::IpcMessage& reply);
+  virtual void execute(const std::string& command, OdinData::IpcMessage& reply);
+  virtual std::vector<std::string> requestCommands();
   void configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void configure_file(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   void configure_dataset(const std::string& dataset_name, OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
@@ -133,6 +135,9 @@ private:
   static const std::string WRITE_ERROR_DURATION;
   static const std::string FLUSH_ERROR_DURATION;
   static const std::string CLOSE_ERROR_DURATION;
+
+  static const std::string START_WRITING;
+  static const std::string STOP_WRITING;
 
   /**
    * Prevent a copy of the FileWriterPlugin plugin.

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -989,7 +989,12 @@ void FileWriterPlugin::execute(const std::string& command, OdinData::IpcMessage&
       }
   } else if (command == FileWriterPlugin::STOP_WRITING) {
       this->stop_writing();
-  } else std::cout << "Command " << command << " not implemented for FileWriterPlugin\n";
+  } else {
+    std::stringstream ss;
+    ss << "Command " << command << " not implemented for FileWriterPlugin";
+    LOG4CXX_ERROR(logger_, ss.str());
+    reply.set_nack(ss.str());
+  }
 }
 
 std::vector<std::string> FileWriterPlugin::requestCommands()

--- a/cpp/test/integrationTest/config/dummyUDP-fp.json
+++ b/cpp/test/integrationTest/config/dummyUDP-fp.json
@@ -70,8 +70,7 @@
 			},
 			"frames": 10,
 			"acquisition_id": "test_1",
-			"timeout_timer_period": 3000,
-			"write": true
+			"timeout_timer_period": 3000
 		}
 	}
 ]

--- a/cpp/test/integrationTest/config/dummyUDP.json
+++ b/cpp/test/integrationTest/config/dummyUDP.json
@@ -10,7 +10,8 @@
             "process": true,
             "command": "${CMAKE_INSTALL_PREFIX}/bin/frameProcessor",
             "pos-args": "",
-            "sleep": "1"
+            "sleep": "1",
+            "socket": "tcp://0.0.0.0:5004"
         },
         "simulator": {
             "process": false,

--- a/cpp/test/integrationTest/src/FrameTestApp.cpp
+++ b/cpp/test/integrationTest/src/FrameTestApp.cpp
@@ -144,6 +144,13 @@ int main(int argc, char *argv[]) {
         boost::optional<std::string> configuration = pt.get_optional<std::string>("Main." + process + "." + "configure");
         if(configuration)
           control->send_configuration(configuration.get());
+        if (!process.compare("processor")) {
+          std::string command_message = // send start_writing command to FrameProcessor
+            "{\"id\":263,\"msg_type\":\"cmd\",\"msg_val\":\"execute\","
+            "\"timestamp\":\"2024-11-21T08:53:06.340914\","
+            "\"params\":{\"hdf\":{\"command\":\"start_writing\"}}}";
+          control->send_configuration(command_message);
+        }
       }
       else
         control->run_command();

--- a/python/src/odin_data/client.py
+++ b/python/src/odin_data/client.py
@@ -68,6 +68,8 @@ class OdinDataClient(object):
                             help='Specify JSON configuration file to send as configure command')
         parser.add_argument('--request-config', action='store_true',
                             help='Request configuration from odin-data application')
+        parser.add_argument('--request-commands', action='store_true',
+                            help='Request commands from odin-data application')
         parser.add_argument('--status', action='store_true',
                             help='Request a status report from the odin-data application')
         parser.add_argument('--shutdown', action='store_true',
@@ -92,6 +94,9 @@ class OdinDataClient(object):
 
         if self.args.request_config:
             self.do_request_config_cmd()
+
+        if self.args.request_commands:
+            self.do_request_command_cmd()
 
         if self.args.status:
             self.do_status_cmd()
@@ -125,9 +130,16 @@ class OdinDataClient(object):
         self.await_response()
 
     def do_request_config_cmd(self):
-        """Send a request configurtion command to odin-data."""
+        """Send a request configuration command to odin-data."""
         status_msg = IpcMessage('cmd', 'request_configuration', id=self._next_msg_id())
         self.logger.info("Sending configuration request to the odin-data application")
+        self.ctrl_channel.send(status_msg.encode())
+        self.await_response()
+
+    def do_request_command_cmd(self):
+        """Send a request commands command to odin-data"""
+        status_msg = IpcMessage('cmd', 'request_commands', id=self._next_msg_id())
+        self.logger.info("Sending command request to the odin-data application")
         self.ctrl_channel.send(status_msg.encode())
         self.await_response()
 

--- a/python/src/odin_data/control/frame_processor_adapter.py
+++ b/python/src/odin_data/control/frame_processor_adapter.py
@@ -62,7 +62,7 @@ class FrameProcessorAdapter(OdinDataAdapter):
             'config/hdf/file/extension': 'h5',
             'config/hdf/frames': 0
         }
-        self._command = 'config/hdf/write'
+        self._write_command = 'config/hdf/write'
         self.setup_rank()
 
     def initialize(self, adapters):
@@ -147,10 +147,9 @@ class FrameProcessorAdapter(OdinDataAdapter):
                     self._param[path] = str(escape.url_unescape(request.body)).replace('"', '')
                 # Merge with the configuration store
 
-            elif path == self._command:
+            elif path == self._write_command:
                 write = bool_from_string(str(escape.url_unescape(request.body)))
-                config = {'hdf': {'write': write}}
-                logging.debug("Setting {} to {}".format(path, config))
+                logging.debug("Setting {} to {}".format(path, write))
                 if write:
                     # Before attempting to write files, make some simple error checks
 
@@ -192,9 +191,11 @@ class FrameProcessorAdapter(OdinDataAdapter):
                         }
                         client.send_configuration(parameters)
                         rank += 1
+                command = "start_writing" if write else "stop_writing"
                 for client in self._clients:
-                    # Send the configuration required to start the acquisition
-                    client.send_configuration(config)
+                    # Send the start/stop_writing command to the clients to start/stop
+                    # the acquisition
+                    client.execute_command("hdf", command)
 
             else:
                 return super(FrameProcessorAdapter, self).put(path, request)

--- a/python/src/odin_data/control/ipc_tornado_client.py
+++ b/python/src/odin_data/control/ipc_tornado_client.py
@@ -175,7 +175,7 @@ class IpcTornadoClient(object):
     def _update_commands(self, commands_msg):
         """Store the response to a request_commands message in the _parameters dict.
 
-        :param commands_msg: Incoming commands message reponse
+        :param commands_msg: Incoming commands message response
         """
         params = commands_msg['params']
         self._parameters['commands'] = params

--- a/python/src/odin_data/control/ipc_tornado_client.py
+++ b/python/src/odin_data/control/ipc_tornado_client.py
@@ -1,23 +1,43 @@
 import logging
 from threading import RLock
+from time import sleep
 
 from odin_data.control.ipc_message import IpcMessage, IpcMessageException
 from odin_data.control.ipc_tornado_channel import IpcTornadoChannel
 
 
 class IpcTornadoClient(object):
+    """Client class that wraps an IpcTornadoClient class with additional
+    message handling and management.
 
+    """
     ENDPOINT_TEMPLATE = "tcp://{IP}:{PORT}"
+    MSG_CHECK_SLEEP_DELTA = 0.01
+    IPC_VAL_REQ_VERS = "request_version"
+    IPC_VAL_REQ_CFG = "request_configuration"
+    IPC_VAL_STATUS = "status"
+    CLIENT_CONNECTED = "connected"
 
     MESSAGE_ID_MAX = 2**32
 
     def __init__(self, ip_address, port):
+        """Initalise the IpcTornadoClient object.
+
+        This creates a DEALER ZeroMQ socket for communication with the following
+        applications:
+        - FrameReceiver
+        - FrameProcessor
+        - MetaWriter
+
+        :param ip_address: IP address for the ZeroMQ socket endpoint
+        :param port: UPort number for the ZeroMQ socket endpoint
+        """
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self._ip_address = ip_address
         self._port = port
 
-        self._parameters = {'status': {'connected': False}}
+        self._parameters = {self.IPC_VAL_STATUS: {self.CLIENT_CONNECTED: False}}
         self.ctrl_endpoint = self.ENDPOINT_TEMPLATE.format(IP=ip_address, PORT=port)
         self.logger.debug("Connecting to client at %s", self.ctrl_endpoint)
         self.ctrl_channel = IpcTornadoChannel(IpcTornadoChannel.CHANNEL_TYPE_DEALER)
@@ -26,56 +46,150 @@ class IpcTornadoClient(object):
         self.ctrl_channel.register_callback(self._callback)
         self.message_id = 0
 
+        # Dictionary of outstanding config messages
+        self._active_msgs = {}
+        self._rejected_configs = {}
+
         self._lock = RLock()
 
     @property
     def parameters(self):
+        """Read out the stored parameters from this client.
+
+        The parameters dictionary contains a snapshot of all responses to
+        messages sent out by this client.  The latest resposnes are
+        stored in the _parameters dict and are returned by this method.
+
+        :return: the _parameters dict
+        """
         return self._parameters
 
+    def read_rejected_configs(self):
+        """Return the current dict of rejected configuration messages.
+
+        :return: a dict of rejected configuration
+        """
+        return self._rejected_configs
+
+    def clear_rejected_configs(self):
+        """Clear any rejected configuration messages.
+        """
+        self.logger.debug("Clearing rejected configurations")
+        with self._lock:
+            self._rejected_configs.clear()
+
     def _monitor_callback(self, msg):
-        # Handle the multi-part message
+        """Handles incoming messages from the monitoring ZeroMQ socket.
+
+        The monitoring socket receives notification messages when the
+        main socket state changes (eg a connection is established).
+        When a state change occurs this method is called with the
+        notification.
+
+        The notification is checked for a connected or disconnected
+        event and the connected status parameter is updated to reflect
+        this new state of the socket.
+
+        :param msg: Incoming message from the monitoring ZeroMQ socket
+        """
         self.logger.debug("Msg received from %s: %s", self.ctrl_endpoint, msg)
         if msg['event'] == IpcTornadoChannel.CONNECTED:
             self.logger.debug("  Connected...")
-            self._parameters['status']['connected'] = True
+            self._parameters[self.IPC_VAL_STATUS][self.CLIENT_CONNECTED] = True
         if msg['event'] == IpcTornadoChannel.DISCONNECTED:
             self.logger.debug("  Disconnected...")
-            self._parameters['status']['connected'] = False
+            self._parameters[self.IPC_VAL_STATUS][self.CLIENT_CONNECTED] = False
 
     def _callback(self, msg):
+        """Handes incoming messages from the main ZeroMQ socket.
+
+        The handled message types are:
+        - Reply to 'request_version'
+        - Reply to 'request_configuration'
+        - Reply to 'status'
+        - Reply to 'configure'
+
+        Replies to request_version, request_configuration and status
+        are stored in the _parameters according to the message type.
+        Replies to 'configure' result in the corresponding message
+        being removed from the _active_msgs dict.  They are then
+        checked for rejection and moved into the _rejected_configs
+        dict if they were rejected.
+
+        :param msg: Incoming message from the main ZeroMQ socket
+        """
         # Handle the multi-part message
         reply = IpcMessage(from_str=msg[0])
-        if 'request_version' in reply.get_msg_val():
+        if self.IPC_VAL_REQ_VERS in reply.get_msg_val():
             self._update_versions(reply.attrs)
-        if 'request_configuration' in reply.get_msg_val():
+        elif self.IPC_VAL_REQ_CFG in reply.get_msg_val():
             self._update_configuration(reply.attrs)
-        if 'status' in reply.get_msg_val():
+        elif self.IPC_VAL_STATUS in reply.get_msg_val():
             self._update_status(reply.attrs)
+        with self._lock:
+            self._active_msgs.pop(reply.get_msg_id())
+            if reply.get_msg_type() == "nack" and reply.get_msg_val() == "configure":
+                with self._lock:
+                    self._rejected_configs[reply.get_msg_id()] = reply
 
     def _update_versions(self, version_msg):
+        """Store the response to a request_version message in the
+        _parameters dict.
+
+        :param version_msg: Incoming version message response
+        """
         params = version_msg['params']
         self._parameters['version'] = params['version']
 
     def _update_configuration(self, config_msg):
+        """Store the response to a request_configuration message in the
+        _parameters dict.
+
+        :param config_msg: Incoming configuration message response
+        """
         params = config_msg['params']
         self._parameters['config'] = params
 
     def _update_status(self, status_msg):
+        """Store the response to a status message in the _parameters dict.
+
+        :param status_msg: Incoming status message response
+        """
         params = status_msg['params']
         params['timestamp'] = status_msg['timestamp']
-        self._parameters['status'] = params
+        self._parameters[self.IPC_VAL_STATUS] = params
+        if 'error' not in self._parameters[self.IPC_VAL_STATUS]:
+            self._parameters[self.IPC_VAL_STATUS]['error'] = []
+        with self._lock:
+            for msg in self._rejected_configs:
+                self._parameters[self.IPC_VAL_STATUS]['error'].append(self._rejected_configs[msg].get_params()['error'])
+
         # If we have received a status response then we must be connected
-        self._parameters['status']['connected'] = True
+        self._parameters[self.IPC_VAL_STATUS][self.CLIENT_CONNECTED] = True
 
     def connected(self):
-        return self._parameters['status']['connected']
+        """Returns the connected state of this client.
+
+        :return: The connected state of the client
+        """
+        return self._parameters[self.IPC_VAL_STATUS][self.CLIENT_CONNECTED]
 
     def _send_message(self, msg):
+        """Injects the next message ID into the message object.
+        Adds the message to the list of active messages (indexed by
+        unique ID).  Sends the encoded ASCII message through the
+        ZeroMQ socket.
+
+        :param msg: The message to send
+        """
         msg.set_msg_id(self.message_id)
         self.message_id = (self.message_id + 1) % self.MESSAGE_ID_MAX
         self.logger.debug("Sending control message [%s]:\n%s", self.ctrl_endpoint, msg.encode())
         with self._lock:
+            self._active_msgs[msg.get_msg_id()] = msg
             self.ctrl_channel.send(msg.encode())
+
+        return msg
 
     @staticmethod
     def _raise_reply_error(msg, reply):
@@ -85,10 +199,22 @@ class IpcTornadoClient(object):
             raise IpcMessageException("Request\n%s\nunsuccessful. Got no response." % msg)
 
     def send_request(self, value):
+        """Creates an IpcMessage object with the specified value
+        and calls the _send_message method with the message object.
+
+        :param value: Value of the IpcMessage object
+        """
         msg = IpcMessage("cmd", value)
-        self._send_message(msg)
+        return self._send_message(msg)
 
     def send_configuration(self, content, target=None, valid_error=None):
+        """Creates a specific configure IpcMessage object.  Sets the
+        parameters of the configure message object to content and sends
+        the message
+
+        :param content: contents of message to send
+        :return: The message object that has been created and sent
+        """
         msg = IpcMessage("cmd", "configure")
 
         if target is not None:
@@ -97,6 +223,47 @@ class IpcTornadoClient(object):
             for parameter, value in content.items():
                 msg.set_param(parameter, value)
 
-        self._send_message(msg)
+        if "clear_errors" in msg.get_params():
+            self.clear_rejected_configs()
 
+        return self._send_message(msg)
 
+    def check_for_rejection(self, msg_id):
+        """Check specific message for rejection.
+
+        :param msg_id: the ID of the message to search for
+        :return: boolean True if the config has been rejected
+        """
+        rejected = False
+        if msg_id in self._rejected_configs:
+            rejected = True
+        return rejected
+
+    def wait_for_response(self, msg_id, timeout=1.0):
+        """Block waiting for a message response, with a timeout
+
+        Check to see if message is in the active message dict.
+        If it is, wait for sleep delta. Keep checking until a
+        timeout occurs or a response arrives.
+
+        :param msg_id: the ID of the message to wait for
+        :param timeout: number of seconds to block for before timing out.  If
+        timeout is set to less than zero then block forever
+        :return: a boolean True if a timout occured
+        """
+        timed_out = False
+        running = True
+        sleep_time = 0.0
+        while running:
+            with self._lock:
+                if msg_id not in self._active_msgs:
+                    running = False
+            if running:
+                if timeout >= 0.0:
+                    sleep(self.MSG_CHECK_SLEEP_DELTA)
+                    sleep_time += self.MSG_CHECK_SLEEP_DELTA
+                    if sleep_time >= timeout:
+                        running = False
+                        timed_out = True
+
+        return timed_out


### PR DESCRIPTION
Fixes https://github.com/odin-detector/odin-data/issues/357

Looks like force pushing auto-closed the other PR so recreating.

Adds support for start_writing and stop_writing commands for the FrameProcessor on top of master. To support this, I had to include Alan's changes for ipc_tornado_client.py by breaking up https://github.com/odin-detector/odin-data/commit/218754111769b122131acd8ee1cb0874aed535e2 into multiple commits and then cherry-picking it - so I will need to rebase fastcs-dev on top of these changes to fix the history.

From my testing, the Start and Stop buttons on the OD screen open and close files in each of the 4 FrameProcessor clients when using Diamond's 1-0-0 release of ADOdin's eiger example IOC against a simulator.

edit: i see tests are failing, will investigate
