### PR TITLE
Make shutdown frames check test if requested number of frames > 0

### DIFF
--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -143,11 +143,11 @@ private:
   /** Condition for exiting this file writing process */
   boost::condition_variable                                       exitCondition_;
   /** Frames to write before shutting down - 0 to disable shutdown */
-  int                                                             shutdownFrameCount;
+  unsigned int                                                    shutdownFrameCount_;
   /** Total frames processed */
-  int                                                             totalFrames;
+  unsigned int                                                    totalFrames_;
   /** Master frame specifier - Frame to include in count of total frames processed */
-  std::string                                                     masterFrame;
+  std::string                                                     masterFrame_;
   /** Mutex used for locking the exitCondition */
   boost::mutex                                                    exitMutex_;
   /** Used to check for Ipc tick timer termination */

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -67,12 +67,12 @@ FrameProcessorController::FrameProcessorController(unsigned int num_io_threads) 
     metaTxChannelEndpoint_(""),
     metaTxChannel_(ZMQ_PUB),
     frReadyEndpoint_(OdinData::Defaults::default_frame_ready_endpoint),
-    frReleaseEndpoint_(OdinData::Defaults::default_frame_release_endpoint)
+    frReleaseEndpoint_(OdinData::Defaults::default_frame_release_endpoint),
+    shutdownFrameCount_(0),
+    totalFrames_(0)
 {
   OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Constructing FrameProcessorController");
-
-  totalFrames = 0;
 
   // Wait for the thread service to initialise and be running properly, so that
   // this constructor only returns once the object is fully initialised (RAII).
@@ -264,12 +264,12 @@ void FrameProcessorController::handleMetaRxChannel()
 void FrameProcessorController::callback(boost::shared_ptr<Frame> frame) {
 
   // If frame is a master frame, or all frames are included (no master frames), increment frame count
-  if (masterFrame == "" || frame->get_meta_data().get_dataset_name() == masterFrame) {
-    totalFrames++;
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Frame " << totalFrames << " complete.");
+  if (masterFrame_ == "" || frame->get_meta_data().get_dataset_name() == masterFrame_) {
+    totalFrames_++;
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Frame " << totalFrames_ << " complete.");
   }
 
-  if (totalFrames == shutdownFrameCount) {
+  if ((shutdownFrameCount_ > 0) && (totalFrames_ == shutdownFrameCount_)) {
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Shutdown frame count reached");
     // Set exit condition so main thread can continue and shutdown
     exitCondition_.notify_all();
@@ -382,8 +382,8 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
 
   // Check if we are being given the master frame specifier
   if (config.has_param("hdf/master")) {
-    masterFrame = config.get_param<std::string>("hdf/master");
-    LOG4CXX_DEBUG_LEVEL(1, logger_, "Master frame specifier set to: " << masterFrame);
+    masterFrame_ = config.get_param<std::string>("hdf/master");
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Master frame specifier set to: " << masterFrame_);
   }
 
   // Check if we have been asked to reset any errors
@@ -396,8 +396,8 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
 
   // If frames given then we are running for defined number and then shutting down
   if (config.has_param("frames") && config.get_param<unsigned int>("frames") != 0) {
-    shutdownFrameCount = config.get_param<unsigned int>("frames");
-    LOG4CXX_DEBUG_LEVEL(1, logger_, "Shutdown frame count set to: " << shutdownFrameCount);
+    shutdownFrameCount_ = config.get_param<unsigned int>("frames");
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Shutdown frame count set to: " << shutdownFrameCount_);
   }
 
   // Check for a request to inject an End Of Acquisition object


### PR DESCRIPTION
This PR resolves #439, where the frameProcessor shuts down abnormally in situations where a master dataset is defined but the first frame to flow through the file writer is not from that frame. The fix ensures that the requested number of frames to trigger an automatic shutdown is non-zero. The associated member variable in the controller is also explicitly initialised to zero.
