### PR TITLE
To Be Validated: Modify the WorkerQueue Class Data Structure

### DIFF
--- a/cpp/frameProcessor/include/IFrameCallback.h
+++ b/cpp/frameProcessor/include/IFrameCallback.h
@@ -52,7 +52,7 @@ public:
 private:
     /** Pointer to logger */
     LoggerPtr logger_;
-    /** Pointer to worker queue thread */
+    /** worker queue thread */
     boost::thread thread_;
     /** WorkQueue for Frame object pointers */
     WorkQueue<boost::shared_ptr<Frame>> queue_;

--- a/cpp/frameProcessor/include/IFrameCallback.h
+++ b/cpp/frameProcessor/include/IFrameCallback.h
@@ -33,7 +33,7 @@ class IFrameCallback {
 public:
     IFrameCallback();
     virtual ~IFrameCallback();
-    boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame>>> getWorkQueue();
+    WorkQueue<boost::shared_ptr<Frame>>& getWorkQueue();
     void start();
     void stop();
     bool isWorking() const;
@@ -53,9 +53,9 @@ private:
     /** Pointer to logger */
     LoggerPtr logger_;
     /** Pointer to worker queue thread */
-    boost::thread* thread_;
-    /** Pointer to WorkQueue for Frame object pointers */
-    boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame>>> queue_;
+    boost::thread thread_;
+    /** WorkQueue for Frame object pointers */
+    WorkQueue<boost::shared_ptr<Frame>> queue_;
     /** IFrameCallback run flag */
     bool run_;
     /** Is this IFrameCallback working */

--- a/cpp/frameProcessor/include/WorkQueue.h
+++ b/cpp/frameProcessor/include/WorkQueue.h
@@ -75,8 +75,10 @@ public:
                 pthread_cond_wait(&m_condv, &m_mutex);
             }
         }
+        bool is_empty = m_queue.empty();
         m_queue.push_back(std::move(item));
-        pthread_cond_signal(&m_condv);
+        if (is_empty)
+            pthread_cond_signal(&m_condv);
         pthread_mutex_unlock(&m_mutex);
     }
 
@@ -95,9 +97,11 @@ public:
         while (m_queue.empty()) {
             pthread_cond_wait(&m_condv, &m_mutex);
         }
+        bool is_full = m_queue.size() == max_queue_size;
         T item = m_queue.front();
         m_queue.pop_front();
-        pthread_cond_signal(&m_condv);
+        if (is_full)
+            pthread_cond_signal(&m_condv);
         pthread_mutex_unlock(&m_mutex);
         return item;
     }
@@ -108,9 +112,11 @@ public:
         while (m_queue.size() == 0) {
             pthread_cond_wait(&m_condv, &m_mutex);
         }
+        bool is_full = m_queue.size() == max_queue_size;
         src = m_queue.front();
         m_queue.pop_front();
-        pthread_cond_signal(&m_condv);
+        if (is_full)
+            pthread_cond_signal(&m_condv);
         pthread_mutex_unlock(&m_mutex);
     }
 

--- a/cpp/frameProcessor/include/WorkQueue.h
+++ b/cpp/frameProcessor/include/WorkQueue.h
@@ -25,7 +25,7 @@ namespace FrameProcessor {
  * Frame objects, and not the Frame objects themselves.
  */
 template <typename T> class WorkQueue {
-    static constexpr int max_queue_size = 8;
+    static constexpr typename boost::circular_buffer<T>::size_type max_queue_size = 8;
     /** Queue (list) of worker items queued for processing */
     boost::circular_buffer<T> m_queue;
     /** Mutex for locking the queue */
@@ -45,11 +45,16 @@ public:
         pthread_cond_init(&m_condv, NULL);
     }
 
+    /**
+     * Delete copy assignment operator
+     */
+    WorkQueue& operator=(const WorkQueue&) = delete;
+
     /** Destructor.
      *
      * The destructor frees resources (mutex and condition).
      */
-    virtual ~WorkQueue()
+    ~WorkQueue()
     {
         pthread_mutex_destroy(&m_mutex);
         pthread_cond_destroy(&m_condv);
@@ -70,7 +75,7 @@ public:
                 pthread_cond_wait(&m_condv, &m_mutex);
             }
         }
-        m_queue.push_back(item);
+        m_queue.push_back(std::move(item));
         pthread_cond_signal(&m_condv);
         pthread_mutex_unlock(&m_mutex);
     }
