### PR TITLE
Fix TCP Socket Potential CPU Lock

### DIFF
--- a/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
@@ -112,12 +112,24 @@ void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_, int recv_
     // the provided memory buffer
     void* frame_buffer = frame_decoder_->get_next_message_buffer();
     size_t message_size = frame_decoder_->get_next_message_size();
-    size_t bytes_received = 0;
+    ssize_t bytes_read = 0;
+    size_t total_bytes_read = 0;
 
-    while (bytes_received < message_size) {
-        int msg_len = read(recv_socket_, frame_buffer, message_size - bytes_received);
-        bytes_received += msg_len;
-        frame_buffer += msg_len;
+    unsigned char* fb_bytePtr = reinterpret_cast<unsigned char*>(frame_buffer
+    ); // reinterpret the void* address as an unsigned char pointer so we can do arithmetic
+    while (total_bytes_read < message_size
+           && ((bytes_read = read(recv_socket_, reinterpret_cast<void*>(fb_bytePtr), message_size - total_bytes_read))
+               > 0)) {
+        total_bytes_read += bytes_read;
+        fb_bytePtr += bytes_read;
     }
-    frame_decoder_->process_message(bytes_received);
+
+    if (bytes_read < 0) {
+        LOG_WITH_ERRNO(logger_, "read() Failed");
+        return;
+    } else if (total_bytes_read < message_size) {
+        LOG4CXX_ERROR(logger_, "read() returned 0 bytes (incomplete data)");
+        return;
+    }
+    frame_decoder_->process_message(total_bytes_read);
 }


### PR DESCRIPTION
Add a check for the return value of the network `read()` instruction in every `while`-loop iteration and break if less than 1.
Duplicate of #443

Fixes #433
Fixes #387