### PR TITLE
Check for Empty FIle Name From generate_filename() function

### DIFF
--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -565,7 +565,7 @@ boost::shared_ptr<HDF5File> Acquisition::get_file(size_t frame_offset, HDF5CallD
       LOG4CXX_DEBUG_LEVEL(1, logger_,"Creating missing file " << next_expected_file_index);
       filename_ = generate_filename(next_expected_file_index);
       if (filename_.empty()) {
-        last_error_ = "Unable to fetch file - no filename to write to";
+        last_error_ = "Failed to generate a valid file name - not creating file.";
         LOG4CXX_ERROR(logger_, last_error_);
         return boost::shared_ptr<HDF5File>();
       }

--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -564,11 +564,11 @@ boost::shared_ptr<HDF5File> Acquisition::get_file(size_t frame_offset, HDF5CallD
     while (next_expected_file_index <= file_index) {
       LOG4CXX_DEBUG_LEVEL(1, logger_,"Creating missing file " << next_expected_file_index);
       filename_ = generate_filename(next_expected_file_index);
-        if (filename_.empty()) {
-          last_error_ = "Unable to fetch file - no filename to write to";
-          LOG4CXX_ERROR(logger_, last_error_);
-          return boost::shared_ptr<HDF5File>();
-        }
+      if (filename_.empty()) {
+        last_error_ = "Unable to fetch file - no filename to write to";
+        LOG4CXX_ERROR(logger_, last_error_);
+        return boost::shared_ptr<HDF5File>();
+      }
       create_file(next_expected_file_index, call_durations);
       next_expected_file_index = current_file_->get_file_index() + concurrent_processes_;
     }

--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -561,16 +561,17 @@ boost::shared_ptr<HDF5File> Acquisition::get_file(size_t frame_offset, HDF5CallD
 
     // Check for missing files and create them if they have been missed
     size_t next_expected_file_index = current_file_->get_file_index() + concurrent_processes_;
-    while (next_expected_file_index < file_index) {
+    while (next_expected_file_index <= file_index) {
       LOG4CXX_DEBUG_LEVEL(1, logger_,"Creating missing file " << next_expected_file_index);
       filename_ = generate_filename(next_expected_file_index);
+        if (filename_.empty()) {
+          last_error_ = "Unable to fetch file - no filename to write to";
+          LOG4CXX_ERROR(logger_, last_error_);
+          return boost::shared_ptr<HDF5File>();
+        }
       create_file(next_expected_file_index, call_durations);
       next_expected_file_index = current_file_->get_file_index() + concurrent_processes_;
     }
-
-    filename_ = generate_filename(file_index);
-
-    create_file(file_index, call_durations);
 
     return this->current_file_;
   } else {


### PR DESCRIPTION
Add a check for empty file_name in the generate_filename() function. 
NB: The generate_filename() function can return an empty string; hence, a check on the file name's return value is added to the function where it is called. 
Fixes #296