### PR TITLE
Fix FrameReceiverController "Stop Reactor" Bug

### DIFF
--- a/cpp/frameReceiver/src/FrameReceiverController.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverController.cpp
@@ -909,8 +909,7 @@ void FrameReceiverController::handle_frame_release_channel(void)
                     logger_,
                     "Specified number of frames (" << config_.frame_count_ << ") received and released, terminating"
                 );
-                this->stop();
-                reactor_.stop();
+                this->stop(true);
             }
         } else if ((frame_release.get_msg_type() == IpcMessage::MsgTypeCmd)
                    && (frame_release.get_msg_val() == IpcMessage::MsgValCmdBufferConfigRequest)) {


### PR DESCRIPTION
- Delete duplicate `reactor_.stop() `command in `FrameReceiverController::handle_frame_release_channel()`.
- Switch the procedure selected for stopping `reactor_` in `FrameReceiverController` to utilise an `IpcReactorTimer`. 
Fixes #524