### PR TITLE
Add Metadata Hash of Parameter Structure to JSON Response from Odin-data

### DIFF
--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -477,7 +477,7 @@ private:
     // helper function to append
     static void get_keys_helper(const rapidjson::Value& value, const char delim, std::string& result)
     {
-        if (value.IsObject()) {
+        if (__builtin_expect(value.IsObject(), 1)) {
             for (const auto& member : value.GetObject()) {
                 // Store the found key
                 result.append(member.name.GetString()) += delim;

--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -272,10 +272,11 @@ public:
     }
 
     // returns all the key-strings of param_str as a single 'delim' delimited string
-    std::string get_keys(const std::string& param_str = "", const char delim = '/')
+    std::string get_keys(const std::string& param_str, const char delim = '/')
     {
         std::string keys_str;
-        keys_str.reserve(256);
+        constexpr size_t string_size = 256;
+        keys_str.reserve(string_size);
         if (this->doc_.FindMember(param_str.c_str()) == doc_.MemberEnd())
             return "";
         rapidjson::Value& params = this->doc_[param_str.c_str()];
@@ -474,7 +475,7 @@ private:
     //! Maps an internal message timestamp representation to an ISO8601 extended format string
     std::string valid_msg_timestamp(boost::posix_time::ptime msg_timestamp);
 
-    // helper function to append
+    // helper function to recursively append key-strings in 'value' to the 'result' variable
     static void get_keys_helper(const rapidjson::Value& value, const char delim, std::string& result)
     {
         if (__builtin_expect(value.IsObject(), 1)) {

--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -271,6 +271,18 @@ public:
         }
     }
 
+    // returns all the key-strings of param_str as a single 'delim' delimited string
+    std::string get_keys(const std::string& param_str = "", const char delim = '/')
+    {
+        std::string keys_str;
+        keys_str.reserve(256);
+        if (this->doc_.FindMember(param_str.c_str()) == doc_.MemberEnd())
+            return "";
+        rapidjson::Value& params = this->doc_[param_str.c_str()];
+        get_keys_helper(params, delim, keys_str);
+        return keys_str;
+    }
+
     //! Sets the nack message type with a reason parameter
     void set_nack(const std::string& reason);
 
@@ -461,6 +473,25 @@ private:
 
     //! Maps an internal message timestamp representation to an ISO8601 extended format string
     std::string valid_msg_timestamp(boost::posix_time::ptime msg_timestamp);
+
+    // helper function to append
+    static void get_keys_helper(const rapidjson::Value& value, const char delim, std::string& result)
+    {
+        if (value.IsObject()) {
+            for (const auto& member : value.GetObject()) {
+                // Store the found key
+                result.append(member.name.GetString()) += delim;
+
+                // Look deeper inside this key's value
+                get_keys_helper(member.value, delim, result);
+            }
+        } else if (value.IsArray()) {
+            // Arrays don't have keys, but their elements (like child objects) might
+            for (const auto& item : value.GetArray()) {
+                get_keys_helper(item, delim, result);
+            }
+        }
+    }
 
     //! Indicates if the message has a params block
     bool has_params(void) const;

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -183,10 +183,6 @@ private:
     std::string frReadyEndpoint_;
     /** End point for frameReceiver release channel */
     std::string frReleaseEndpoint_;
-    /** Time stamp for config metadata update of frame processors */
-    size_t last_hash_config_metadata_;
-    /** Time stamp for metadata update of frame processors */
-    size_t last_hash_status_metadata_;
 };
 
 } /* namespace FrameProcessor */

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -77,6 +77,9 @@ private:
     /** Configuration constant for executing setup of shared memory interface **/
     static const std::string CONFIG_FR_SETUP;
 
+    /** current metadata hash-value **/
+    static const std::string METADATA_HASH;
+
     /** Configuration constant for control socket endpoint **/
     static const std::string CONFIG_CTRL_ENDPOINT;
     /** Configuration constant for meta data endpoint **/
@@ -180,6 +183,10 @@ private:
     std::string frReadyEndpoint_;
     /** End point for frameReceiver release channel */
     std::string frReleaseEndpoint_;
+    /** Time stamp for config metadata update of frame processors */
+    size_t last_hash_config_metadata_;
+    /** Time stamp for metadata update of frame processors */
+    size_t last_hash_status_metadata_;
 };
 
 } /* namespace FrameProcessor */

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -297,10 +297,7 @@ void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply, bool m
     // returns all key strings in "params" as a '/' delimited string
     std::string param_keys = reply.get_keys("params", '/');
     size_t hash = std::hash<std::string> {}(param_keys);
