### PR TITLE
Build on Rockylinux:9 to match RHEL 9 Kernel. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-# Shared setup stage ###########################################################
-FROM ubuntu:24.04 AS common
+FROM rockylinux:9  AS common
 
 ENV PATH=/odin/bin:/odin/scripts:/venv/bin:$PATH
 
 # Get fundamental packages
-RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y curl \
-    tar ca-certificates software-properties-common && \
-    apt-get -y clean all
+RUN dnf update -y && \
+    dnf install  -y \
+    tar ca-certificates  && \
+    dnf -y clean all
 
 # Get zellij
 RUN curl -L https://github.com/zellij-org/zellij/releases/download/v0.40.1/zellij-x86_64-unknown-linux-musl.tar.gz -o zellij.tar.gz && \
@@ -20,26 +19,30 @@ RUN mkdir -p ~/.config/zellij && \
 FROM common AS developer
 
 # System dependencies
-RUN add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get update -y && apt-get install -y --no-install-recommends \
+
+RUN dnf install -y epel-release && \
+    dnf config-manager --set-enabled crb
+RUN dnf group install -y "Development Tools"
+RUN dnf update -y && dnf install -y  \
     # General build
-    build-essential cmake git \
+    cmake git \
     # odin-data C++ dependencies
-    libblosc-dev libboost-all-dev libhdf5-dev liblog4cxx-dev libpcap-dev libczmq-dev \
+    blosc-devel boost-devel hdf5-devel log4cxx-devel libpcap-devel czmq-devel \
     # python
-    python3.11-dev python3.11-venv \
+    python3.11-devel python3.11-pip \
     # clang tools
-    clang-format-20 clang-tidy-20 \
+    clang20-tools-extra \
     # debugging
     gdb valgrind && \
     # tidy up
-    apt-get -y clean all
+    dnf -y clean all
+
 
 # Python dependencies
 RUN python3.11 -m ensurepip && \
     python3.11 -m venv /venv && \
-    python -m pip install --upgrade pip && \
-    python -m pip install git+https://github.com/odin-detector/odin-control
+    /venv/bin/python -m pip install --upgrade pip && \
+    /venv/bin/python -m pip install git+https://github.com/odin-detector/odin-control
 
 # Install hdf5filters from source
 RUN git clone https://github.com/DiamondLightSource/hdf5filters.git && cd hdf5filters && \
@@ -62,20 +65,21 @@ RUN mkdir -p build && cd build && \
     make install
 
 # Python
-RUN python -m pip install /odin/odin-data/python[meta_writer]
+RUN python3.11 -m pip install /odin/odin-data/python[meta_writer]
 
 # Runtime stage ################################################################
 FROM common AS runtime
 
 # Runtime system dependencies
-RUN add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get update -y && apt-get install -y --no-install-recommends \
+RUN dnf install -y epel-release && \
+    dnf config-manager --set-enabled crb
+RUN dnf update -y && dnf install -y \
     # C++ dependencies
-    libblosc-dev libboost-all-dev libhdf5-dev liblog4cxx-dev libpcap-dev libczmq-dev \
+    blosc-devel boost-devel hdf5-devel log4cxx-devel libpcap-devel czmq-devel \
     # Python dependencies
-    python3.11 && \
+    python3.11-devel && \
     # Tidy up
-    apt-get -y clean all
+    dnf -y clean all
 
 COPY --from=build /odin /odin
 COPY --from=build /venv /venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN dnf update -y && dnf install -y  \
     # General build
     cmake git \
     # cpp compiler
-    gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-binutils \
+    #gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-binutils \
     # odin-data C++ dependencies
     blosc-devel boost-devel hdf5-devel log4cxx-devel libpcap-devel czmq-devel \
     # python
@@ -40,10 +40,10 @@ RUN dnf update -y && dnf install -y  \
     dnf -y clean all
 
 #Source GCC15 to ensure it is the compiler
