### PR TITLE
Update BLOSC Settings As String

### DIFF
--- a/cpp/frameProcessor/include/BloscPlugin.h
+++ b/cpp/frameProcessor/include/BloscPlugin.h
@@ -19,11 +19,11 @@ namespace FrameProcessor
 
 typedef struct{
   int compression_level;
-  unsigned int shuffle;
+  std::string shuffle;
   size_t type_size;
   size_t uncompressed_size;
   unsigned int threads;
-  unsigned int blosc_compressor;
+  std::string blosc_compressor;
 } BloscCompressionSettings;
 void create_cd_values(const BloscCompressionSettings& settings, std::vector<unsigned int> cd_values);
 


### PR DESCRIPTION
Update Blosc Setting - shuffle from int to std::string. 
Update Blosc Setting - blosc_compressor from int to std::string. 
Add conversion function mapping from unsigned int to std::string shuffle_i2str. 
Add conversion function mapping from unsigned int to std::string compressor_i2str. 
Add hash-maps from std::string to unsigned int - shuffle_str2i and compressor_str2i. 
Update references to shuffle and blosc_compressor, to map to required format. 

Fixes #204