@@ -87,7 +92,7 @@ public:
     {
         static_assert(std::is_nothrow_copy_constructible<T>::value && std::is_nothrow_move_constructible<T>::value);
         pthread_mutex_lock(&m_mutex);
-        while (m_queue.size() == 0) {
+        while (m_queue.empty()) {
             pthread_cond_wait(&m_condv, &m_mutex);
         }
         T item = m_queue.front();
@@ -119,6 +124,14 @@ public:
         int size = m_queue.size();
         pthread_mutex_unlock(&m_mutex);
         return size;
+    }
+
+    /**
+     * Return the max Queue size
+     */
+    constexpr typename boost::circular_buffer<T>::size_type max_size()
+    {
+        return max_queue_size;
     }
 };
 

--- a/cpp/frameProcessor/include/WorkQueue.h
+++ b/cpp/frameProcessor/include/WorkQueue.h
@@ -30,8 +30,12 @@ template <typename T> class WorkQueue {
     boost::circular_buffer<T> m_queue;
     /** Mutex for locking the queue */
     pthread_mutex_t m_mutex;
-    /** Condition for waking up blocked threads when a new item is added to the queue */
-    pthread_cond_t m_condv;
+    /** Condition variable for waking up blocked consumer threads when a new item is added to the previously empty queue
+     */
+    pthread_cond_t m_prod_condv;
+    /** Condition variable for waking up blocked producer threads when an item is removed from the previously full queue
+     */
+    pthread_cond_t m_cons_condv;
 
 public:
     /** Constructor.
@@ -42,7 +46,8 @@ public:
         m_queue(max_queue_size)
     {
         pthread_mutex_init(&m_mutex, NULL);
-        pthread_cond_init(&m_condv, NULL);
+        pthread_cond_init(&m_prod_condv, NULL);
+        pthread_cond_init(&m_cons_condv, NULL);
     }
 
     /**
@@ -57,7 +62,8 @@ public:
     ~WorkQueue()
     {
         pthread_mutex_destroy(&m_mutex);
-        pthread_cond_destroy(&m_condv);
+        pthread_cond_destroy(&m_prod_condv);
+        pthread_cond_destroy(&m_cons_condv);
     }
 
     /** Add an item to the queue.
@@ -72,13 +78,13 @@ public:
         pthread_mutex_lock(&m_mutex);
         if (!ignore_max_limit) {
             while (m_queue.size() >= max_queue_size) {
-                pthread_cond_wait(&m_condv, &m_mutex);
+                pthread_cond_wait(&m_cons_condv, &m_mutex);
             }
         }
         bool is_empty = m_queue.empty();
         m_queue.push_back(std::move(item));
         if (is_empty)
-            pthread_cond_signal(&m_condv);
+            pthread_cond_signal(&m_prod_condv);
         pthread_mutex_unlock(&m_mutex);
     }
 
@@ -95,13 +101,13 @@ public:
         static_assert(std::is_nothrow_copy_constructible<T>::value && std::is_nothrow_move_constructible<T>::value);
         pthread_mutex_lock(&m_mutex);
         while (m_queue.empty()) {
-            pthread_cond_wait(&m_condv, &m_mutex);
+            pthread_cond_wait(&m_prod_condv, &m_mutex);
         }
         bool is_full = m_queue.size() == max_queue_size;
         T item = m_queue.front();
         m_queue.pop_front();
         if (is_full)
-            pthread_cond_signal(&m_condv);
+            pthread_cond_signal(&m_cons_condv);
         pthread_mutex_unlock(&m_mutex);
         return item;
     }
@@ -110,13 +116,13 @@ public:
     {
         pthread_mutex_lock(&m_mutex);
         while (m_queue.size() == 0) {
-            pthread_cond_wait(&m_condv, &m_mutex);
+            pthread_cond_wait(&m_prod_condv, &m_mutex);
         }
         bool is_full = m_queue.size() == max_queue_size;
         src = m_queue.front();
         m_queue.pop_front();
         if (is_full)
-            pthread_cond_signal(&m_condv);
+            pthread_cond_signal(&m_cons_condv);
         pthread_mutex_unlock(&m_mutex);
     }
 

--- a/cpp/frameProcessor/include/WorkQueue.h
+++ b/cpp/frameProcessor/include/WorkQueue.h
@@ -8,13 +8,13 @@
 #ifndef TOOLS_FILEWRITER_WORKQUEUE_H_
 #define TOOLS_FILEWRITER_WORKQUEUE_H_
 
+#include <boost/circular_buffer.hpp>
 #include <cstddef>
-#include <list>
+#include <type_traits>
 
 namespace FrameProcessor {
 
 /** Maximum queue size - to prevent unlimited use of memory **/
-const int max_queue_size = 8;
 
 /** Thread safe producer consumer work queue.
  *
@@ -25,8 +25,9 @@ const int max_queue_size = 8;
  * Frame objects, and not the Frame objects themselves.
  */
 template <typename T> class WorkQueue {
+    static constexpr int max_queue_size = 8;
     /** Queue (list) of worker items queued for processing */
-    std::list<T> m_queue;
+    boost::circular_buffer<T> m_queue;
     /** Mutex for locking the queue */
     pthread_mutex_t m_mutex;
     /** Condition for waking up blocked threads when a new item is added to the queue */
@@ -37,7 +38,8 @@ public:
      *
      * The constructor initialises the mutex and condition required for the class.
      */
-    WorkQueue()
+    WorkQueue() :
+        m_queue(max_queue_size)
     {
         pthread_mutex_init(&m_mutex, NULL);
         pthread_cond_init(&m_condv, NULL);
@@ -83,6 +85,7 @@ public:
      */
     T remove()
     {
+        static_assert(std::is_nothrow_copy_constructible<T>::value && std::is_nothrow_move_constructible<T>::value);
         pthread_mutex_lock(&m_mutex);
         while (m_queue.size() == 0) {
             pthread_cond_wait(&m_condv, &m_mutex);
@@ -92,6 +95,18 @@ public:
         pthread_cond_signal(&m_condv);
         pthread_mutex_unlock(&m_mutex);
         return item;
+    }
+
+    void remove(T& src)
+    {
+        pthread_mutex_lock(&m_mutex);
+        while (m_queue.size() == 0) {
+            pthread_cond_wait(&m_condv, &m_mutex);
+        }
+        src = m_queue.front();
+        m_queue.pop_front();
+        pthread_cond_signal(&m_condv);
+        pthread_mutex_unlock(&m_mutex);
     }
 
     /** Return the size of the queue.

--- a/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -410,7 +410,7 @@ void FrameProcessorPlugin::push(boost::shared_ptr<Frame> frame)
     // Loop over non-blocking callbacks, placing frame onto each queue
     std::map<std::string, boost::shared_ptr<IFrameCallback>>::iterator cbIter;
     for (cbIter = callbacks_.begin(); cbIter != callbacks_.end(); ++cbIter) {
-        cbIter->second->getWorkQueue()->add(frame);
+        cbIter->second->getWorkQueue().add(frame);
     }
 }
 
@@ -431,7 +431,7 @@ void FrameProcessorPlugin::push(const std::string& plugin_name, boost::shared_pt
         blocking_callbacks_[plugin_name]->callback(frame);
     }
     if (callbacks_.find(plugin_name) != callbacks_.end()) {
-        callbacks_[plugin_name]->getWorkQueue()->add(frame);
+        callbacks_[plugin_name]->getWorkQueue().add(frame);
     }
 }
 

--- a/cpp/frameProcessor/src/IFrameCallback.cpp
+++ b/cpp/frameProcessor/src/IFrameCallback.cpp
@@ -15,12 +15,9 @@ namespace FrameProcessor {
  * The constructor creates the new WorkQueue object.
  */
 IFrameCallback::IFrameCallback() :
-    thread_(0),
     run_(false),
     working_(false)
 {
-    // Create the work queue for message offload
-    queue_ = boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame>>>(new WorkQueue<boost::shared_ptr<Frame>>);
 }
 
 /**
@@ -34,7 +31,7 @@ IFrameCallback::~IFrameCallback()
  *
  * \return a pointer to the WorkQueue owned by this IFrameCallback class.
  */
-boost::shared_ptr<WorkQueue<boost::shared_ptr<Frame>>> IFrameCallback::getWorkQueue()
+WorkQueue<boost::shared_ptr<Frame>>& IFrameCallback::getWorkQueue()
 {
     return queue_;
 }
@@ -50,7 +47,8 @@ void IFrameCallback::start()
         // Set the run condition to true
         run_ = true;
         // Now start the worker thread to monitor the queue
-        thread_ = new boost::thread(&IFrameCallback::workerTask, this);
+        thread_ = boost::thread(&IFrameCallback::workerTask, this);
+        thread_.detach();
     }
 }
 
@@ -67,7 +65,7 @@ void IFrameCallback::stop()
         run_ = false;
         // Now notify the work queue we have finished by adding a null ptr
         boost::shared_ptr<Frame> nullMsg;
-        queue_->add(nullMsg);
+        queue_.add(nullMsg);
     }
 }
 