-    if (this->last_hash_config_metadata_ != hash) {
-        this->last_hash_config_metadata_ = hash;
-    }
-    reply.set_param(FrameProcessorController::METADATA_HASH, last_hash_config_metadata_);
+    reply.set_param(FrameProcessorController::METADATA_HASH, hash);
 
     std::map<std::string, boost::shared_ptr<FrameProcessorPlugin>>::iterator iter;
     if (metadata) {
@@ -546,10 +543,7 @@ void FrameProcessorController::requestConfiguration(OdinData::IpcMessage& reply,
     // returns all key strings in "params" as a '/' delimited string
     std::string param_keys = reply.get_keys("params", '/');
     size_t hash = std::hash<std::string> {}(param_keys);
-    if (this->last_hash_status_metadata_ != hash) {
-        this->last_hash_status_metadata_ = hash;
-    }
-    reply.set_param(FrameProcessorController::METADATA_HASH, last_hash_status_metadata_);
+    reply.set_param(FrameProcessorController::METADATA_HASH, hash);
 
     if (metadata) {
         for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -43,6 +43,7 @@ const std::string FrameProcessorController::CONFIG_VALUE = "value";
 
 const std::string FrameProcessorController::COMMAND_KEY = "command";
 const std::string FrameProcessorController::SUPPORTED_KEY = "supported";
+const std::string FrameProcessorController::METADATA_HASH = "metadata_hash";
 
 const int FrameProcessorController::META_TX_HWM = 10000;
 
@@ -293,6 +294,14 @@ void FrameProcessorController::provideStatus(OdinData::IpcMessage& reply, bool m
         sharedMemController_->status(reply);
     }
 
+    // returns all key strings in "params" as a '/' delimited string
+    std::string param_keys = reply.get_keys("params", '/');
+    size_t hash = std::hash<std::string> {}(param_keys);
+    if (this->last_hash_config_metadata_ != hash) {
+        this->last_hash_config_metadata_ = hash;
+    }
+    reply.set_param(FrameProcessorController::METADATA_HASH, last_hash_config_metadata_);
+
     std::map<std::string, boost::shared_ptr<FrameProcessorPlugin>>::iterator iter;
     if (metadata) {
         for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
@@ -533,6 +542,14 @@ void FrameProcessorController::requestConfiguration(OdinData::IpcMessage& reply,
     for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
         iter->second->requestConfiguration(reply);
     }
+
+    // returns all key strings in "params" as a '/' delimited string
+    std::string param_keys = reply.get_keys("params", '/');
+    size_t hash = std::hash<std::string> {}(param_keys);
+    if (this->last_hash_status_metadata_ != hash) {
+        this->last_hash_status_metadata_ = hash;
+    }
+    reply.set_param(FrameProcessorController::METADATA_HASH, last_hash_status_metadata_);
 
     if (metadata) {
         for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {

--- a/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
@@ -384,4 +384,31 @@ BOOST_AUTO_TEST_CASE(TestIpcMessageCreationSpeed)
     );
 }
 
+BOOST_AUTO_TEST_CASE(IpcMessageGetKeys)
+{
+    const char* json_str = "{     \"msg_type\":\"cmd\","
+                           "      \"msg_val\":\"status\","
+                           "      \"timestamp\" : \"2026-05-09T12:10:01.123456\","
+                           "      \"status\" : true,"
+                           "      \"params\" : {"
+                           "          \"param1\" : \"values\","
+                           "          \"param2\" : 274,"
+                           "          \"info\": {"
+                           "               \"phoneNumber\": 2026,"
+                           "               \"state\": true,"
+                           "               \"name\":{"
+                           "                   \"first\": \"odin\","
+                           "                   \"last\": \"data\""
+                           "               },"
+                           "               \"dob\": 2011"
+                           "          }"
+                           "      }"
+                           "}";
+    OdinData::IpcMessage test_msg(json_str, true);
+    BOOST_CHECK(test_msg.is_valid() == true);
+    std::string keys_list = test_msg.get_keys("params");
+    std::cout << keys_list << '\n';
+    BOOST_CHECK(keys_list == "param1/param2/info/phoneNumber/state/name/first/last/dob/");
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
@@ -407,7 +407,6 @@ BOOST_AUTO_TEST_CASE(IpcMessageGetKeys)
     OdinData::IpcMessage test_msg(json_str, true);
     BOOST_CHECK(test_msg.is_valid() == true);
     std::string keys_list = test_msg.get_keys("params");
-    std::cout << keys_list << '\n';
     BOOST_CHECK(keys_list == "param1/param2/info/phoneNumber/state/name/first/last/dob/");
 }
 


### PR DESCRIPTION
- Implement an `IpcMessage::get_keys()` method to return a delimited string of all keys in the "params" node of the response. 
- Add last_hash_*_metadata_ for status and configuration requests. Implement logic to hash the parameter keys and update the last_hash_ value if changed.
- Add the last_hash_*_metadata_ value to the JSON response.

Fixes #513