### PR TITLE
#497: Set the frameProcessor reply msg_type to be ack.

### DIFF
--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -118,6 +118,7 @@ void FrameProcessorController::handleCtrlChannel()
     try {
         OdinData::IpcMessage ctrlMsg(ctrlMsgEncoded.c_str());
         OdinData::IpcMessage replyMsg; // Instantiate default IpmMessage
+        replyMsg.set_msg_type(OdinData::IpcMessage::MsgTypeAck);
         replyMsg.set_msg_val(ctrlMsg.get_msg_val());
         msg_id = ctrlMsg.get_msg_id();
         replyMsg.set_msg_id(msg_id);

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -118,7 +118,7 @@ void FrameProcessorController::handleCtrlChannel()
     try {
         OdinData::IpcMessage ctrlMsg(ctrlMsgEncoded.c_str());
         OdinData::IpcMessage replyMsg; // Instantiate default IpmMessage
-        replyMsg.set_msg_type(OdinData::IpcMessage::MsgTypeAck);
+        replyMsg.set_msg_type(OdinData::IpcMessage::MsgTypeAck); // GCOV_EXCL_LINE
         replyMsg.set_msg_val(ctrlMsg.get_msg_val());
         msg_id = ctrlMsg.get_msg_id();
         replyMsg.set_msg_id(msg_id);


### PR DESCRIPTION
Currently the msg_type is not set i.e. it defaults to "illegal". The #482 branch is probably the only thing that cares about this :-)