### PR TITLE
Mount Build Directory as Volume

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,0 @@
-{
-  "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {
-      "version": "2.5.9",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
-      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
-    }
-  }
-}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,6 +46,7 @@
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     "mounts": [
         // Mount /dev/shm for odin-data applications to use
+        "source=odin-data-build,target=/workspaces/odin-data/vscode_build,type=volume",
         "source=/dev/shm,target=/dev/shm,type=bind"
     ],
     // After the container is created, install the python project in editable form


### PR DESCRIPTION
This creates build dependency issues when building on macOS due to differences in `APFS` and the Linux File System. Mounting as a volume allows Docker to manage the mount, resolving the build issues. Tested on both a Linux workstation and on Mac
