### PR TITLE
Fix cleanup of callback worker threads

### DIFF
--- a/cpp/frameProcessor/include/IFrameCallback.h
+++ b/cpp/frameProcessor/include/IFrameCallback.h
@@ -58,6 +58,8 @@ private:
   boost::thread *thread_;
   /** Pointer to WorkQueue for Frame object pointers */
   boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame> > > queue_;
+  /** IFrameCallback run flag */
+  bool run_;
   /** Is this IFrameCallback working */
   bool working_;
   /** Map of confirmed registrations to this worker queue */

--- a/cpp/frameProcessor/src/IFrameCallback.cpp
+++ b/cpp/frameProcessor/src/IFrameCallback.cpp
@@ -17,6 +17,7 @@ namespace FrameProcessor
  */
 IFrameCallback::IFrameCallback() :
     thread_(0),
+    run_(false),
     working_(false)
 {
   // Create the work queue for message offload
@@ -47,8 +48,8 @@ boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame> > > IFrameCallback::getWork
 void IFrameCallback::start()
 {
   if (!working_) {
-    // Set the working flag to true
-    working_ = true;
+    // Set the run condition to true
+    run_ = true;
     // Now start the worker thread to monitor the queue
     thread_ = new boost::thread(&IFrameCallback::workerTask, this);
   }
@@ -63,8 +64,8 @@ void IFrameCallback::start()
 void IFrameCallback::stop()
 {
   if (working_) {
-    // Set the working flag to false
-    working_ = false;
+    // Set the run condition flag to false
+    run_ = false;
     // Now notify the work queue we have finished by adding a null ptr
     boost::shared_ptr<Frame> nullMsg;
     queue_->add(nullMsg);
@@ -117,14 +118,20 @@ void IFrameCallback::workerTask()
   OdinData::configure_logging_mdc(OdinData::app_path.c_str());
 
   // Main worker task of this callback
+
+  // Set the working flag to true
+  working_ = true;
+
   // Check the queue for messages
-  while (working_) {
+  while (run_) {
     boost::shared_ptr<Frame> msg = queue_->remove();
     if (msg) {
       // Once we have a message, call the callback
       this->callback(msg);
     }
   }
+  // Clear the working flag
+  working_ = false;
 }
 
 } /* namespace FrameProcessor */

--- a/cpp/frameProcessor/src/SharedMemoryController.cpp
+++ b/cpp/frameProcessor/src/SharedMemoryController.cpp
@@ -80,6 +80,14 @@ SharedMemoryController::SharedMemoryController(boost::shared_ptr<OdinData::IpcRe
 SharedMemoryController::~SharedMemoryController()
 {
   LOG4CXX_TRACE(logger_, "Shutting down SharedMemoryController");
+
+  auto it = callbacks_.begin();
+  while (it != callbacks_.end()) {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Shutting down callback for " << it->first);
+    it->second->stop();
+    it = callbacks_.erase(it);
+  }
+
   // Close the IPC Channels
   reactor_->remove_channel(txChannel_);
   reactor_->remove_channel(rxChannel_);


### PR DESCRIPTION
This PR resolves #440 where the frameProcessor can terminate with an unhandled exception during some shutdown scenarios, for instance when frames are still flowing from the frameReceiver. The cleanup of worker threads associated with frame callbacks during shutdown and in the destructor of the SharedMemoryController is improved to avoid a race condition where shared pointers to frames in shared memory buffers are deleted and generate IPC messages to the frame receiver after the frame release channel has been closed.
