### PR TITLE
Add dependency header to ClassLoader.h to allow stand-alone compilation

### DIFF
--- a/cpp/common/include/ClassLoader.h
+++ b/cpp/common/include/ClassLoader.h
@@ -11,6 +11,9 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <map>
+#include <stdexcept>
+#include <string>
 
 #define REGISTER(Base,Class,Name) OdinData::ClassLoader<Base> cl(Name, OdinData::maker<Base,Class>);
 


### PR DESCRIPTION
Add dependency header to ClassLoader.h to allow stand-alone compilation.

Fixes #319 