### PR TITLE
Add Pre-commit Hook to Reject Commits that Fail the Clang-format Check!

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,5 +50,5 @@
     ],
     // After the container is created, install the python project in editable form
     "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e './python[dev]'",
-    "postStartCommand": "./setup_git.sh"
+    "postStartCommand":  "/workspaces/odin-data/scripts/setup_git.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,5 +49,6 @@
         "source=/dev/shm,target=/dev/shm,type=bind"
     ],
     // After the container is created, install the python project in editable form
-    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e './python[dev]'"
+    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e './python[dev]'",
+    "postStartCommand": "./setup_git.sh"
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For them to be used you MUST run the following command (only needs to be run onc
 
 Either:
 
-    Build (or rebuild) the dev-container in VScode, and the hooks are a automatically setup.
+    Build (or rebuild) the dev-container in VScode, and the hooks are automatically setup.
 
 Or:
     Run
@@ -38,7 +38,7 @@ for this repository)
 
 Either:
 
-   Build (or rebuild) the dev-container in VScode, and the tools are a automatically setup.
+   Build (or rebuild) the dev-container in VScode, and the tools are automatically setup.
 
 Or:
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,36 @@ of two communicating applications; the FrameReceiver and FrameProcessor. It acts
 data capture and processing pipeline for detector data streams transferred over a
 network connection. The FrameReceiver constructs data frames in shared memory buffers
 and the FrameProcessor performs processing on the buffer and writes data to disk.
+
+Notes to Contributors:
+
+1. To allow sharing of git hooks they have been stored in the directory '.githooks'.
+For them to be used you MUST run the following command (only needs to be run once)
+
+Either:
+
+    Build (or rebuild) the dev-container in VScode, and the hooks are a automatically setup.
+
+Or:
+    Run
+    `git config core.hooksPath .githooks`
+    If not developing using the dev container.
+
+2. In order to allow formatting changes (and possibly other things) to be made to the codebase,
+without too much disruption to the efficacy of the git-blame the following procedure can
+be used.
+
+There is a file called .git-blame-ignore-revs in the root of the repository that can be
+updated to record each commit that should be ignored for git-blame purposes.
+
+To actually set this up so that it is used by git-blame you need to the run the following
+command (it only needs to be run once as the information is then stored in .git/config
+for this repository)
+
+Either:
+
+   Build (or rebuild) the dev-container in VScode, and the tools are a automatically setup.
+
+Or:
+
+   git config blame.ignoreRevsFile .git-blame-ignore-revs


### PR DESCRIPTION
Add 'postStartCommand' to copy the pre-commit script to ./git/hooks directory at container startup.

Fixes #533