@@ -123,7 +121,7 @@ void IFrameCallback::workerTask()
 
     // Check the queue for messages
     while (run_) {
-        boost::shared_ptr<Frame> msg = queue_->remove();
+        boost::shared_ptr<Frame> msg = queue_.remove();
         if (msg) {
             // Once we have a message, call the callback
             this->callback(msg);

--- a/cpp/frameProcessor/src/IFrameCallback.cpp
+++ b/cpp/frameProcessor/src/IFrameCallback.cpp
@@ -25,8 +25,10 @@ IFrameCallback::IFrameCallback() :
  */
 IFrameCallback::~IFrameCallback()
 {
-    if (working_) stop();
-    if(thread_.joinable()) thread_.join();
+    if (working_)
+        stop();
+    if (thread_.joinable())
+        thread_.join();
 }
 
 /** Return the pointer to the WorkQueue.

--- a/cpp/frameProcessor/src/IFrameCallback.cpp
+++ b/cpp/frameProcessor/src/IFrameCallback.cpp
@@ -25,6 +25,8 @@ IFrameCallback::IFrameCallback() :
  */
 IFrameCallback::~IFrameCallback()
 {
+    if (working_) stop();
+    if(thread_.joinable()) thread_.join();
 }
 
 /** Return the pointer to the WorkQueue.
@@ -48,7 +50,6 @@ void IFrameCallback::start()
         run_ = true;
         // Now start the worker thread to monitor the queue
         thread_ = boost::thread(&IFrameCallback::workerTask, this);
-        thread_.detach();
     }
 }
 

--- a/cpp/frameProcessor/src/SharedMemoryController.cpp
+++ b/cpp/frameProcessor/src/SharedMemoryController.cpp
@@ -195,7 +195,7 @@ void SharedMemoryController::handleRxChannel()
                     // Loop over registered callbacks, placing the frame onto each queue
                     std::map<std::string, boost::shared_ptr<IFrameCallback>>::iterator cbIter;
                     for (cbIter = callbacks_.begin(); cbIter != callbacks_.end(); ++cbIter) {
-                        cbIter->second->getWorkQueue()->add(frame, true);
+                        cbIter->second->getWorkQueue().add(frame, true);
                     }
 
                 } else {
@@ -298,7 +298,7 @@ void SharedMemoryController::injectEOA()
     // Loop over registered callbacks, placing the frame onto each queue
     std::map<std::string, boost::shared_ptr<IFrameCallback>>::iterator cbIter;
     for (cbIter = callbacks_.begin(); cbIter != callbacks_.end(); ++cbIter) {
-        cbIter->second->getWorkQueue()->add(eoa, true);
+        cbIter->second->getWorkQueue().add(eoa, true);
     }
 }
 

--- a/cpp/frameProcessor/test/BloscPluginTest.cpp
+++ b/cpp/frameProcessor/test/BloscPluginTest.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(BloscPlugin_compress_decompress)
     setup_blosc_config(cfg_, reply);
     // Compress Test
     BOOST_REQUIRE_NO_THROW(blosc_plugin.process_frame(frame));
-    boost::shared_ptr<FrameProcessor::Frame> compressed_frame = blosc_plugin.getWorkQueue()->remove();
+    boost::shared_ptr<FrameProcessor::Frame> compressed_frame = blosc_plugin.getWorkQueue().remove();
     BOOST_CHECK(compressed_frame->get_image_size() < frame->get_image_size());
     BOOST_TEST_MESSAGE(
         "Compressed frame size = " << compressed_frame->get_image_size()
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(BloscPlugin_compress_decompress)
     BOOST_CHECK_NO_THROW(cfg_.set_param(FrameProcessor::BloscPlugin::CONFIG_BLOSC_MODE, std::string("decompress")));
     BOOST_REQUIRE_NO_THROW(blosc_plugin.configure(cfg_, reply));
     BOOST_REQUIRE_NO_THROW(blosc_plugin.process_frame(compressed_frame));
-    boost::shared_ptr<FrameProcessor::Frame> decompressed_frame = blosc_plugin.getWorkQueue()->remove();
+    boost::shared_ptr<FrameProcessor::Frame> decompressed_frame = blosc_plugin.getWorkQueue().remove();
     BOOST_CHECK(
         decompressed_frame->get_image_size() > compressed_frame->get_image_size()
         && decompressed_frame->get_image_size() == frame->get_image_size()
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(BloscPlugin_off)
     BOOST_CHECK_NO_THROW(cfg_.set_param(FrameProcessor::BloscPlugin::CONFIG_BLOSC_MODE, std::string("off")));
     BOOST_REQUIRE_NO_THROW(blosc_plugin.configure(cfg_, reply));
     BOOST_REQUIRE_NO_THROW(blosc_plugin.process_frame(frame));
-    boost::shared_ptr<FrameProcessor::Frame> same_frame = blosc_plugin.getWorkQueue()->remove();
+    boost::shared_ptr<FrameProcessor::Frame> same_frame = blosc_plugin.getWorkQueue().remove();
     BOOST_CHECK(
         same_frame->get_image_size() == frame->get_image_size() && frame->get_data_ptr() == same_frame->get_data_ptr()
     );

--- a/cpp/frameProcessor/test/CMakeLists.txt
+++ b/cpp/frameProcessor/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_unit_test(OffsetAdjustmentPlugin)
 add_unit_test(ParameterAdjustmentPlugin)
 add_unit_test(RawFileWriterPlugin)
 add_unit_test(SumPlugin)
+add_unit_test(WorkQueue)
 
 if (${BLOSC_FOUND})
   include_directories(${BLOSC_INCLUDE_DIR})

--- a/cpp/frameProcessor/test/WorkQueueTest.cpp
+++ b/cpp/frameProcessor/test/WorkQueueTest.cpp
@@ -1,0 +1,53 @@
+#define BOOST_TEST_MODULE "WorkQueueTests"
+#define BOOST_TEST_MAIN
+
+#include "WorkQueue.h"
+#include "Fixtures.h"
+#include "TestHelperFunctions.h"
+
+BOOST_GLOBAL_FIXTURE(GlobalConfig);
+
+// BOOST_FIXTURE_TEST_SUITE(WorkQueueUnitTest, WorkQueueTestFixture);
+
+BOOST_AUTO_TEST_CASE(WorkQueue_PushRemoveTest)
+{
+    FrameProcessor::WorkQueue<int> wq;
+    wq.add(5);
+    wq.add(4);
+    wq.add(3);
+    wq.add(2);
+    wq.add(1);
+    BOOST_CHECK(wq.remove() == 5);
+    BOOST_CHECK(wq.remove() == 4);
+    BOOST_CHECK(wq.remove() == 3);
+    BOOST_CHECK(wq.remove() == 2);
+    BOOST_CHECK(wq.remove() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(WorkQueue_FramesTest)
+{
+    constexpr size_t no_of_frames = 6;
+
+    FrameProcessor::WorkQueue<boost::shared_ptr<FrameProcessor::Frame>> wq;
+    static_assert(no_of_frames < wq.max_size());
+    unsigned int img[12] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+    std::vector<boost::shared_ptr<FrameProcessor::Frame>> frames;
+    frames.reserve(no_of_frames);
+    for (unsigned int i = 0; i < no_of_frames; ++i) {
+        img[0] = i;
+        boost::shared_ptr<FrameProcessor::DataBlockFrame> tmp_frame {
+            boost::make_shared<FrameProcessor::DataBlockFrame>(
+                FrameProcessor::FrameMetaData(
+                    i, "data", FrameProcessor::raw_32bit, "scan2", { 3, 4 }, FrameProcessor::no_compression
+                ),
+                static_cast<void*>(img), 24
+            )
+        };
+        frames.push_back(tmp_frame);
+        wq.add(frames.back());
+    }
+    BOOST_CHECK(wq.size() == no_of_frames);
+    for (int i = 0; i < no_of_frames; ++i) {
+        BOOST_CHECK(wq.remove()->get_meta_data().get_frame_number() == frames[i]->get_meta_data().get_frame_number());
+    }
+}


### PR DESCRIPTION
- Modify the worker queue class to use `boost::circular_queue` with a fixed size at allocation.
- Add an overload to the `WorkQueue::remove()` method that takes a reference of the stored type and assigns the `front()` value to it.
- Change the `IFrameCallback` class's `WorkQueue` object from a `shared_ptr` wrapper to a plain member function.
- Fix the `IFrameCallback` memory leak by changing the class's `boost::thread` member pointer from a pointer to a member object hosted in the class.

Fixes #493