### PR TITLE
Remove BloscPlugin status() Method Implementation

### DIFF
--- a/cpp/frameProcessor/include/BloscPlugin.h
+++ b/cpp/frameProcessor/include/BloscPlugin.h
@@ -48,7 +48,6 @@ public:
 
     // Baseclass API to implement:
     void process_frame(boost::shared_ptr<Frame> frame);
-    void status(OdinData::IpcMessage& status);
     void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void requestConfiguration(OdinData::IpcMessage& reply);
     int get_version_major();

--- a/cpp/frameProcessor/src/BloscPlugin.cpp
+++ b/cpp/frameProcessor/src/BloscPlugin.cpp
@@ -350,18 +350,6 @@ void BloscPlugin::requestConfiguration(OdinData::IpcMessage& reply)
     );
 }
 
-/** Collate status information for the plugin
- *
- * @param status - Reference to an IpcMessage value to store the status
- */
-void BloscPlugin::status(OdinData::IpcMessage& status)
-{
-    status.set_param(this->get_name() + "/compressor", this->compression_settings_.blosc_compressor);
-    status.set_param(this->get_name() + "/threads", this->compression_settings_.threads);
-    status.set_param(this->get_name() + "/shuffle", this->compression_settings_.shuffle);
-    status.set_param(this->get_name() + "/level", this->compression_settings_.compression_level);
-}
-
 int BloscPlugin::get_version_major()
 {
     return ODIN_DATA_VERSION_MAJOR;


### PR DESCRIPTION
The status() method in BloscPlugin duplicates the requestConfiguration() method. Its implementation should be removed from the plugin. Fixes #477