### PR TITLE
mplement requestMetadata Within C++ FP Apps

### DIFF
--- a/cpp/frameProcessor/include/FrameProcessorPlugin.h
+++ b/cpp/frameProcessor/include/FrameProcessorPlugin.h
@@ -45,6 +45,8 @@ public:
   std::vector<std::string> get_warnings();
   virtual void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
   virtual void requestConfiguration(OdinData::IpcMessage& reply);
+  virtual void requestMetadata(OdinData::IpcMessage& reply);
+  virtual void requestStatusMetadata(OdinData::IpcMessage& reply);
   virtual void execute(const std::string& command, OdinData::IpcMessage& reply);
   virtual std::vector<std::string> requestCommands();
   virtual void status(OdinData::IpcMessage& status);

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -304,6 +304,8 @@ void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply)
     reply.set_param("plugins/names[]", iter->first);
     // Request status for the plugin
     iter->second->status(reply);
+    // Request status metadata for the plugin
+    iter->second->requestStatusMetadata(reply);
     // Add performance statistics
     iter->second->add_performance_stats(reply);
     // Read error level
@@ -521,6 +523,7 @@ void FrameProcessorController::requestConfiguration(OdinData::IpcMessage& reply)
   std::map<std::string, boost::shared_ptr<FrameProcessorPlugin> >::iterator iter;
   for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
     iter->second->requestConfiguration(reply);
+    iter->second->requestMetadata(reply);
   }
 }
 

--- a/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -168,6 +168,30 @@ void FrameProcessorPlugin::requestConfiguration(OdinData::IpcMessage& reply)
   // Default method simply does nothing
 }
 
+/** Request the plugin's Metadata configuration.
+ *
+ * In this abstract class the requestMetadata method doesn't 
+ * perform any actions, this should be overridden by subclasses.
+ *
+ * \param[out] reply - Response IpcMessage with current configuration.
+ */
+void FrameProcessorPlugin::requestMetadata(OdinData::IpcMessage& reply)
+{
+  // Default method simply does nothing
+}
+
+/** Request the plugin's Metadata configuration.
+ *
+ * In this abstract class the requestStatusMetadata method doesn't 
+ * perform any actions, this should be overridden by subclasses.
+ *
+ * \param[out] reply - Response IpcMessage with current configuration.
+ */
+void FrameProcessorPlugin::requestStatusMetadata(OdinData::IpcMessage& reply)
+{
+  // Default method simply does nothing
+}
+
 /** Execute a command within the plugin.
  *
  * In this abstract class the command method doesn't perform any


### PR DESCRIPTION
Add a requestStatusMetadata method  to the base FrameProcessorPlugin class. Add a requestMetadata method  to the base FrameProcessorPlugin class. Call requestStatusMetadata in the provideStatus method if FrameProcessorController for all plugins.
Call requestMetadata in requestConfiguration method for all plugins.