### PR TITLE
Add Plugin Names List to Configuration Request Responses.

### DIFF
--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -537,6 +537,7 @@ void FrameProcessorController::requestConfiguration(OdinData::IpcMessage& reply,
     // Loop over plugins and request current configuration from each
     std::map<std::string, boost::shared_ptr<FrameProcessorPlugin>>::iterator iter;
     for (iter = plugins_.begin(); iter != plugins_.end(); ++iter) {
+        reply.set_param("plugins/names[]", iter->first);
         iter->second->requestConfiguration(reply);
     }
 


### PR DESCRIPTION
Append the list of active plugin names to the configuration request. 
This will allow odin-control to isolate the information on plugin configuration and pass the metadata into it.

Fixes #521