### PR TITLE
Use latest github cache action

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # All history
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
`actions/cache@v2` is now deprecated and the default (`actions/cache`) is now version 4

See: https://github.com/actions/toolkit/discussions/1890