### PR TITLE
Track Dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 // For format details, see https://containers.dev/implementors/json_reference/
 {
     "name": "odin-data devcontainer",
-    "image": "ghcr.io/odin-detector/odin-data-developer:latest",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "..",
+        "target": "developer"
+    },
     "remoteEnv": {
         // Allow X11 apps to run inside the container
         "DISPLAY": "${localEnv:DISPLAY}"


### PR DESCRIPTION
Modify the devcontainer.json to track and build its image using the Dockerfile.
Fixes #535