-ENV PATH="/opt/rh/gcc-toolset-15/root/usr/bin:${PATH}"
-ENV PCP_DIR="/opt/rh/gcc-toolset-15/root"
-ENV CC="/opt/rh/gcc-toolset-15/root/usr/bin/gcc"
-ENV CXX="/opt/rh/gcc-toolset-15/root/usr/bin/g++"
+#ENV PATH="/opt/rh/gcc-toolset-15/root/usr/bin:${PATH}"
+#ENV PCP_DIR="/opt/rh/gcc-toolset-15/root"
+#ENV CC="/opt/rh/gcc-toolset-15/root/usr/bin/gcc"
+#ENV CXX="/opt/rh/gcc-toolset-15/root/usr/bin/g++"
 
 
 # Python dependencies
@@ -69,7 +69,7 @@ COPY . .
 # C++
 RUN mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/odin \
-          -DCMAKE_BUILD_TYPE=RelWithDebInf \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_CXX_FLAGS="-O3 -fno-omit-frame-pointer" \
     ../cpp && \
     make -j8 VERBOSE=1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,8 @@ COPY . .
 # C++
 RUN mkdir -p build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/odin \
-    -DODIN_DATA_VERSION_MAJOR=1 \
-    -DODIN_DATA_VERSION_MINOR=13 \
-    -DODIN_DATA_VERSION_PATCH=0 \
+          -DCMAKE_BUILD_TYPE=RelWithDebInf \
+          -DCMAKE_CXX_FLAGS="-O3 -fno-omit-frame-pointer" \
     ../cpp && \
     make -j8 VERBOSE=1 && \
     make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN python3.11 -m ensurepip && \
 # Install hdf5filters from source
 RUN git clone https://github.com/DiamondLightSource/hdf5filters.git && cd hdf5filters && \
     mkdir -p cmake-build && cd cmake-build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/odin -DCMAKE_BUILD_TYPE=Release -DUSE_AVX2=ON .. && \
+    cmake -DCMAKE_INSTALL_PREFIX=/odin -DCMAKE_BUILD_TYPE=Release .. && \
     make install && \
     rm -rf hdf5filters
 
@@ -60,7 +60,11 @@ COPY . .
 
 # C++
 RUN mkdir -p build && cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/odin ../cpp && \
+    cmake -DCMAKE_INSTALL_PREFIX=/odin \
+    -DODIN_DATA_VERSION_MAJOR=1 \
+    -DODIN_DATA_VERSION_MINOR=13 \
+    -DODIN_DATA_VERSION_PATCH=0 \
+    ../cpp && \
     make -j8 VERBOSE=1 && \
     make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN dnf group install -y "Development Tools"
 RUN dnf update -y && dnf install -y  \
     # General build
     cmake git \
+    # cpp compiler
+    gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-binutils \
     # odin-data C++ dependencies
     blosc-devel boost-devel hdf5-devel log4cxx-devel libpcap-devel czmq-devel \
     # python
@@ -36,6 +38,12 @@ RUN dnf update -y && dnf install -y  \
     gdb valgrind && \
     # tidy up
     dnf -y clean all
+
+#Source GCC15 to ensure it is the compiler
+ENV PATH="/opt/rh/gcc-toolset-15/root/usr/bin:${PATH}"
+ENV PCP_DIR="/opt/rh/gcc-toolset-15/root"
+ENV CC="/opt/rh/gcc-toolset-15/root/usr/bin/gcc"
+ENV CXX="/opt/rh/gcc-toolset-15/root/usr/bin/g++"
 
 
 # Python dependencies

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
     {name = "Tim Nicholls", email = "tim.nicholls@stfc.ac.uk"},
 ]
 dependencies = [
-    "odin-control@git+https://github.com/odin-detector/odin-control@1cf475b60abf66666d31c7e74b9d19540c2ea6c3",
+    "odin-control@git+https://github.com/odin-detector/odin-control@1.6.2",
     "posix_ipc>=1.0.4",
     "pysnmp>=4.4.4",
     "numpy>=1.14.0",


### PR DESCRIPTION
This builds odin on `rockylinux:9` to match `RHEL 9` kernel. it also pins `odin-control` to `1.6.2`. It is likely we should be able to start compiling with gcc 15 once `hdf5filters` compilation bugs are fixed and upstreamed.

Reasoning: Low level performance analysis tools (such as `perf` or `eBPF`, which are kernel level tools used to inspect the performance of applications) are built against the kernel. Version mismatches lead either to degraded capabilities or to downright inability to run/collect metrics due to ABI differences. `rockylinux` is a FOSS linux distro with 100% RHEL binary compatibility.