### PR TITLE
Add Clang-tidy Script to Improve Code-base Memory Security and Structure

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Require CMake version >=3.22 (default in Ubuntu 22.04)
 cmake_minimum_required(VERSION 3.22)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Project name
 project(OdinData)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ add_compile_options(
   -Wall
   -Wextra
   -Wpedantic
+  $<$<CXX_COMPILER_ID:GNU>:-Wno-class-memaccess>
 )
 
 # Set output directories

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -7,6 +7,12 @@ project(OdinData)
 include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
 setup_coverage()
 
+add_compile_options(
+  -Wall
+  -Wextra
+  -Wpedantic
+)
+
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cpp/common/include/ClassLoader.h
+++ b/cpp/common/include/ClassLoader.h
@@ -43,7 +43,7 @@ template <typename BaseClass> class ClassLoader {
     /**
      * Shared pointer to the specified BaseClass
      */
-    typedef boost::shared_ptr<BaseClass> maker_t();
+    using maker_t = boost::shared_ptr<BaseClass>();
 
 public:
     /**
@@ -75,7 +75,7 @@ public:
 
             // This will open the shared library and in doing so register
             void* dlib = dlopen(path.c_str(), RTLD_NOW);
-            if (dlib == NULL) {
+            if (dlib == nullptr) {
                 // Throw a traceable exception with the dlerror as the reason
                 throw std::runtime_error(dlerror());
             } else {

--- a/cpp/common/include/DebugLevelLogger.h
+++ b/cpp/common/include/DebugLevelLogger.h
@@ -12,7 +12,7 @@
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 
-typedef unsigned int DebugLevel;
+using DebugLevel = unsigned int;
 
 extern DebugLevel debug_level;
 void set_debug_level(DebugLevel level);

--- a/cpp/common/include/DummyUDPDefinitions.h
+++ b/cpp/common/include/DummyUDPDefinitions.h
@@ -42,7 +42,7 @@ typedef struct {
     uint8_t packet_state[max_packets];
 } FrameHeader;
 
-inline const std::size_t max_frame_size(void)
+inline std::size_t max_frame_size(void)
 {
     std::size_t max_frame_size = sizeof(FrameHeader) + (max_packet_size * max_packets);
     return max_frame_size;

--- a/cpp/common/include/DummyUDPDefinitions.h
+++ b/cpp/common/include/DummyUDPDefinitions.h
@@ -27,12 +27,12 @@ static const uint32_t packet_number_mask = 0x3FFFFFFF;
 static const int32_t default_frame_number = -1;
 static const std::size_t default_packet_size = 8000;
 
-typedef struct {
+struct PacketHeader {
     uint32_t frame_number;
     uint32_t packet_number_flags;
-} PacketHeader;
+};
 
-typedef struct {
+struct FrameHeader {
     uint32_t frame_number;
     uint32_t frame_state;
     struct timespec frame_start_time;
@@ -40,7 +40,7 @@ typedef struct {
     uint32_t total_packets_received;
     std::size_t packet_size;
     uint8_t packet_state[max_packets];
-} FrameHeader;
+};
 
 inline std::size_t max_frame_size(void)
 {

--- a/cpp/common/include/IVersionedObject.h
+++ b/cpp/common/include/IVersionedObject.h
@@ -17,8 +17,8 @@ namespace OdinData {
  */
 class IVersionedObject {
 public:
-    IVersionedObject() { };
-    virtual ~IVersionedObject() { };
+    IVersionedObject() = default;
+    virtual ~IVersionedObject() = default;
     virtual int get_version_major() = 0;
     virtual int get_version_minor() = 0;
     virtual int get_version_patch() = 0;

--- a/cpp/common/include/IpcChannel.h
+++ b/cpp/common/include/IpcChannel.h
@@ -21,11 +21,11 @@ class IpcContext {
 public:
     static IpcContext& Instance(unsigned int io_threads = 1);
     zmq::context_t& get(void);
+    IpcContext(const IpcContext&) = delete;
+    IpcContext& operator=(const IpcContext&) = delete;
 
 private:
     IpcContext(unsigned int io_threads = 1);
-    IpcContext(const IpcContext&);
-    IpcContext& operator=(const IpcContext&);
 
     zmq::context_t zmq_context_;
 };

--- a/cpp/common/include/IpcChannel.h
+++ b/cpp/common/include/IpcChannel.h
@@ -49,8 +49,8 @@ public:
     void send(const char* message, int flags = 0, const std::string& identity_str = std::string());
     void send(size_t msg_size, void* message, int flags = 0, const std::string& identity_str = std::string());
 
-    const std::string recv(std::string* identity_str = 0);
-    std::size_t recv_raw(void* msg_buf, std::string* identity_str = 0);
+    std::string recv(std::string* identity_str = nullptr);
+    std::size_t recv_raw(void* msg_buf, std::string* identity_str = nullptr);
 
     void setsockopt(int option, const void* option_value, std::size_t option_len);
     void getsockopt(int option, void* option_value, std::size_t* option_len);

--- a/cpp/common/include/IpcChannel.h
+++ b/cpp/common/include/IpcChannel.h
@@ -50,7 +50,7 @@ public:
     void send(size_t msg_size, void* message, int flags = 0, const std::string& identity_str = std::string());
 
     const std::string recv(std::string* identity_str = 0);
-    const std::size_t recv_raw(void* msg_buf, std::string* identity_str = 0);
+    std::size_t recv_raw(void* msg_buf, std::string* identity_str = 0);
 
     void setsockopt(int option, const void* option_value, std::size_t option_len);
     void getsockopt(int option, void* option_value, std::size_t* option_len);

--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -25,21 +25,21 @@ namespace OdinData {
 class IpcMessageException : public std::exception {
 public:
     //! Create IpcMessageException with no message
-    IpcMessageException(void) throw() :
+    IpcMessageException(void) noexcept :
         what_("") { };
 
     //! Creates IpcMessageExcetpion with informational message
-    IpcMessageException(const std::string what) throw() :
+    IpcMessageException(const std::string what) noexcept :
         what_(what) { };
 
     //! Returns the content of the informational message
-    virtual const char* what(void) const throw()
+    const char* what(void) const noexcept override
     {
         return what_.c_str();
     };
 
     //! Destructor
-    ~IpcMessageException(void) throw() { };
+    ~IpcMessageException(void) noexcept override = default;
 
 private:
     // Member variables
@@ -100,13 +100,13 @@ public:
     };
 
     //! Internal bi-directional mapping of message type from string to enumerated MsgType
-    typedef boost::bimap<std::string, MsgType> MsgTypeMap;
+    using MsgTypeMap = boost::bimap<std::string, MsgType>;
     //! Internal bi-directional mapping of message type from string to enumerated MsgType
-    typedef MsgTypeMap::value_type MsgTypeMapEntry;
+    using MsgTypeMapEntry = MsgTypeMap::value_type;
     //! Internal bi-directional mapping of message value from string to enumerated MsgVal
-    typedef boost::bimap<std::string, MsgVal> MsgValMap;
+    using MsgValMap = boost::bimap<std::string, MsgVal>;
     //! Internal bi-directional mapping of message value from string to enumerated MsgVal
-    typedef MsgValMap::value_type MsgValMapEntry;
+    using MsgValMapEntry = MsgValMap::value_type;
 
     IpcMessage(MsgType msg_type = MsgTypeIllegal, MsgVal msg_val = MsgValIllegal, bool strict_validation = true);
 

--- a/cpp/common/include/IpcMessage.h
+++ b/cpp/common/include/IpcMessage.h
@@ -278,13 +278,13 @@ public:
     bool is_valid(void);
 
     //! Returns type attribute of message
-    const MsgType get_msg_type(void) const;
+    MsgType get_msg_type(void) const;
 
     //! Returns value attribute of message
-    const MsgVal get_msg_val(void) const;
+    MsgVal get_msg_val(void) const;
 
     //! Returns id attribute of message
-    const unsigned int get_msg_id(void) const;
+    unsigned int get_msg_id(void) const;
 
     //! Returns message timestamp as a string in ISO8601 extended format
     const std::string get_msg_timestamp(void) const;

--- a/cpp/common/include/IpcReactor.h
+++ b/cpp/common/include/IpcReactor.h
@@ -44,10 +44,10 @@ public:
 };
 
 //! Function signature for timer callback methods
-typedef boost::function<void()> TimerCallback;
+using TimerCallback = boost::function<void()>;
 
 //! Reactor millisecond time type
-typedef int64_t TimeMs;
+using TimeMs = int64_t;
 
 //! IpcReactorTimer - timer objects for use in the IpcReactor class
 class IpcReactorTimer {
@@ -86,18 +86,18 @@ private:
 };
 
 //! Function signature for reactor callback methods
-typedef boost::function<void()> ReactorCallback;
+using ReactorCallback = boost::function<void()>;
 
 //! Pointer to underlying ZMQ socket of a channel
-typedef zmq::socket_t* SocketPtr;
+using SocketPtr = zmq::socket_t*;
 
 //! Internal map to associate channel socket with a callback method
-typedef std::map<SocketPtr, ReactorCallback> ChannelMap;
+using ChannelMap = std::map<SocketPtr, ReactorCallback>;
 
-typedef std::map<int, ReactorCallback> SocketMap;
+using SocketMap = std::map<int, ReactorCallback>;
 
 //! Internal map to associate timer ID with a timer
-typedef std::map<int, boost::shared_ptr<IpcReactorTimer>> TimerMap;
+using TimerMap = std::map<int, boost::shared_ptr<IpcReactorTimer>>;
 
 class IpcReactor {
 public:

--- a/cpp/common/include/OdinDataException.h
+++ b/cpp/common/include/OdinDataException.h
@@ -16,21 +16,21 @@ namespace OdinData {
 class OdinDataException : public std::exception {
 public:
     //! Create OdinDataException with no message
-    OdinDataException(void) throw() :
+    OdinDataException(void) noexcept :
         what_("") { };
 
     //! Creates OdinDataException with informational message
-    OdinDataException(const std::string what) throw() :
+    OdinDataException(const std::string what) noexcept :
         what_(what) { };
 
     //! Returns the content of the informational message
-    virtual const char* what(void) const throw()
+    const char* what(void) const noexcept override
     {
         return what_.c_str();
     };
 
     //! Destructor
-    ~OdinDataException(void) throw() { };
+    ~OdinDataException(void) noexcept override = default;
 
 private:
     // Member variables

--- a/cpp/common/include/ParamContainer.h
+++ b/cpp/common/include/ParamContainer.h
@@ -24,21 +24,21 @@ namespace OdinData {
 class ParamContainerException : public std::exception {
 public:
     //! Create ParamContainerException with no message
-    ParamContainerException(void) throw() :
+    ParamContainerException(void) noexcept :
         what_("") { };
 
     //! Create ParamContainerException with informational message
-    ParamContainerException(const std::string what) throw() :
+    ParamContainerException(const std::string what) noexcept :
         what_(what) { };
 
     //! Return the content of the informational message
-    virtual const char* what(void) const throw()
+    const char* what(void) const noexcept override
     {
         return what_.c_str();
     };
 
     //! Destructor
-    ~ParamContainerException(void) throw() { };
+    ~ParamContainerException(void) noexcept override = default;
 
 private:
     // Member variables
@@ -66,21 +66,21 @@ namespace OdinData {
 class ParamContainer {
 
     //! Parameter setter function type definition
-    typedef boost::function<void(rapidjson::Value&)> SetterFunc;
+    using SetterFunc = boost::function<void(rapidjson::Value&)>;
     //! Parameter setter function map type definition
-    typedef std::map<std::string, SetterFunc> SetterFuncMap;
+    using SetterFuncMap = std::map<std::string, SetterFunc>;
     //! Parameter getter function type definition
-    typedef boost::function<void(rapidjson::Value&)> GetterFunc;
+    using GetterFunc = boost::function<void(rapidjson::Value&)>;
     //! Parameter getter function map type definition
-    typedef std::map<std::string, GetterFunc> GetterFuncMap;
+    using GetterFuncMap = std::map<std::string, GetterFunc>;
 
 public:
     //! Use the RapidJSON Document and Value types throughout
-    typedef rapidjson::Document Document;
-    typedef rapidjson::Value Value;
+    using Document = rapidjson::Document;
+    using Value = rapidjson::Value;
 
     //! Default constructor
-    ParamContainer() { };
+    ParamContainer() = default;
 
     //! Copy constructor
     ParamContainer(const ParamContainer& container);

--- a/cpp/common/include/ParamContainer.h
+++ b/cpp/common/include/ParamContainer.h
@@ -169,7 +169,7 @@ protected:
     //! \param param - reference to the parameter to retrieve
     //! \param value_obj - reference to a RapidJSON value object to be set with the value
 
-    template <typename T> const void param_get(T& param, rapidjson::Value& value_obj)
+    template <typename T> void param_get(T& param, rapidjson::Value& value_obj)
     {
         get_value<T>(param, value_obj);
     }

--- a/cpp/common/include/SegFaultHandler.h
+++ b/cpp/common/include/SegFaultHandler.h
@@ -31,11 +31,13 @@ void print_stack_trace(FILE* out = stderr, unsigned int max_frames = 63)
     // Print a header
     fprintf(out, "stack trace:\n");
 
-    // Declare storage array for stack trace address data
-    void* addrlist[max_frames + 1];
+    // Keep this storage fixed-size: the handler must not allocate memory.
+    constexpr unsigned int max_supported_frames = 63;
+    const unsigned int frame_limit = max_frames < max_supported_frames ? max_frames : max_supported_frames;
+    void* addrlist[max_supported_frames + 1];
 
     // Retrieve current stack addresses
-    uint32_t addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+    uint32_t addrlen = backtrace(addrlist, frame_limit + 1);
 
     if (addrlen == 0) {
         fprintf(out, "  \n");
@@ -59,7 +61,7 @@ void print_stack_trace(FILE* out = stderr, unsigned int max_frames = 63)
  * @param si struct with signal information
  * @param unused
  */
-void abort_handler(int signum, siginfo_t* si, void* unused)
+void abort_handler(int signum, siginfo_t*, void*)
 {
     // Associate each signal with a signal name string.
     const char* name = NULL;

--- a/cpp/common/include/SegFaultHandler.h
+++ b/cpp/common/include/SegFaultHandler.h
@@ -64,7 +64,7 @@ void print_stack_trace(FILE* out = stderr, unsigned int max_frames = 63)
 void abort_handler(int signum, siginfo_t*, void*)
 {
     // Associate each signal with a signal name string.
-    const char* name = NULL;
+    const char* name = nullptr;
     switch (signum) {
     case SIGABRT:
         name = "SIGABRT";
@@ -124,12 +124,12 @@ void init_seg_fault_handler()
     sa.sa_sigaction = abort_handler;
     sigemptyset(&sa.sa_mask);
 
-    sigaction(SIGABRT, &sa, NULL);
-    sigaction(SIGSEGV, &sa, NULL);
-    sigaction(SIGBUS, &sa, NULL);
-    sigaction(SIGILL, &sa, NULL);
-    sigaction(SIGFPE, &sa, NULL);
-    sigaction(SIGPIPE, &sa, NULL);
+    sigaction(SIGABRT, &sa, nullptr);
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGBUS, &sa, nullptr);
+    sigaction(SIGILL, &sa, nullptr);
+    sigaction(SIGFPE, &sa, nullptr);
+    sigaction(SIGPIPE, &sa, nullptr);
 }
 }
 

--- a/cpp/common/include/SharedBufferManager.h
+++ b/cpp/common/include/SharedBufferManager.h
@@ -46,9 +46,9 @@ public:
 
     ~SharedBufferManager();
 
-    const size_t get_manager_id(void) const;
-    const size_t get_num_buffers(void) const;
-    const size_t get_buffer_size(void) const;
+    size_t get_manager_id(void) const;
+    size_t get_num_buffers(void) const;
+    size_t get_buffer_size(void) const;
 
     void* get_buffer_address(const unsigned int buffer) const;
 

--- a/cpp/common/include/SharedBufferManager.h
+++ b/cpp/common/include/SharedBufferManager.h
@@ -30,11 +30,11 @@ public:
 
 class SharedBufferManager {
 public:
-    typedef struct {
+    struct Header {
         size_t manager_id;
         size_t num_buffers;
         size_t buffer_size;
-    } Header;
+    };
 
     SharedBufferManager(
         const std::string& shared_mem_name,
@@ -63,7 +63,7 @@ private:
     static size_t last_manager_id;
 };
 
-typedef boost::shared_ptr<SharedBufferManager> SharedBufferManagerPtr;
+using SharedBufferManagerPtr = boost::shared_ptr<SharedBufferManager>;
 
 } // namespace OdinData
 #endif /* SHAREDBUFFERMANAGER_H_ */

--- a/cpp/common/include/stringparse.h
+++ b/cpp/common/include/stringparse.h
@@ -26,7 +26,7 @@ static int extract_line_no(const std::string& input, const int position)
 
     size_t pos = input.find(line_char);
 
-    while (pos < position) {
+    while (pos < static_cast<size_t>(position)) {
         line_no++;
         pos = input.find(line_char, pos + line_char.size());
     }

--- a/cpp/common/src/IpcChannel.cpp
+++ b/cpp/common/src/IpcChannel.cpp
@@ -355,7 +355,7 @@ const std::string IpcChannel::recv(std::string* identity_str)
 //! \param[out] identity_str - pointer to string to receive identity on ROUTER sockets
 //! \return size of the received message
 //!
-const std::size_t IpcChannel::recv_raw(void* msg_buf, std::string* identity_str)
+std::size_t IpcChannel::recv_raw(void* msg_buf, std::string* identity_str)
 {
 
     // For ROUTER channels, receive the required identity message part first and copy

--- a/cpp/common/src/IpcChannel.cpp
+++ b/cpp/common/src/IpcChannel.cpp
@@ -330,7 +330,7 @@ const std::string IpcChannel::recv(std::string* identity_str)
     if (socket_type_ == ZMQ_ROUTER) {
         zmq::message_t identity_msg;
         socket_.recv(&identity_msg);
-        if (identity_str != NULL) {
+        if (identity_str != nullptr) {
             *identity_str = std::string(static_cast<char*>(identity_msg.data()), identity_msg.size());
         }
     }
@@ -363,7 +363,7 @@ std::size_t IpcChannel::recv_raw(void* msg_buf, std::string* identity_str)
     if (socket_type_ == ZMQ_ROUTER) {
         zmq::message_t identity_msg;
         socket_.recv(&identity_msg);
-        if (identity_str != NULL) {
+        if (identity_str != nullptr) {
             *identity_str = std::string(static_cast<char*>(identity_msg.data()), identity_msg.size());
         }
     }

--- a/cpp/common/src/IpcChannel.cpp
+++ b/cpp/common/src/IpcChannel.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "IpcChannel.h"
-#include <stdio.h>
+#include <cstdio>
 
 #define within(num) (int)((float)(num) * random() / (RAND_MAX + 1.0))
 
@@ -91,9 +91,7 @@ IpcChannel::IpcChannel(int type, const std::string identity) :
 
 //! IpcChannel destructor
 //!
-IpcChannel::~IpcChannel()
-{
-}
+IpcChannel::~IpcChannel() = default;
 
 //! Bind the IpcChannel to an endpoint
 //!

--- a/cpp/common/src/IpcChannel.cpp
+++ b/cpp/common/src/IpcChannel.cpp
@@ -321,7 +321,7 @@ void IpcChannel::router_send_identity(const std::string& identity_str)
 //! \param[out] identity_str - pointer to string to receive identity on ROUTER sockets
 //! \return string containing the message
 //!
-const std::string IpcChannel::recv(std::string* identity_str)
+std::string IpcChannel::recv(std::string* identity_str)
 {
     // For ROUTER channels, receive the required identity message part first and copy
     // into the specified string location if not NULL.

--- a/cpp/common/src/IpcMessage.cpp
+++ b/cpp/common/src/IpcMessage.cpp
@@ -134,8 +134,8 @@ IpcMessage::IpcMessage(const rapidjson::Value& value, MsgType msg_type, MsgVal m
 void IpcMessage::update(const IpcMessage& other)
 {
     std::vector<std::string> params = other.get_param_names();
-    for (std::vector<std::string>::const_iterator itr = params.begin(); itr != params.end(); ++itr) {
-        this->set_param<const rapidjson::Value&>(*itr, other.get_param<const rapidjson::Value&>(*itr));
+    for (const auto& param : params) {
+        this->set_param<const rapidjson::Value&>(param, other.get_param<const rapidjson::Value&>(param));
     }
 }
 

--- a/cpp/common/src/IpcMessage.cpp
+++ b/cpp/common/src/IpcMessage.cpp
@@ -24,8 +24,8 @@ IpcMessage::IpcMessage(MsgType msg_type, MsgVal msg_val, bool strict_validation)
     strict_validation_(strict_validation),
     msg_type_(msg_type),
     msg_val_(msg_val),
-    msg_id_(0),
-    msg_timestamp_(boost::posix_time::microsec_clock::local_time())
+    msg_timestamp_(boost::posix_time::microsec_clock::local_time()),
+    msg_id_(0)
 {
     // Intialise empty JSON document
     doc_.SetObject();
@@ -113,8 +113,8 @@ IpcMessage::IpcMessage(const rapidjson::Value& value, MsgType msg_type, MsgVal m
     strict_validation_(strict_validation),
     msg_type_(msg_type),
     msg_val_(msg_val),
-    msg_id_(0),
-    msg_timestamp_(boost::posix_time::microsec_clock::local_time())
+    msg_timestamp_(boost::posix_time::microsec_clock::local_time()),
+    msg_id_(0)
 {
     // Intialise empty JSON document
     doc_.SetObject();

--- a/cpp/common/src/IpcMessage.cpp
+++ b/cpp/common/src/IpcMessage.cpp
@@ -252,7 +252,7 @@ bool IpcMessage::is_valid(void)
 //!
 //! \return MsgType enumerated message type attribute
 
-const IpcMessage::MsgType IpcMessage::get_msg_type(void) const
+IpcMessage::MsgType IpcMessage::get_msg_type(void) const
 {
     return msg_type_;
 }
@@ -263,7 +263,7 @@ const IpcMessage::MsgType IpcMessage::get_msg_type(void) const
 //!
 //! \return MsgVal enumerated message value attribute
 
-const IpcMessage::MsgVal IpcMessage::get_msg_val(void) const
+IpcMessage::MsgVal IpcMessage::get_msg_val(void) const
 {
     return msg_val_;
 }
@@ -296,7 +296,7 @@ const struct tm IpcMessage::get_msg_datetime(void) const
 //! This method returns the "id" attribute of the message.
 //!
 //! \return unsigned int message id
-const unsigned int IpcMessage::get_msg_id(void) const
+unsigned int IpcMessage::get_msg_id(void) const
 {
     return msg_id_;
 }
@@ -650,7 +650,7 @@ boost::posix_time::ptime IpcMessage::valid_msg_timestamp(std::string msg_timesta
 std::string IpcMessage::valid_msg_timestamp(boost::posix_time::ptime msg_timestamp)
 {
     // Return message timestamp as string in ISO8601 extended format
-    return boost::posix_time::to_iso_extended_string(msg_timestamp_);
+    return boost::posix_time::to_iso_extended_string(msg_timestamp);
 }
 
 //! Indicates if the message has a params block.

--- a/cpp/common/src/IpcReactor.cpp
+++ b/cpp/common/src/IpcReactor.cpp
@@ -32,9 +32,7 @@ IpcReactorTimer::IpcReactorTimer(size_t delay_ms, size_t times, TimerCallback ca
 }
 
 //! Destructor - destroys an IpcReactorTimer object
-IpcReactorTimer::~IpcReactorTimer()
-{
-}
+IpcReactorTimer::~IpcReactorTimer() = default;
 
 //! Returns the unique ID of the timer instance
 //!
@@ -392,9 +390,9 @@ long IpcReactor::calculate_timeout(void)
     // Calculate shortest timeout up to one hour (!!), looping through
     // current timers to see which fires first
     TimeMs tickless = IpcReactorTimer::clock_mono_ms() + (1000 * 3600);
-    for (TimerMap::iterator it = timers_.begin(); it != timers_.end(); ++it) {
-        if (tickless > (it->second)->when()) {
-            tickless = (it->second)->when();
+    for (auto& timer : timers_) {
+        if (tickless > (timer.second)->when()) {
+            tickless = (timer.second)->when();
         }
     }
 

--- a/cpp/common/src/IpcReactor.cpp
+++ b/cpp/common/src/IpcReactor.cpp
@@ -130,8 +130,8 @@ int IpcReactorTimer::last_timer_id_ = 0;
 
 IpcReactor::IpcReactor() :
     terminate_reactor_(false),
-    pollitems_(0),
-    callbacks_(0),
+    pollitems_(nullptr),
+    callbacks_(nullptr),
     pollsize_(0),
     needs_rebuild_(true)
 {
@@ -338,13 +338,13 @@ void IpcReactor::rebuild_pollitems(void)
     // If the existing pollitems array is valid, delete it
     if (pollitems_) {
         delete[] pollitems_;
-        pollitems_ = 0;
+        pollitems_ = nullptr;
     }
 
     // If the existing callback array is valid, delete it
     if (callbacks_) {
         delete[] callbacks_;
-        callbacks_ = 0;
+        callbacks_ = nullptr;
     }
 
     // Set the number of items to poll to the number of channels registered
@@ -369,7 +369,7 @@ void IpcReactor::rebuild_pollitems(void)
         }
 
         for (SocketMap::iterator it = sockets_.begin(); it != sockets_.end(); ++item, ++it) {
-            zmq::pollitem_t pollitem = { 0, it->first, ZMQ_POLLIN, 0 };
+            zmq::pollitem_t pollitem = { nullptr, it->first, ZMQ_POLLIN, 0 };
             pollitems_[item] = pollitem;
             callbacks_[item] = it->second;
         }

--- a/cpp/common/src/ParamContainer.cpp
+++ b/cpp/common/src/ParamContainer.cpp
@@ -76,10 +76,10 @@ void ParamContainer::encode(ParamContainer::Document& doc_obj, std::string prefi
     // Iterate through all the bound parameters in the getter map, retreiving their current
     // values and setting in the JSON document. The first element of each map entry returned
     // by the iterator is the path of the parameter and the second is the bound getter method.
-    for (GetterFuncMap::const_iterator it = getter_map_.begin(); it != getter_map_.end(); ++it) {
+    for (const auto& it : getter_map_) {
         rapidjson::Value value_obj;
-        (*it).second(value_obj);
-        std::string path = pointer_prefix + (*it).first;
+        it.second(value_obj);
+        std::string path = pointer_prefix + it.first;
         rapidjson::Pointer(path.c_str()).Set(doc_obj, value_obj);
     }
 }
@@ -169,11 +169,11 @@ void ParamContainer::update(ParamContainer::Document& doc_obj)
     // Iterate through all bound parameters in the setter function map. The first element of each
     // map entry returned by the iterator is the path of the parameter and the second is the bound
     // getter method.
-    for (SetterFuncMap::iterator it = setter_map_.begin(); it != setter_map_.end(); ++it) {
+    for (auto& it : setter_map_) {
         // If the path of the bound parameter is found in the JSON document, call the setter
         // function to update the value of the parameter
-        if (rapidjson::Value* value_ptr = rapidjson::Pointer(pointer_path((*it).first).c_str()).Get(doc_obj)) {
-            (*it).second(*value_ptr);
+        if (rapidjson::Value* value_ptr = rapidjson::Pointer(pointer_path(it.first).c_str()).Get(doc_obj)) {
+            it.second(*value_ptr);
         }
     }
 }

--- a/cpp/common/src/SharedBufferManager.cpp
+++ b/cpp/common/src/SharedBufferManager.cpp
@@ -23,7 +23,7 @@ try :
     shared_mem_size_(shared_mem_size),
     remove_when_deleted_(remove_when_deleted),
     shared_mem_(open_or_create, shared_mem_name_.c_str(), read_write),
-    manager_hdr_(0) {
+    manager_hdr_(nullptr) {
 
     // Check that the buffer size specified is non-zero
     if (buffer_size == 0) {

--- a/cpp/common/src/SharedBufferManager.cpp
+++ b/cpp/common/src/SharedBufferManager.cpp
@@ -84,16 +84,16 @@ SharedBufferManager::~SharedBufferManager()
     }
 }
 
-const size_t SharedBufferManager::get_manager_id(void) const
+size_t SharedBufferManager::get_manager_id(void) const
 {
     return manager_hdr_->manager_id;
 }
-const size_t SharedBufferManager::get_num_buffers(void) const
+size_t SharedBufferManager::get_num_buffers(void) const
 {
     return manager_hdr_->num_buffers;
 }
 
-const size_t SharedBufferManager::get_buffer_size(void) const
+size_t SharedBufferManager::get_buffer_size(void) const
 {
     return manager_hdr_->buffer_size;
 }

--- a/cpp/common/src/logging.cpp
+++ b/cpp/common/src/logging.cpp
@@ -1,8 +1,8 @@
 #ifndef ODINDATA_LOGGING_H
 #define ODINDATA_LOGGING_H
 
+#include <cstring>
 #include <pwd.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <log4cxx/basicconfigurator.h>

--- a/cpp/common/src/logging.cpp
+++ b/cpp/common/src/logging.cpp
@@ -46,7 +46,7 @@ void configure_logging_mdc(const char* app_path)
     MDC::put("pid", ss.str());
 
     const char* app_name = strrchr(app_path, static_cast<int>('/'));
-    if (app_name != NULL) {
+    if (app_name != nullptr) {
         MDC::put("app", app_name + 1);
     } else {
         MDC::put("app", app_path);

--- a/cpp/frameProcessor/include/BloscPlugin.h
+++ b/cpp/frameProcessor/include/BloscPlugin.h
@@ -16,14 +16,14 @@ using namespace log4cxx;
 
 namespace FrameProcessor {
 
-typedef struct {
+struct BloscCompressionSettings {
     int compression_level;
     std::string shuffle;
     size_t type_size;
     size_t uncompressed_size;
     unsigned int threads;
     std::string blosc_compressor;
-} BloscCompressionSettings;
+};
 void create_cd_values(const BloscCompressionSettings& settings, std::vector<unsigned int> cd_values);
 
 /**
@@ -37,7 +37,7 @@ class BloscPlugin : public FrameProcessorPlugin {
 
 public:
     BloscPlugin();
-    virtual ~BloscPlugin();
+    ~BloscPlugin() override;
 
     /** Configuration constants */
     static const std::string CONFIG_BLOSC_COMPRESSOR;
@@ -55,14 +55,14 @@ public:
     constexpr static char BLOSC_OFF_MODE_STR[] = "off";
 
     // Baseclass API to implement:
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    void requestConfiguration(OdinData::IpcMessage& reply);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
 private:
     // Methods unique to this class
@@ -75,12 +75,12 @@ private:
         DECOMPRESS,
         OFF
     };
-    typedef struct {
+    struct BloscDecompressionSettings {
         size_t type_size;
         size_t uncompressed_size;
         unsigned int threads;
         unsigned int blosc_compressor;
-    } BloscDecompressionSettings;
+    };
     // private data
     /** Pointer to logger */
     LoggerPtr logger_;

--- a/cpp/frameProcessor/include/CallDuration.h
+++ b/cpp/frameProcessor/include/CallDuration.h
@@ -18,7 +18,7 @@ namespace FrameProcessor {
 class CallDuration {
 public:
     CallDuration();
-    ~CallDuration() { };
+    ~CallDuration() = default;
 
     void update(unsigned int duration);
     void reset();

--- a/cpp/frameProcessor/include/DataBlockFrame.h
+++ b/cpp/frameProcessor/include/DataBlockFrame.h
@@ -32,7 +32,7 @@ public:
     ~DataBlockFrame();
 
     /** Return a void pointer to the raw data */
-    virtual void* get_data_ptr() const;
+    void* get_data_ptr() const override;
 
 private:
     /** Pointer to raw data block */

--- a/cpp/frameProcessor/include/DummyUDPProcessPlugin.h
+++ b/cpp/frameProcessor/include/DummyUDPProcessPlugin.h
@@ -31,19 +31,19 @@ namespace FrameProcessor {
 class DummyUDPProcessPlugin : public FrameProcessorPlugin {
 public:
     DummyUDPProcessPlugin();
-    virtual ~DummyUDPProcessPlugin();
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    ~DummyUDPProcessPlugin() override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    void requestConfiguration(OdinData::IpcMessage& reply);
-    void execute(const std::string& command, OdinData::IpcMessage& reply);
-    std::vector<std::string> requestCommands();
-    void status(OdinData::IpcMessage& status);
-    bool reset_statistics(void);
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
+    void execute(const std::string& command, OdinData::IpcMessage& reply) override;
+    std::vector<std::string> requestCommands() override;
+    void status(OdinData::IpcMessage& status) override;
+    bool reset_statistics(void) override;
 
 private:
     /** Configuration constant for image width **/
@@ -56,7 +56,7 @@ private:
     /** Command execution constant for print command **/
     static const std::string EXECUTE_PRINT;
 
-    void process_frame(boost::shared_ptr<Frame> frame);
+    void process_frame(boost::shared_ptr<Frame> frame) override;
     void process_lost_packets(boost::shared_ptr<Frame>& frame);
 
     /** Pointer to logger */

--- a/cpp/frameProcessor/include/EndOfAcquisitionFrame.h
+++ b/cpp/frameProcessor/include/EndOfAcquisitionFrame.h
@@ -24,7 +24,7 @@ public:
     virtual void* get_data_ptr() const;
 
     /** Return confirmation that this is an "end of acquisition" frame*/
-    virtual bool get_end_of_acquisition() const;
+    bool get_end_of_acquisition() const override;
 };
 
 }

--- a/cpp/frameProcessor/include/EndOfAcquisitionFrame.h
+++ b/cpp/frameProcessor/include/EndOfAcquisitionFrame.h
@@ -21,7 +21,7 @@ public:
     ~EndOfAcquisitionFrame();
 
     /** Return a null pointer (no raw data) */
-    virtual void* get_data_ptr() const;
+    void* get_data_ptr() const override;
 
     /** Return confirmation that this is an "end of acquisition" frame*/
     bool get_end_of_acquisition() const override;

--- a/cpp/frameProcessor/include/FileWriterPlugin.h
+++ b/cpp/frameProcessor/include/FileWriterPlugin.h
@@ -36,31 +36,32 @@ class Frame;
 class FileWriterPlugin : public FrameProcessorPlugin {
 public:
     explicit FileWriterPlugin();
-    virtual ~FileWriterPlugin();
+    ~FileWriterPlugin() override;
+    FileWriterPlugin(const FileWriterPlugin& src) = delete;
 
     void start_writing();
     void stop_writing();
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    void requestConfiguration(OdinData::IpcMessage& reply);
-    virtual void execute(const std::string& command, OdinData::IpcMessage& reply);
-    virtual std::vector<std::string> requestCommands();
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
+    void execute(const std::string& command, OdinData::IpcMessage& reply) override;
+    std::vector<std::string> requestCommands() override;
     void configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void configure_file(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void configure_dataset(const std::string& dataset_name, OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void create_new_dataset(const std::string& dset_name);
     void delete_datasets();
-    void status(OdinData::IpcMessage& status);
+    void status(OdinData::IpcMessage& status) override;
     void add_file_writing_stats(OdinData::IpcMessage& status);
-    bool reset_statistics();
+    bool reset_statistics() override;
     void stop_acquisition();
     void start_close_file_timeout();
     void run_close_file_timeout();
     size_t calc_num_frames(size_t total_frames);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
     /** Configuration constant for status related items */
     static constexpr char STATUS_WRITING[8] = "writing";
@@ -163,15 +164,8 @@ public:
     static const std::string STOP_WRITING;
 
 private:
-    /**
-     * Prevent a copy of the FileWriterPlugin plugin.
-     *
-     * \param[in] src
-     */
-    FileWriterPlugin(const FileWriterPlugin& src); // prevent copying one of these
-
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void process_end_of_acquisition();
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void process_end_of_acquisition() override;
     bool frame_in_acquisition(boost::shared_ptr<Frame> frame);
 
     /** Pointer to logger */

--- a/cpp/frameProcessor/include/FrameMetaData.h
+++ b/cpp/frameProcessor/include/FrameMetaData.h
@@ -11,8 +11,8 @@
 
 #include "FrameProcessorDefinitions.h"
 
-typedef unsigned long long dimsize_t;
-typedef std::vector<dimsize_t> dimensions_t;
+using dimsize_t = unsigned long long;
+using dimensions_t = std::vector<dimsize_t>;
 
 namespace FrameProcessor {
 

--- a/cpp/frameProcessor/include/FrameMetaData.h
+++ b/cpp/frameProcessor/include/FrameMetaData.h
@@ -30,7 +30,8 @@ public:
 
     FrameMetaData();
 
-    FrameMetaData(const FrameMetaData& frame);
+    FrameMetaData(const FrameMetaData& frame) = default;
+    FrameMetaData& operator=(const FrameMetaData&) = default;
 
     /** Return frame parameters */
     const std::map<std::string, boost::any>& get_parameters() const;

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -144,10 +144,6 @@ private:
     std::map<std::string, std::string> stored_configs_;
     /** Condition for exiting this file writing process */
     boost::condition_variable exitCondition_;
-    /** Frames to write before shutting down - 0 to disable shutdown */
-    unsigned int shutdownFrameCount_;
-    /** Total frames processed */
-    unsigned int totalFrames_;
     /** Master frame specifier - Frame to include in count of total frames processed */
     std::string masterFrame_;
     /** Mutex used for locking the exitCondition */
@@ -162,6 +158,8 @@ private:
     bool pluginShutdownSent_;
     /** Have we successfully shutdown */
     bool shutdown_;
+    /** ZMQ context for IPC channels */
+    OdinData::IpcContext& ipc_context_;
     /** Main thread used for control message handling */
     boost::thread ctrlThread_;
     /** Store for any messages occurring during thread initialisation */
@@ -170,8 +168,6 @@ private:
     boost::shared_ptr<OdinData::IpcReactor> reactor_;
     /** End point for control messages */
     std::string ctrlChannelEndpoint_;
-    /** ZMQ context for IPC channels */
-    OdinData::IpcContext& ipc_context_;
     /** IpcChannel for control messages */
     OdinData::IpcChannel ctrlChannel_;
     /** IpcChannel for meta-data messages */
@@ -184,6 +180,10 @@ private:
     std::string frReadyEndpoint_;
     /** End point for frameReceiver release channel */
     std::string frReleaseEndpoint_;
+    /** Frames to write before shutting down - 0 to disable shutdown */
+    unsigned int shutdownFrameCount_;
+    /** Total frames processed */
+    unsigned int totalFrames_;
 };
 
 } /* namespace FrameProcessor */

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -46,7 +46,7 @@ public:
     void execute(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void requestCommands(OdinData::IpcMessage& reply);
     void resetStatistics(OdinData::IpcMessage& reply);
-    void configurePlugin(OdinData::IpcMessage& config);
+    void configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void loadPlugin(const std::string& index, const std::string& name, const std::string& library);
     void connectPlugin(const std::string& index, const std::string& connectTo);
     void disconnectPlugin(const std::string& index, const std::string& disconnectFrom);

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -36,7 +36,7 @@ class FrameProcessorController : public IFrameCallback,
                                  public boost::enable_shared_from_this<FrameProcessorController> {
 public:
     FrameProcessorController(unsigned int num_io_threads = OdinData::Defaults::default_io_threads);
-    virtual ~FrameProcessorController();
+    ~FrameProcessorController() override;
     void handleCtrlChannel();
     void handleMetaRxChannel();
     void provideStatus(OdinData::IpcMessage& reply, bool metadata);
@@ -132,7 +132,7 @@ private:
     void closeMetaTxInterface();
     void runIpcService(void);
     void tickTimer(void);
-    void callback(boost::shared_ptr<Frame> frame);
+    void callback(boost::shared_ptr<Frame> frame) override;
 
     /** Pointer to the logging facility */
     log4cxx::LoggerPtr logger_;

--- a/cpp/frameProcessor/include/FrameProcessorController.h
+++ b/cpp/frameProcessor/include/FrameProcessorController.h
@@ -46,7 +46,7 @@ public:
     void execute(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
     void requestCommands(OdinData::IpcMessage& reply);
     void resetStatistics(OdinData::IpcMessage& reply);
-    void configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
+    void configurePlugin(OdinData::IpcMessage& config);
     void loadPlugin(const std::string& index, const std::string& name, const std::string& library);
     void connectPlugin(const std::string& index, const std::string& connectTo);
     void disconnectPlugin(const std::string& index, const std::string& disconnectFrom);

--- a/cpp/frameProcessor/include/FrameProcessorDefinitions.h
+++ b/cpp/frameProcessor/include/FrameProcessorDefinitions.h
@@ -53,7 +53,7 @@ const std::string COMPRESS_TYPES[] = { "unknown", "none", "LZ4", "BSLZ4", "blosc
  * @param str data type as string
  * @return DataType data type
  */
-static DataType get_type_from_string(const std::string& str)
+inline DataType get_type_from_string(const std::string& str)
 {
     if (str == "unknown")
         return raw_unknown;
@@ -75,7 +75,7 @@ static DataType get_type_from_string(const std::string& str)
  * \param[in] type - enum value
  * \return size_t data type size
  */
-static size_t get_size_from_enum(DataType type)
+inline size_t get_size_from_enum(DataType type)
 {
     if (type == raw_8bit)
         return sizeof(uint8_t); // 1 byte
@@ -103,7 +103,7 @@ static size_t get_size_from_enum(DataType type)
  * \param[in] type - enum value
  * \return string value representing data type, or "unknown" if an unrecognised enum value
  */
-static std::string get_type_from_enum(DataType type)
+inline std::string get_type_from_enum(DataType type)
 {
     if (type >= 0 && type < sizeof(DATA_TYPES) / sizeof(DATA_TYPES[0])) {
         return DATA_TYPES[type];
@@ -117,7 +117,7 @@ static std::string get_type_from_enum(DataType type)
  * @param str compression type as string
  * @return CompressionType compression type
  */
-static CompressionType get_compression_from_string(const std::string& str)
+inline CompressionType get_compression_from_string(const std::string& str)
 {
     if (str == "unknown")
         return unknown_compression;
@@ -138,7 +138,7 @@ static CompressionType get_compression_from_string(const std::string& str)
  * \param[in] compress - enum value
  * \return the string value representing the compression. Assumed none if the enum value is unrecognised.
  */
-static std::string get_compress_from_enum(CompressionType compress)
+inline std::string get_compress_from_enum(CompressionType compress)
 {
     if (compress >= 0 && compress < sizeof(COMPRESS_TYPES) / sizeof(COMPRESS_TYPES[0])) {
         return COMPRESS_TYPES[compress];

--- a/cpp/frameProcessor/include/FrameProcessorPlugin.h
+++ b/cpp/frameProcessor/include/FrameProcessorPlugin.h
@@ -34,7 +34,7 @@ namespace FrameProcessor {
 class FrameProcessorPlugin : public IFrameCallback, public OdinData::IVersionedObject, public MetaMessagePublisher {
 public:
     FrameProcessorPlugin();
-    virtual ~FrameProcessorPlugin();
+    ~FrameProcessorPlugin() override;
     void set_name(const std::string& name);
     std::string get_name() const;
     void set_error(const std::string& msg);
@@ -240,7 +240,7 @@ private:
         }
     }
 
-    void callback(boost::shared_ptr<Frame> frame);
+    void callback(boost::shared_ptr<Frame> frame) override;
 
     /**
      * This is called by the callback method when any new frames have

--- a/cpp/frameProcessor/include/GapFillPlugin.h
+++ b/cpp/frameProcessor/include/GapFillPlugin.h
@@ -24,16 +24,16 @@ class GapFillPlugin : public FrameProcessorPlugin {
 
 public:
     GapFillPlugin();
-    virtual ~GapFillPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
+    ~GapFillPlugin() override;
+    void process_frame(boost::shared_ptr<Frame> frame) override;
     bool configuration_valid(boost::shared_ptr<Frame> frame);
     boost::shared_ptr<Frame> insert_gaps(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
     /*Config Names*/
     /** The required grid for the image [y, x]*/
@@ -46,7 +46,7 @@ public:
     static const std::string CONFIG_GRID_Y_GAPS;
 
 private:
-    void requestConfiguration(OdinData::IpcMessage& reply);
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
 
     /** Pointer to logger */
     LoggerPtr logger_;

--- a/cpp/frameProcessor/include/GapFillPlugin.h
+++ b/cpp/frameProcessor/include/GapFillPlugin.h
@@ -51,8 +51,8 @@ private:
     /** Pointer to logger */
     LoggerPtr logger_;
 
-    std::vector<int> grid_;
-    std::vector<int> chip_;
+    std::vector<uint32_t> grid_;
+    std::vector<uint32_t> chip_;
     std::vector<int> gaps_x_;
     std::vector<int> gaps_y_;
     std::mutex mutex_;

--- a/cpp/frameProcessor/include/LiveViewPlugin.h
+++ b/cpp/frameProcessor/include/LiveViewPlugin.h
@@ -24,15 +24,15 @@ class LiveViewPlugin : public FrameProcessorPlugin {
 
 public:
     LiveViewPlugin();
-    virtual ~LiveViewPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
+    ~LiveViewPlugin() override;
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
     void pass_live_frame(boost::shared_ptr<Frame> frame);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
     /*DEFAULT CONFIG VALUES*/
     /** The default value for the Frame Frequency configuration*/
@@ -67,7 +67,7 @@ private:
 
     void add_json_member(rapidjson::Document* document, std::string key, std::string value);
     void add_json_member(rapidjson::Document* document, std::string key, uint32_t value);
-    void requestConfiguration(OdinData::IpcMessage& reply);
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
     void set_per_second_config(int32_t value);
     void set_frame_freq_config(int32_t value);
     void set_socket_addr_config(std::string value);

--- a/cpp/frameProcessor/include/OffsetAdjustmentPlugin.h
+++ b/cpp/frameProcessor/include/OffsetAdjustmentPlugin.h
@@ -32,17 +32,17 @@ static const std::string OFFSET_ADJUSTMENT_CONFIG = "offset_adjustment";
 class OffsetAdjustmentPlugin : public FrameProcessorPlugin {
 public:
     OffsetAdjustmentPlugin();
-    virtual ~OffsetAdjustmentPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    ~OffsetAdjustmentPlugin() override;
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
 private:
-    void requestConfiguration(OdinData::IpcMessage& reply);
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
 
     /** Pointer to logger */
     LoggerPtr logger_;

--- a/cpp/frameProcessor/include/ParamMetadata.h
+++ b/cpp/frameProcessor/include/ParamMetadata.h
@@ -140,8 +140,8 @@ struct ParamMetadata {
     friend class FrameProcessorPlugin;
 
 private:
-    AccessMode access_mode_;
     Datatype type_;
+    AccessMode access_mode_;
     std::vector<allowed_values_t> allowed_values_;
     int32_t min_;
     int32_t max_;

--- a/cpp/frameProcessor/include/ParameterAdjustmentPlugin.h
+++ b/cpp/frameProcessor/include/ParameterAdjustmentPlugin.h
@@ -31,17 +31,17 @@ static const std::string PARAMETER_ADJUSTMENT_CONFIG = "adjustment";
 class ParameterAdjustmentPlugin : public FrameProcessorPlugin {
 public:
     ParameterAdjustmentPlugin();
-    virtual ~ParameterAdjustmentPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    ~ParameterAdjustmentPlugin() override;
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
 private:
-    void requestConfiguration(OdinData::IpcMessage& reply);
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
 
     /** Pointer to logger */
     LoggerPtr logger_;

--- a/cpp/frameProcessor/include/ParameterPublishPlugin.h
+++ b/cpp/frameProcessor/include/ParameterPublishPlugin.h
@@ -23,15 +23,15 @@ namespace FrameProcessor {
 class ParameterPublishPlugin : public FrameProcessorPlugin {
 public:
     ParameterPublishPlugin();
-    ~ParameterPublishPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    void requestConfiguration(OdinData::IpcMessage& reply);
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    ~ParameterPublishPlugin() override;
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
     // Config message keys
     static const std::string CONFIG_ENDPOINT;

--- a/cpp/frameProcessor/include/RawFileWriterPlugin.h
+++ b/cpp/frameProcessor/include/RawFileWriterPlugin.h
@@ -20,10 +20,10 @@ namespace FrameProcessor {
 class RawFileWriterPlugin : public FrameProcessorPlugin {
 public:
     RawFileWriterPlugin();
-    void process_frame(boost::shared_ptr<Frame> frame);
-    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
-    void requestConfiguration(OdinData::IpcMessage& reply);
-    void status(OdinData::IpcMessage& reply);
+    void process_frame(boost::shared_ptr<Frame> frame) override;
+    void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) override;
+    void requestConfiguration(OdinData::IpcMessage& reply) override;
+    void status(OdinData::IpcMessage& reply) override;
     int get_version_major() override;
     int get_version_minor() override;
     int get_version_patch() override;

--- a/cpp/frameProcessor/include/SharedBufferFrame.h
+++ b/cpp/frameProcessor/include/SharedBufferFrame.h
@@ -28,7 +28,7 @@ public:
     ~SharedBufferFrame();
 
     /** Return a void pointer to the raw data */
-    virtual void* get_data_ptr() const;
+    void* get_data_ptr() const override;
 
 private:
     /** Pointer to shared memory raw block **/

--- a/cpp/frameProcessor/include/SumPlugin.h
+++ b/cpp/frameProcessor/include/SumPlugin.h
@@ -26,19 +26,19 @@ class SumPlugin : public FrameProcessorPlugin {
 public:
     SumPlugin();
 
-    ~SumPlugin();
+    ~SumPlugin() override;
 
-    void process_frame(boost::shared_ptr<Frame> frame);
+    void process_frame(boost::shared_ptr<Frame> frame) override;
 
-    int get_version_major();
+    int get_version_major() override;
 
-    int get_version_minor();
+    int get_version_minor() override;
 
-    int get_version_patch();
+    int get_version_patch() override;
 
-    std::string get_version_short();
+    std::string get_version_short() override;
 
-    std::string get_version_long();
+    std::string get_version_long() override;
 
 private:
     /** Pointer to logger */

--- a/cpp/frameProcessor/include/WorkQueue.h
+++ b/cpp/frameProcessor/include/WorkQueue.h
@@ -39,8 +39,8 @@ public:
      */
     WorkQueue()
     {
-        pthread_mutex_init(&m_mutex, NULL);
-        pthread_cond_init(&m_condv, NULL);
+        pthread_mutex_init(&m_mutex, nullptr);
+        pthread_cond_init(&m_condv, nullptr);
     }
 
     /** Destructor.

--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -59,9 +59,7 @@ Acquisition::Acquisition(const HDF5ErrorDefinition_t& hdf5_error_definition) :
     connect_meta_channel();
 }
 
-Acquisition::~Acquisition()
-{
-}
+Acquisition::~Acquisition() = default;
 
 /**
  * Returns the last error message that was generated
@@ -105,7 +103,7 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame, HD
 
             boost::shared_ptr<HDF5File> file = this->get_file(frame_offset, call_durations);
 
-            if (file == 0) {
+            if (file == nullptr) {
                 last_error_ = "Unable to get file for this frame";
                 return status_invalid;
             }
@@ -286,7 +284,7 @@ void Acquisition::create_file(size_t file_number, HDF5CallDurations_t& call_dura
  */
 void Acquisition::close_file(boost::shared_ptr<HDF5File> file, HDF5CallDurations_t& call_durations)
 {
-    if (file != 0) {
+    if (file != nullptr) {
         LOG4CXX_INFO(logger_, "Closing file " << file->get_filename());
         size_t close_duration = file->close_file();
         call_durations.close.update(close_duration);
@@ -552,7 +550,7 @@ boost::shared_ptr<HDF5File> Acquisition::get_file(size_t frame_offset, HDF5CallD
     // Get the file for this frame index
     if (file_index == current_file_->get_file_index()) {
         return this->current_file_;
-    } else if (previous_file_ != 0 && file_index == previous_file_->get_file_index()) {
+    } else if (previous_file_ != nullptr && file_index == previous_file_->get_file_index()) {
         return this->previous_file_;
     } else if (file_index > current_file_->get_file_index()) {
         LOG4CXX_TRACE(

--- a/cpp/frameProcessor/src/Acquisition.cpp
+++ b/cpp/frameProcessor/src/Acquisition.cpp
@@ -37,22 +37,22 @@ const std::string META_START_ITEM = "startacquisition";
 const std::string META_STOP_ITEM = "stopacquisition";
 
 Acquisition::Acquisition(const HDF5ErrorDefinition_t& hdf5_error_definition) :
-    concurrent_rank_(0),
-    concurrent_processes_(1),
-    frames_per_block_(1),
-    blocks_per_file_(0),
-    frames_written_(0),
-    frames_processed_(0),
-    total_frames_(0),
     frames_to_write_(0),
+    total_frames_(0),
     starting_file_index_(0),
     use_file_numbers_(true),
+    file_postfix_(""),
     use_earliest_hdf5_(false),
     alignment_threshold_(1),
     alignment_value_(1),
-    last_error_(""),
-    file_postfix_(""),
-    hdf5_error_definition_(hdf5_error_definition)
+    frames_written_(0),
+    frames_processed_(0),
+    concurrent_processes_(1),
+    concurrent_rank_(0),
+    frames_per_block_(1),
+    blocks_per_file_(0),
+    hdf5_error_definition_(hdf5_error_definition),
+    last_error_("")
 {
     this->logger_ = Logger::getLogger("FP.Acquisition");
     LOG4CXX_TRACE(logger_, "Acquisition constructor.");
@@ -112,7 +112,7 @@ ProcessFrameStatus Acquisition::process_frame(boost::shared_ptr<Frame> frame, HD
 
             size_t frame_offset_in_file = this->get_frame_offset_in_file(frame_offset);
 
-            int dataset_max_offset = file->get_dataset_max_size(frame_dataset_name) - 1;
+            size_t dataset_max_offset = file->get_dataset_max_size(frame_dataset_name) - 1;
             if (dataset_max_offset && frame_offset_in_file > dataset_max_offset) {
                 last_error_ = "Frame offset exceeds dimensions of static dataset";
                 return status_invalid;
@@ -248,7 +248,7 @@ void Acquisition::create_file(size_t file_number, HDF5CallDurations_t& call_dura
         if (dset_def.create_low_high_indexes && frames_per_block_ > 1) {
             low_index = file_number * frames_per_block_ + 1;
             high_index = low_index + frames_per_block_ - 1;
-            if (blocks_per_file_ == 0 || high_index > total_frames_) {
+            if (blocks_per_file_ == 0 || static_cast<size_t>(high_index) > total_frames_) {
                 high_index = total_frames_;
             }
         }
@@ -258,7 +258,7 @@ void Acquisition::create_file(size_t file_number, HDF5CallDurations_t& call_dura
         int wrap = (file_number / concurrent_processes_) + 1;
         int frames_per_file = blocks_per_file_ * frames_per_block_ * dset_def.chunks[0];
         if (frames_per_file > 1) {
-            if (wrap * frames_per_file > frames_to_write_) {
+            if (wrap * frames_per_file > static_cast<long int>(frames_to_write_)) {
                 // This is the final file creation which may contain less than a full block of frames
                 dset_def.num_frames = frames_to_write_ % frames_per_file;
             } else {

--- a/cpp/frameProcessor/src/BloscPlugin.cpp
+++ b/cpp/frameProcessor/src/BloscPlugin.cpp
@@ -197,7 +197,7 @@ std::pair<boost::shared_ptr<Frame>, bool> BloscPlugin::compress_frame(const boos
                     << src_frame->get_meta_data().get_acquisition_ID() << "\""
             );
         }
-    } catch (std::bad_alloc) {
+    } catch (std::bad_alloc&) {
         LOG4CXX_ERROR(logger_, "Failed to allocate memory for compressed frame");
     }
     return { std::move(dest_frame), comp_res };
@@ -251,7 +251,7 @@ std::pair<boost::shared_ptr<Frame>, bool> BloscPlugin::decompress_frame(const bo
                     << " compressed bytes=" << src_frame->get_data_size() << " destsize=" << dest_size
             );
         }
-    } catch (std::bad_alloc) {
+    } catch (std::bad_alloc&) {
         LOG4CXX_ERROR(logger_, "Failed to allocate memory for decompressed frame");
     }
     return { std::move(dest_frame), decomp_res };

--- a/cpp/frameProcessor/src/DataBlockPool.cpp
+++ b/cpp/frameProcessor/src/DataBlockPool.cpp
@@ -15,9 +15,7 @@ namespace FrameProcessor {
  */
 std::map<size_t, DataBlockPool*> DataBlockPool::instance_map_;
 
-DataBlockPool::~DataBlockPool()
-{
-}
+DataBlockPool::~DataBlockPool() = default;
 
 /**
  * Static method to force allocation of new DataBlocks which are added to

--- a/cpp/frameProcessor/src/DataBlockPool.cpp
+++ b/cpp/frameProcessor/src/DataBlockPool.cpp
@@ -126,11 +126,11 @@ DataBlockPool* DataBlockPool::instance(size_t block_size)
  * methods to enforce only one pool for each index is created.
  */
 DataBlockPool::DataBlockPool() :
+    logger_(log4cxx::Logger::getLogger("FP.DataBlockPool")),
     free_blocks_(0),
     used_blocks_(0),
     total_blocks_(0),
-    memory_allocated_(0),
-    logger_(log4cxx::Logger::getLogger("FP.DataBlockPool"))
+    memory_allocated_(0)
 {
 }
 

--- a/cpp/frameProcessor/src/DummyUDPProcessPlugin.cpp
+++ b/cpp/frameProcessor/src/DummyUDPProcessPlugin.cpp
@@ -291,7 +291,7 @@ void DummyUDPProcessPlugin::process_lost_packets(boost::shared_ptr<Frame>& frame
         char* payload_ptr = static_cast<char*>(frame->get_data_ptr()) + sizeof(DummyUDP::FrameHeader);
 
         // Loop over all packets in frame
-        for (int packet_idx = 0; packet_idx < hdr_ptr->total_packets_expected; packet_idx++) {
+        for (uint32_t packet_idx = 0; packet_idx < hdr_ptr->total_packets_expected; packet_idx++) {
             // If header reports packet missing, zero out the packet
             if (hdr_ptr->packet_state[packet_idx] == 0) {
                 LOG4CXX_DEBUG(logger_, "Missing packet number " << packet_idx);

--- a/cpp/frameProcessor/src/DummyUDPProcessPlugin.cpp
+++ b/cpp/frameProcessor/src/DummyUDPProcessPlugin.cpp
@@ -96,7 +96,7 @@ std::string DummyUDPProcessPlugin::get_version_long()
  * \param[in] config - Reference to the configuration IpcMessage object.
  * \param[out] reply - Reference to the reply IpcMessage object.
  */
-void DummyUDPProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void DummyUDPProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
 
     if (config.has_param(DummyUDPProcessPlugin::CONFIG_IMAGE_WIDTH)) {
@@ -140,7 +140,7 @@ void DummyUDPProcessPlugin::requestConfiguration(OdinData::IpcMessage& reply)
  * \param[in] config - String containing the command to execute.
  * \param[out] reply - Reference to the reply IpcMessage object.
  */
-void DummyUDPProcessPlugin::execute(const std::string& command, OdinData::IpcMessage& reply)
+void DummyUDPProcessPlugin::execute(const std::string& command, OdinData::IpcMessage& /* reply */)
 {
     if (command == DummyUDPProcessPlugin::EXECUTE_PRINT) {
         LOG4CXX_INFO(logger_, "Image width is " << image_width_);

--- a/cpp/frameProcessor/src/EndOfAcquisitionFrame.cpp
+++ b/cpp/frameProcessor/src/EndOfAcquisitionFrame.cpp
@@ -13,33 +13,26 @@ EndOfAcquisitionFrame::EndOfAcquisitionFrame() :
  * implement as shallow copy
  * @param frame
  */
-EndOfAcquisitionFrame::EndOfAcquisitionFrame(const EndOfAcquisitionFrame& frame) :
-    Frame(frame) { };
+EndOfAcquisitionFrame::EndOfAcquisitionFrame(const EndOfAcquisitionFrame& frame) = default;
 
 /** Assignment operator;
  * implement as deep copy
  * @param frame
  * @return Frame
  */
-EndOfAcquisitionFrame& EndOfAcquisitionFrame::operator=(EndOfAcquisitionFrame& frame)
-{
-    Frame::operator=(frame);
-    return *this;
-}
+EndOfAcquisitionFrame& EndOfAcquisitionFrame::operator=(EndOfAcquisitionFrame& frame) = default;
 
 /** Destroy frame
  *
  */
-EndOfAcquisitionFrame::~EndOfAcquisitionFrame()
-{
-}
+EndOfAcquisitionFrame::~EndOfAcquisitionFrame() = default;
 
 /** No data ptr so return null
  *
  */
 void* EndOfAcquisitionFrame::get_data_ptr() const
 {
-    return NULL;
+    return nullptr;
 }
 
 /** Return true to signify that this frame

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -374,8 +374,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
         }
 
         // Check to see if we are being told how many frames to write
-        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)
-            && config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES) >= 0) {
+        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)) {
             size_t totalFrames = config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES);
             next_acquisition_->total_frames_ = totalFrames;
             next_acquisition_->frames_to_write_ = calc_num_frames(totalFrames);
@@ -509,7 +508,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     // Check for process number
     if (config.has_param(FileWriterPlugin::CONFIG_PROCESS_NUMBER)) {
@@ -727,7 +726,7 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
 void FileWriterPlugin::configure_dataset(
     const std::string& dataset_name,
     OdinData::IpcMessage& config,
-    OdinData::IpcMessage& reply
+    OdinData::IpcMessage& /* reply */
 )
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Configuring dataset [" << dataset_name << "]");
@@ -754,7 +753,7 @@ void FileWriterPlugin::configure_dataset(
         // Set first chunk dimension (n dimension) to a single frame or item
         chunks[0] = 1;
         // Set the remaining chunk dimensions to the same as the dataset dimensions
-        for (int index = 0; index < dset.frame_dimensions.size(); index++) {
+        for (std::size_t index = 0; index < dset.frame_dimensions.size(); index++) {
             chunks[index + 1] = dset.frame_dimensions[index];
         }
         dset.chunks = chunks;

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -80,16 +80,16 @@ FileWriterPlugin::FileWriterPlugin() :
     concurrent_rank_(0),
     frames_per_block_(1),
     blocks_per_file_(0),
-    first_file_index_(0),
-    use_file_numbering_(true),
-    file_postfix_(""),
-    file_extension_("h5"),
     use_earliest_hdf5_(false),
     alignment_threshold_(1),
     alignment_value_(1),
     timeout_period_(0),
     timeout_thread_running_(true),
-    timeout_thread_(boost::bind(&FileWriterPlugin::run_close_file_timeout, this))
+    timeout_thread_(boost::bind(&FileWriterPlugin::run_close_file_timeout, this)),
+    first_file_index_(0),
+    use_file_numbering_(true),
+    file_postfix_(""),
+    file_extension_("h5")
 {
     std::string prefix = FileWriterPlugin::CONFIG_PROCESS + '/';
     add_config_param_metadata(
@@ -483,7 +483,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
         if (iter->second.frame_dimensions.size() > 0) {
             std::string dimParamName
                 = get_name() + "/dataset/" + iter->first + '/' + FileWriterPlugin::CONFIG_DATASET_DIMS + "[]";
-            for (int index = 0; index < iter->second.frame_dimensions.size(); index++) {
+            for (uint32_t index = 0; index < iter->second.frame_dimensions.size(); index++) {
                 reply.set_param(dimParamName, (int)iter->second.frame_dimensions[index]);
             }
         }
@@ -491,7 +491,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
         if (iter->second.chunks.size() > 0) {
             std::string chunkParamName
                 = get_name() + "/dataset/" + iter->first + '/' + FileWriterPlugin::CONFIG_DATASET_CHUNKS + "[]";
-            for (int index = 0; index < iter->second.chunks.size(); index++) {
+            for (uint32_t index = 0; index < iter->second.chunks.size(); index++) {
                 reply.set_param(chunkParamName, (int)iter->second.chunks[index]);
             }
         }
@@ -756,7 +756,7 @@ void FileWriterPlugin::configure_dataset(
         // Set first chunk dimension (n dimension) to a single frame or item
         chunks[0] = 1;
         // Set the remaining chunk dimensions to the same as the dataset dimensions
-        for (int index = 0; index < dset.frame_dimensions.size(); index++) {
+        for (uint32_t index = 0; index < dset.frame_dimensions.size(); index++) {
             chunks[index + 1] = dset.frame_dimensions[index];
         }
         dset.chunks = chunks;

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -3,7 +3,7 @@
  *
  */
 
-#include <assert.h>
+#include <cassert>
 
 #include <boost/filesystem.hpp>
 #include <hdf5_hl.h>
@@ -85,7 +85,7 @@ FileWriterPlugin::FileWriterPlugin() :
     alignment_value_(1),
     timeout_period_(0),
     timeout_thread_running_(true),
-    timeout_thread_(boost::bind(&FileWriterPlugin::run_close_file_timeout, this)),
+    timeout_thread_([this] { run_close_file_timeout(); }),
     first_file_index_(0),
     use_file_numbering_(true),
     file_postfix_(""),
@@ -177,7 +177,7 @@ FileWriterPlugin::FileWriterPlugin() :
     hdf5_error_definition_.write_duration = 0;
     hdf5_error_definition_.flush_duration = 0;
     hdf5_error_definition_.close_duration = 0;
-    hdf5_error_definition_.callback = boost::bind(&FileWriterPlugin::set_warning, this, _1);
+    hdf5_error_definition_.callback = [this](const std::string& message) { set_warning(message); };
 }
 
 /**
@@ -357,9 +357,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
                     config.get_param<const rapidjson::Value&>(FileWriterPlugin::CONFIG_DATASET)
                 );
                 std::vector<std::string> dataset_names = dataset_config.get_param_names();
-                for (std::vector<std::string>::iterator iter = dataset_names.begin(); iter != dataset_names.end();
-                     ++iter) {
-                    std::string dataset_name = *iter;
+                for (auto dataset_name : dataset_names) {
                     LOG4CXX_INFO(logger_, "Dataset name " << dataset_name << " found, creating...");
                     create_new_dataset(dataset_name);
                     OdinData::IpcMessage dsetConfig(dataset_config.get_param<const rapidjson::Value&>(dataset_name));
@@ -376,7 +374,8 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
         }
 
         // Check to see if we are being told how many frames to write
-        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)) {
+        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)
+            && config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES) >= 0) {
             size_t totalFrames = config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES);
             next_acquisition_->total_frames_ = totalFrames;
             next_acquisition_->frames_to_write_ = calc_num_frames(totalFrames);
@@ -482,16 +481,16 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
         if (iter->second.frame_dimensions.size() > 0) {
             std::string dimParamName
                 = get_name() + "/dataset/" + iter->first + '/' + FileWriterPlugin::CONFIG_DATASET_DIMS + "[]";
-            for (uint32_t index = 0; index < iter->second.frame_dimensions.size(); index++) {
-                reply.set_param(dimParamName, (int)iter->second.frame_dimensions[index]);
+            for (unsigned long long frame_dimension : iter->second.frame_dimensions) {
+                reply.set_param(dimParamName, (int)frame_dimension);
             }
         }
         // Check for and add chunking dimensions
         if (iter->second.chunks.size() > 0) {
             std::string chunkParamName
                 = get_name() + "/dataset/" + iter->first + '/' + FileWriterPlugin::CONFIG_DATASET_CHUNKS + "[]";
-            for (uint32_t index = 0; index < iter->second.chunks.size(); index++) {
-                reply.set_param(chunkParamName, (int)iter->second.chunks[index]);
+            for (unsigned long long chunk : iter->second.chunks) {
+                reply.set_param(chunkParamName, (int)chunk);
             }
         }
     }
@@ -510,7 +509,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
+void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
 {
     // Check for process number
     if (config.has_param(FileWriterPlugin::CONFIG_PROCESS_NUMBER)) {
@@ -728,7 +727,7 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
 void FileWriterPlugin::configure_dataset(
     const std::string& dataset_name,
     OdinData::IpcMessage& config,
-    OdinData::IpcMessage& /* reply */
+    OdinData::IpcMessage& reply
 )
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Configuring dataset [" << dataset_name << "]");
@@ -755,7 +754,7 @@ void FileWriterPlugin::configure_dataset(
         // Set first chunk dimension (n dimension) to a single frame or item
         chunks[0] = 1;
         // Set the remaining chunk dimensions to the same as the dataset dimensions
-        for (uint32_t index = 0; index < dset.frame_dimensions.size(); index++) {
+        for (int index = 0; index < dset.frame_dimensions.size(); index++) {
             chunks[index + 1] = dset.frame_dimensions[index];
         }
         dset.chunks = chunks;

--- a/cpp/frameProcessor/src/FileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/FileWriterPlugin.cpp
@@ -376,8 +376,7 @@ void FileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMess
         }
 
         // Check to see if we are being told how many frames to write
-        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)
-            && config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES) >= 0) {
+        if (config.has_param(FileWriterPlugin::CONFIG_FRAMES)) {
             size_t totalFrames = config.get_param<size_t>(FileWriterPlugin::CONFIG_FRAMES);
             next_acquisition_->total_frames_ = totalFrames;
             next_acquisition_->frames_to_write_ = calc_num_frames(totalFrames);
@@ -511,7 +510,7 @@ void FileWriterPlugin::requestConfiguration(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void FileWriterPlugin::configure_process(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     // Check for process number
     if (config.has_param(FileWriterPlugin::CONFIG_PROCESS_NUMBER)) {
@@ -729,7 +728,7 @@ void FileWriterPlugin::configure_file(OdinData::IpcMessage& config, OdinData::Ip
 void FileWriterPlugin::configure_dataset(
     const std::string& dataset_name,
     OdinData::IpcMessage& config,
-    OdinData::IpcMessage& reply
+    OdinData::IpcMessage& /* reply */
 )
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Configuring dataset [" << dataset_name << "]");

--- a/cpp/frameProcessor/src/Frame.cpp
+++ b/cpp/frameProcessor/src/Frame.cpp
@@ -9,12 +9,12 @@ namespace FrameProcessor {
  * @param image_offset - between start of data memory and image
  */
 Frame::Frame(const FrameMetaData& meta_data, const size_t& data_size, const int& image_offset) :
+    logger_(log4cxx::Logger::getLogger("FP.Frame")),
     meta_data_(meta_data),
     data_size_(data_size),
-    image_offset_(image_offset),
     image_size_(data_size - image_offset),
-    outer_chunk_size_(1),
-    logger_(log4cxx::Logger::getLogger("FP.Frame"))
+    image_offset_(image_offset),
+    outer_chunk_size_(1)
 {
 }
 
@@ -94,9 +94,8 @@ void Frame::set_data_size(size_t size)
 }
 
 /** Return the frame number
-/** Return the frame number
-* @return frame frame number
-*/
+ *  @return frame frame number
+ * */
 long long Frame::get_frame_number() const
 {
     return this->meta_data_.get_frame_number();

--- a/cpp/frameProcessor/src/FrameMetaData.cpp
+++ b/cpp/frameProcessor/src/FrameMetaData.cpp
@@ -11,23 +11,23 @@ FrameMetaData::FrameMetaData(
     const CompressionType& compression_type
 ) :
     frame_number_(frame_number),
+    logger(log4cxx::Logger::getLogger("FP.FrameMetaData")),
     dataset_name_(dataset_name),
     data_type_(data_type),
     acquisition_ID_(acquisition_ID),
     dimensions_(dimensions),
     compression_type_(compression_type),
-    frame_offset_(0),
-    logger(log4cxx::Logger::getLogger("FP.FrameMetaData"))
+    frame_offset_(0)
 {
 }
 
 FrameMetaData::FrameMetaData() :
     frame_number_(-1),
+    logger(log4cxx::Logger::getLogger("FP.FrameMetaData")),
     dataset_name_(""),
     data_type_(raw_unknown),
     compression_type_(unknown_compression),
-    frame_offset_(0),
-    logger(log4cxx::Logger::getLogger("FP.FrameMetaData"))
+    frame_offset_(0)
 {
 }
 

--- a/cpp/frameProcessor/src/FrameMetaData.cpp
+++ b/cpp/frameProcessor/src/FrameMetaData.cpp
@@ -31,19 +31,6 @@ FrameMetaData::FrameMetaData() :
 {
 }
 
-FrameMetaData::FrameMetaData(const FrameMetaData& frame)
-{
-    frame_number_ = frame.frame_number_;
-    dataset_name_ = frame.dataset_name_;
-    data_type_ = frame.data_type_;
-    acquisition_ID_ = frame.acquisition_ID_;
-    dimensions_ = frame.dimensions_;
-    compression_type_ = frame.compression_type_;
-    parameters_ = frame.parameters_;
-    frame_offset_ = frame.frame_offset_;
-    logger = frame.logger;
-}
-
 /** Get frame parameters
  * @return std::map <std::string, boost::any>  map
  */

--- a/cpp/frameProcessor/src/FrameProcessorApp.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorApp.cpp
@@ -5,10 +5,10 @@
  *      Author: Alan Greer
  */
 
+#include <csignal>
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <signal.h>
 #include <string>
 using namespace std;
 

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -431,7 +431,7 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
         OdinData::IpcMessage pluginConfig(
             config.get_param<const rapidjson::Value&>(FrameProcessorController::CONFIG_PLUGIN)
         );
-        this->configurePlugin(pluginConfig, reply);
+        this->configurePlugin(pluginConfig);
     }
 
     // Check if we are being passed the shared memory configuration
@@ -664,7 +664,7 @@ void FrameProcessorController::resetStatistics(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config)
 {
     // Check if we are being asked to load a plugin
     if (config.has_param(FrameProcessorController::CONFIG_PLUGIN_LOAD)) {

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -179,6 +179,8 @@ void FrameProcessorController::handleCtrlChannel()
                 LOG4CXX_DEBUG_LEVEL(3, logger_, "Control thread reply message (shutdown): " << replyMsg.encode());
                 break;
             }
+            default:
+                throw std::runtime_error("Unhandled IpcMessage value: " + std::to_string(mval) + " . in FrameProcessorController.cpp#183");
             };
         } else {
             LOG4CXX_ERROR(logger_, "Control thread got unexpected message: " << ctrlMsgEncoded);

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -1062,6 +1062,7 @@ void FrameProcessorController::runIpcService(void)
 
     // Create the reactor
     reactor_ = boost::shared_ptr<OdinData::IpcReactor>(new OdinData::IpcReactor());
+    reactor_->register_timer(1000, 0, boost::bind(&FrameProcessorController::tickTimer, this));
 
     // Set thread state to running, allows constructor to return
     threadRunning_ = true;

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -1061,9 +1061,6 @@ void FrameProcessorController::runIpcService(void)
     // Create the reactor
     reactor_ = boost::shared_ptr<OdinData::IpcReactor>(new OdinData::IpcReactor());
 
-    // Add the tick timer to the reactor
-    int tick_timer_id = reactor_->register_timer(1000, 0, boost::bind(&FrameProcessorController::tickTimer, this));
-
     // Set thread state to running, allows constructor to return
     threadRunning_ = true;
 

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -179,6 +179,10 @@ void FrameProcessorController::handleCtrlChannel()
                 LOG4CXX_DEBUG_LEVEL(3, logger_, "Control thread reply message (shutdown): " << replyMsg.encode());
                 break;
             }
+            default:
+                throw std::runtime_error(
+                    "Unhandled IpcMessage value: " + std::to_string(mval) + " in FrameProcessorController"
+                );
             };
         } else {
             LOG4CXX_ERROR(logger_, "Control thread got unexpected message: " << ctrlMsgEncoded);
@@ -429,7 +433,7 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
         OdinData::IpcMessage pluginConfig(
             config.get_param<const rapidjson::Value&>(FrameProcessorController::CONFIG_PLUGIN)
         );
-        this->configurePlugin(pluginConfig, reply);
+        this->configurePlugin(pluginConfig);
     }
 
     // Check if we are being passed the shared memory configuration
@@ -662,7 +666,7 @@ void FrameProcessorController::resetStatistics(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config)
 {
     // Check if we are being asked to load a plugin
     if (config.has_param(FrameProcessorController::CONFIG_PLUGIN_LOAD)) {

--- a/cpp/frameProcessor/src/FrameProcessorController.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorController.cpp
@@ -5,7 +5,7 @@
  *      Author: gnx91527
  */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "DataBlockPool.h"
 #include "DebugLevelLogger.h"
@@ -61,7 +61,7 @@ FrameProcessorController::FrameProcessorController(unsigned int num_io_threads) 
     pluginShutdownSent_(false),
     shutdown_(false),
     ipc_context_(OdinData::IpcContext::Instance(num_io_threads)),
-    ctrlThread_(boost::bind(&FrameProcessorController::runIpcService, this)),
+    ctrlThread_([this] { runIpcService(); }),
     ctrlChannelEndpoint_(""),
     ctrlChannel_(ZMQ_ROUTER),
     metaRxChannel_(ZMQ_PULL),
@@ -179,8 +179,6 @@ void FrameProcessorController::handleCtrlChannel()
                 LOG4CXX_DEBUG_LEVEL(3, logger_, "Control thread reply message (shutdown): " << replyMsg.encode());
                 break;
             }
-            default:
-                throw std::runtime_error("Unhandled IpcMessage value: " + std::to_string(mval) + " . in FrameProcessorController.cpp#183");
             };
         } else {
             LOG4CXX_ERROR(logger_, "Control thread got unexpected message: " << ctrlMsgEncoded);
@@ -431,7 +429,7 @@ void FrameProcessorController::configure(OdinData::IpcMessage& config, OdinData:
         OdinData::IpcMessage pluginConfig(
             config.get_param<const rapidjson::Value&>(FrameProcessorController::CONFIG_PLUGIN)
         );
-        this->configurePlugin(pluginConfig);
+        this->configurePlugin(pluginConfig, reply);
     }
 
     // Check if we are being passed the shared memory configuration
@@ -664,7 +662,7 @@ void FrameProcessorController::resetStatistics(OdinData::IpcMessage& reply)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config)
+void FrameProcessorController::configurePlugin(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
 {
     // Check if we are being asked to load a plugin
     if (config.has_param(FrameProcessorController::CONFIG_PLUGIN_LOAD)) {
@@ -983,7 +981,7 @@ void FrameProcessorController::setupControlInterface(const std::string& ctrlEndp
     }
 
     // Add the control channel to the reactor
-    reactor_->register_channel(ctrlChannel_, boost::bind(&FrameProcessorController::handleCtrlChannel, this));
+    reactor_->register_channel(ctrlChannel_, [this] { handleCtrlChannel(); });
 }
 
 /** Close the control interface.
@@ -1011,7 +1009,7 @@ void FrameProcessorController::setupMetaRxInterface()
     }
 
     // Add the control channel to the reactor
-    reactor_->register_channel(metaRxChannel_, boost::bind(&FrameProcessorController::handleMetaRxChannel, this));
+    reactor_->register_channel(metaRxChannel_, [this] { handleMetaRxChannel(); });
 }
 
 void FrameProcessorController::closeMetaRxInterface()
@@ -1062,7 +1060,9 @@ void FrameProcessorController::runIpcService(void)
 
     // Create the reactor
     reactor_ = boost::shared_ptr<OdinData::IpcReactor>(new OdinData::IpcReactor());
-    reactor_->register_timer(1000, 0, boost::bind(&FrameProcessorController::tickTimer, this));
+
+    // Add the tick timer to the reactor
+    reactor_->register_timer(1000, 0, [this] { tickTimer(); });
 
     // Set thread state to running, allows constructor to return
     threadRunning_ = true;

--- a/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -27,10 +27,7 @@ FrameProcessorPlugin::FrameProcessorPlugin() :
 /**
  * Destructor
  */
-FrameProcessorPlugin::~FrameProcessorPlugin()
-{
-    // TODO Auto-generated destructor stub
-}
+FrameProcessorPlugin::~FrameProcessorPlugin() = default;
 
 /**
  * Set the name of this plugin

--- a/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
+++ b/cpp/frameProcessor/src/FrameProcessorPlugin.cpp
@@ -152,7 +152,7 @@ std::vector<std::string> FrameProcessorPlugin::get_warnings()
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void FrameProcessorPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void FrameProcessorPlugin::configure(OdinData::IpcMessage& /* config */, OdinData::IpcMessage& /* reply */)
 {
     // Default method simply does nothing
 }
@@ -164,7 +164,7 @@ void FrameProcessorPlugin::configure(OdinData::IpcMessage& config, OdinData::Ipc
  *
  * \param[out] reply - Response IpcMessage with current configuration.
  */
-void FrameProcessorPlugin::requestConfiguration(OdinData::IpcMessage& reply)
+void FrameProcessorPlugin::requestConfiguration(OdinData::IpcMessage& /* reply */)
 {
     // Default method simply does nothing
 }
@@ -210,7 +210,7 @@ std::vector<std::string> FrameProcessorPlugin::requestCommands()
  *
  * \param[out] status - Reference to an IpcMessage value to store the status.
  */
-void FrameProcessorPlugin::status(OdinData::IpcMessage& status)
+void FrameProcessorPlugin::status(OdinData::IpcMessage& /* status */)
 {
     // Default method simply does nothing
 }

--- a/cpp/frameProcessor/src/GapFillPlugin.cpp
+++ b/cpp/frameProcessor/src/GapFillPlugin.cpp
@@ -201,7 +201,7 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };

--- a/cpp/frameProcessor/src/GapFillPlugin.cpp
+++ b/cpp/frameProcessor/src/GapFillPlugin.cpp
@@ -124,12 +124,12 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
     dimensions_t frame_dimensions = frame->get_meta_data().get_dimensions();
 
     int img_x = grid_[1] * chip_[1];
-    for (int index = 0; index <= grid_[1]; index++) {
+    for (uint32_t index = 0; index <= grid_[1]; index++) {
         img_x += gaps_x_[index];
     }
     LOG4CXX_TRACE(logger_, "New image width: " << img_x);
     int img_y = grid_[0] * chip_[0];
-    for (int index = 0; index <= grid_[0]; index++) {
+    for (uint32_t index = 0; index <= grid_[0]; index++) {
         img_y += gaps_y_[index];
     }
     LOG4CXX_TRACE(logger_, "New image height: " << img_y);
@@ -142,15 +142,15 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
 
     // Loop over the y grid
     int current_offset_y = 0;
-    for (int y_index = 0; y_index < grid_[0]; y_index++) {
+    for (uint32_t y_index = 0; y_index < grid_[0]; y_index++) {
         current_offset_y += gaps_y_[y_index];
         // Loop over the individual y rows for the grid item
-        for (int y_row = 0; y_row < chip_[0]; y_row++) {
+        for (uint32_t y_row = 0; y_row < chip_[0]; y_row++) {
             int current_offset_x = 0;
             int current_src_row = (y_index * chip_[0]) + y_row;
             int current_dest_row = current_src_row + current_offset_y;
             // Loop over the x grid
-            for (int x_index = 0; x_index < grid_[1]; x_index++) {
+            for (uint32_t x_index = 0; x_index < grid_[1]; x_index++) {
                 // Calculate the current total x gap in pixels
                 current_offset_x += gaps_x_[x_index];
 
@@ -307,16 +307,16 @@ std::string GapFillPlugin::get_version_long()
  */
 void GapFillPlugin::requestConfiguration(OdinData::IpcMessage& reply)
 {
-    for (int index = 0; index < grid_.size(); index++) {
+    for (uint32_t index = 0; index < grid_.size(); index++) {
         reply.set_param(get_name() + '/' + CONFIG_GRID_SIZE + "[]", grid_[index]);
     }
-    for (int index = 0; index < chip_.size(); index++) {
+    for (uint32_t index = 0; index < chip_.size(); index++) {
         reply.set_param(get_name() + '/' + CONFIG_CHIP_SIZE + "[]", chip_[index]);
     }
-    for (int index = 0; index < gaps_x_.size(); index++) {
+    for (uint32_t index = 0; index < gaps_x_.size(); index++) {
         reply.set_param(get_name() + '/' + CONFIG_GRID_X_GAPS + "[]", gaps_x_[index]);
     }
-    for (int index = 0; index < gaps_y_.size(); index++) {
+    for (uint32_t index = 0; index < gaps_y_.size(); index++) {
         reply.set_param(get_name() + '/' + CONFIG_GRID_Y_GAPS + "[]", gaps_y_[index]);
     }
 }

--- a/cpp/frameProcessor/src/GapFillPlugin.cpp
+++ b/cpp/frameProcessor/src/GapFillPlugin.cpp
@@ -121,12 +121,12 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
     dimensions_t frame_dimensions = frame->get_meta_data().get_dimensions();
 
     int img_x = grid_[1] * chip_[1];
-    for (int index = 0; index <= grid_[1]; index++) {
+    for (uint32_t index = 0; index <= grid_[1]; index++) {
         img_x += gaps_x_[index];
     }
     LOG4CXX_TRACE(logger_, "New image width: " << img_x);
     int img_y = grid_[0] * chip_[0];
-    for (int index = 0; index <= grid_[0]; index++) {
+    for (uint32_t index = 0; index <= grid_[0]; index++) {
         img_y += gaps_y_[index];
     }
     LOG4CXX_TRACE(logger_, "New image height: " << img_y);
@@ -139,15 +139,15 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
 
     // Loop over the y grid
     int current_offset_y = 0;
-    for (int y_index = 0; y_index < grid_[0]; y_index++) {
+    for (uint32_t y_index = 0; y_index < grid_[0]; y_index++) {
         current_offset_y += gaps_y_[y_index];
         // Loop over the individual y rows for the grid item
-        for (int y_row = 0; y_row < chip_[0]; y_row++) {
+        for (uint32_t y_row = 0; y_row < chip_[0]; y_row++) {
             int current_offset_x = 0;
             int current_src_row = (y_index * chip_[0]) + y_row;
             int current_dest_row = current_src_row + current_offset_y;
             // Loop over the x grid
-            for (int x_index = 0; x_index < grid_[1]; x_index++) {
+            for (uint32_t x_index = 0; x_index < grid_[1]; x_index++) {
                 // Calculate the current total x gap in pixels
                 current_offset_x += gaps_x_[x_index];
 
@@ -198,7 +198,7 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };

--- a/cpp/frameProcessor/src/GapFillPlugin.cpp
+++ b/cpp/frameProcessor/src/GapFillPlugin.cpp
@@ -33,10 +33,7 @@ GapFillPlugin::GapFillPlugin()
     LOG4CXX_INFO(logger_, "GapFillPlugin version " << this->get_version_long() << " loaded");
 }
 
-GapFillPlugin::~GapFillPlugin()
-{
-    // Nothing to do in the destructor
-}
+GapFillPlugin::~GapFillPlugin() = default;
 
 /**
  * Process received frame.
@@ -124,12 +121,12 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
     dimensions_t frame_dimensions = frame->get_meta_data().get_dimensions();
 
     int img_x = grid_[1] * chip_[1];
-    for (uint32_t index = 0; index <= grid_[1]; index++) {
+    for (int index = 0; index <= grid_[1]; index++) {
         img_x += gaps_x_[index];
     }
     LOG4CXX_TRACE(logger_, "New image width: " << img_x);
     int img_y = grid_[0] * chip_[0];
-    for (uint32_t index = 0; index <= grid_[0]; index++) {
+    for (int index = 0; index <= grid_[0]; index++) {
         img_y += gaps_y_[index];
     }
     LOG4CXX_TRACE(logger_, "New image height: " << img_y);
@@ -142,15 +139,15 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
 
     // Loop over the y grid
     int current_offset_y = 0;
-    for (uint32_t y_index = 0; y_index < grid_[0]; y_index++) {
+    for (int y_index = 0; y_index < grid_[0]; y_index++) {
         current_offset_y += gaps_y_[y_index];
         // Loop over the individual y rows for the grid item
-        for (uint32_t y_row = 0; y_row < chip_[0]; y_row++) {
+        for (int y_row = 0; y_row < chip_[0]; y_row++) {
             int current_offset_x = 0;
             int current_src_row = (y_index * chip_[0]) + y_row;
             int current_dest_row = current_src_row + current_offset_y;
             // Loop over the x grid
-            for (uint32_t x_index = 0; x_index < grid_[1]; x_index++) {
+            for (int x_index = 0; x_index < grid_[1]; x_index++) {
                 // Calculate the current total x gap in pixels
                 current_offset_x += gaps_x_[x_index];
 
@@ -201,7 +198,7 @@ boost::shared_ptr<Frame> GapFillPlugin::insert_gaps(boost::shared_ptr<Frame> fra
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
+void GapFillPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };
@@ -307,17 +304,17 @@ std::string GapFillPlugin::get_version_long()
  */
 void GapFillPlugin::requestConfiguration(OdinData::IpcMessage& reply)
 {
-    for (uint32_t index = 0; index < grid_.size(); index++) {
-        reply.set_param(get_name() + '/' + CONFIG_GRID_SIZE + "[]", grid_[index]);
+    for (int index : grid_) {
+        reply.set_param(get_name() + '/' + CONFIG_GRID_SIZE + "[]", index);
     }
-    for (uint32_t index = 0; index < chip_.size(); index++) {
-        reply.set_param(get_name() + '/' + CONFIG_CHIP_SIZE + "[]", chip_[index]);
+    for (int index : chip_) {
+        reply.set_param(get_name() + '/' + CONFIG_CHIP_SIZE + "[]", index);
     }
-    for (uint32_t index = 0; index < gaps_x_.size(); index++) {
-        reply.set_param(get_name() + '/' + CONFIG_GRID_X_GAPS + "[]", gaps_x_[index]);
+    for (int index : gaps_x_) {
+        reply.set_param(get_name() + '/' + CONFIG_GRID_X_GAPS + "[]", index);
     }
-    for (uint32_t index = 0; index < gaps_y_.size(); index++) {
-        reply.set_param(get_name() + '/' + CONFIG_GRID_Y_GAPS + "[]", gaps_y_[index]);
+    for (int index : gaps_y_) {
+        reply.set_param(get_name() + '/' + CONFIG_GRID_Y_GAPS + "[]", index);
     }
 }
 

--- a/cpp/frameProcessor/src/HDF5File.cpp
+++ b/cpp/frameProcessor/src/HDF5File.cpp
@@ -104,7 +104,7 @@ void HDF5File::handle_h5_error(
     throw std::runtime_error(error.str());
 }
 
-void HDF5File::hdf_error_handler(unsigned n, const H5E_error2_t* err_desc)
+void HDF5File::hdf_error_handler(unsigned /* n */, const H5E_error2_t* err_desc)
 {
     hdf5_error_flag_ = true;
     hdf5_errors_.push_back(*err_desc);

--- a/cpp/frameProcessor/src/HDF5File.cpp
+++ b/cpp/frameProcessor/src/HDF5File.cpp
@@ -28,11 +28,11 @@ herr_t hdf5_error_cb(unsigned n, const H5E_error2_t* err_desc, void* client_data
 
 HDF5File::HDF5File(const HDF5ErrorDefinition_t& hdf5_error_definition) :
     hdf5_file_id_(-1),
-    param_memspace_(-1),
     hdf5_error_flag_(false),
     file_index_(0),
     use_earliest_version_(false),
     unlimited_(false),
+    param_memspace_(-1),
     watchdog_timer_(hdf5_error_definition.callback),
     hdf5_error_definition_(hdf5_error_definition)
 {
@@ -315,7 +315,6 @@ void HDF5File::write_parameter(const Frame& frame, DatasetDefinition dataset_def
     std::lock_guard<std::mutex> lock { mutex_ };
 
     void* data_ptr;
-    size_t size = 0;
     uint8_t u8value = 0;
     uint16_t u16value = 0;
     uint32_t u32value = 0;
@@ -327,32 +326,26 @@ void HDF5File::write_parameter(const Frame& frame, DatasetDefinition dataset_def
     case raw_8bit:
         u8value = frame.get_meta_data().get_parameter<uint8_t>(dataset_definition.name);
         data_ptr = &u8value;
-        size = sizeof(uint8_t);
         break;
     case raw_16bit:
         u16value = frame.get_meta_data().get_parameter<uint16_t>(dataset_definition.name);
         data_ptr = &u16value;
-        size = sizeof(uint16_t);
         break;
     case raw_32bit:
         u32value = frame.get_meta_data().get_parameter<uint32_t>(dataset_definition.name);
         data_ptr = &u32value;
-        size = sizeof(uint32_t);
         break;
     case raw_64bit:
         u64value = frame.get_meta_data().get_parameter<uint64_t>(dataset_definition.name);
         data_ptr = &u64value;
-        size = sizeof(uint64_t);
         break;
     case raw_float:
         f32value = frame.get_meta_data().get_parameter<float>(dataset_definition.name);
         data_ptr = &f32value;
-        size = sizeof(float);
         break;
     default:
         u16value = frame.get_meta_data().get_parameter<uint16_t>(dataset_definition.name);
         data_ptr = &u16value;
-        size = sizeof(uint16_t);
         break;
     }
 
@@ -470,7 +463,7 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
     /* Enable chunking  */
     std::stringstream ss;
     ss << "Chunking = " << chunk_dims[0];
-    for (int index = 1; index < chunk_dims.size(); index++) {
+    for (uint32_t index = 1; index < chunk_dims.size(); index++) {
         ss << "," << chunk_dims[index];
     }
     LOG4CXX_DEBUG_LEVEL(1, logger_, ss.str());

--- a/cpp/frameProcessor/src/HDF5File.cpp
+++ b/cpp/frameProcessor/src/HDF5File.cpp
@@ -40,7 +40,7 @@ HDF5File::HDF5File(const HDF5ErrorDefinition_t& hdf5_error_definition) :
     this->logger_ = Logger::getLogger("FP.HDF5File");
     LOG4CXX_TRACE(logger_, "HDF5File constructor.");
     if (!hdf_initialised) {
-        ensure_h5_result(H5Eset_auto2(H5E_DEFAULT, NULL, NULL), "H5Eset_auto2 failed");
+        ensure_h5_result(H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr), "H5Eset_auto2 failed");
         ensure_h5_result(H5Ewalk2(H5E_DEFAULT, H5E_WALK_DOWNWARD, hdf5_error_cb, this), "H5Ewalk2 failed");
         hdf_initialised = true;
     }
@@ -191,7 +191,7 @@ size_t HDF5File::create_file(
 
     // Create the memspace for writing parameter datasets
     hsize_t elementSize[1] = { 1 };
-    param_memspace_ = H5Screate_simple(1, elementSize, NULL);
+    param_memspace_ = H5Screate_simple(1, elementSize, nullptr);
     ensure_h5_result(param_memspace_, "Failed to create parameter dataspace");
 
     file_index_ = file_index;
@@ -369,7 +369,7 @@ void HDF5File::write_parameter(const Frame& frame, DatasetDefinition dataset_def
 
     // Select the hyperslab
     ensure_h5_result(
-        H5Sselect_hyperslab(fspace, H5S_SELECT_SET, &offset.front(), NULL, elementSize, NULL),
+        H5Sselect_hyperslab(fspace, H5S_SELECT_SET, &offset.front(), nullptr, elementSize, nullptr),
         "H5Sselect_hyperslab failed"
     );
 
@@ -452,7 +452,7 @@ void HDF5File::create_dataset(const DatasetDefinition& definition, int low_index
         // Create a fixed size dataspace with the given dimensions
         LOG4CXX_DEBUG_LEVEL(1, logger_, "Creating fixed size dataspace");
         dset_dims[0] = definition.num_frames;
-        dataspace = H5Screate_simple(dset_dims.size(), &dset_dims.front(), NULL);
+        dataspace = H5Screate_simple(dset_dims.size(), &dset_dims.front(), nullptr);
         // Limit outermost chunk dimension to maximum dataset size (H5Dchunk.c:891 [1.10.5])
         if (chunk_dims[0] > dset_dims[0]) {
             chunk_dims[0] = dset_dims[0];

--- a/cpp/frameProcessor/src/IFrameCallback.cpp
+++ b/cpp/frameProcessor/src/IFrameCallback.cpp
@@ -15,7 +15,7 @@ namespace FrameProcessor {
  * The constructor creates the new WorkQueue object.
  */
 IFrameCallback::IFrameCallback() :
-    thread_(0),
+    thread_(nullptr),
     run_(false),
     working_(false)
 {
@@ -26,9 +26,7 @@ IFrameCallback::IFrameCallback() :
 /**
  * Destructor
  */
-IFrameCallback::~IFrameCallback()
-{
-}
+IFrameCallback::~IFrameCallback() = default;
 
 /** Return the pointer to the WorkQueue.
  *

--- a/cpp/frameProcessor/src/LiveViewPlugin.cpp
+++ b/cpp/frameProcessor/src/LiveViewPlugin.cpp
@@ -28,9 +28,9 @@ const std::string LiveViewPlugin::CONFIG_TAGGED_FILTER_NAME = "filter_tagged";
  * Constructor for this class. Sets up ZMQ pub socket and other default values for the config
  */
 LiveViewPlugin::LiveViewPlugin() :
-    time_last_frame_(boost::posix_time::min_date_time),
     publish_socket_(ZMQ_PUB),
-    is_bound_(false)
+    is_bound_(false),
+    time_last_frame_(boost::posix_time::min_date_time)
 {
     logger_ = Logger::getLogger("FP.LiveViewPlugin");
     LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");
@@ -79,8 +79,8 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
             bool tag_filter_active = !tags_.empty();
             bool is_tagged = false;
             if (tag_filter_active) {
-                for (uint32_t i = 0; i < tags_.size(); i++) {
-                    if (frame->get_meta_data().has_parameter(tags_[i])) {
+                for (const auto& tag : tags_) {
+                    if (frame->get_meta_data().has_parameter(tag)) {
                         is_tagged = true;
                         break;
                     }
@@ -148,7 +148,7 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
+void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };
@@ -243,9 +243,9 @@ void LiveViewPlugin::pass_live_frame(boost::shared_ptr<Frame> frame)
     rapidjson::Value keyTags("tags", document.GetAllocator());
     rapidjson::Value valueTags(rapidjson::kArrayType);
     if (!tags_.empty()) {
-        for (uint32_t i = 0; i < tags_.size(); i++) {
-            if (meta_data.has_parameter(tags_[i])) {
-                rapidjson::Value tagStringVal(tags_[i].c_str(), document.GetAllocator());
+        for (const auto& tag : tags_) {
+            if (meta_data.has_parameter(tag)) {
+                rapidjson::Value tagStringVal(tag.c_str(), document.GetAllocator());
                 valueTags.PushBack(tagStringVal, document.GetAllocator());
             }
         }
@@ -400,7 +400,7 @@ void LiveViewPlugin::set_dataset_name_config(std::string value)
 
     // loop to log datasets
     this->dataset_names_ = "";
-    for (uint32_t i = 0; i < this->dataset_names_.size(); i++) {
+    for (int i = 0; i < this->dataset_names_.size(); i++) {
         this->dataset_names_ += dataset_names[i] + ":";
     }
     LOG4CXX_INFO(logger_, "Setting the datasets allowed to: " << this->dataset_names_);
@@ -414,9 +414,9 @@ void LiveViewPlugin::set_tagged_filter_config(std::string value)
         boost::split(tags_, value, boost::is_any_of(delim));
     }
     std::string tags_string = "";
-    for (uint32_t i = 0; i < tags_.size(); i++) {
-        boost::trim(tags_[i]);
-        tags_string += tags_[i] + ", ";
+    for (auto& tag : tags_) {
+        boost::trim(tag);
+        tags_string += tag + ", ";
     }
     LOG4CXX_INFO(logger_, "Only Displaying images with the following tags: " << tags_string);
 }

--- a/cpp/frameProcessor/src/LiveViewPlugin.cpp
+++ b/cpp/frameProcessor/src/LiveViewPlugin.cpp
@@ -148,7 +148,7 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };

--- a/cpp/frameProcessor/src/LiveViewPlugin.cpp
+++ b/cpp/frameProcessor/src/LiveViewPlugin.cpp
@@ -28,9 +28,9 @@ const std::string LiveViewPlugin::CONFIG_TAGGED_FILTER_NAME = "filter_tagged";
  * Constructor for this class. Sets up ZMQ pub socket and other default values for the config
  */
 LiveViewPlugin::LiveViewPlugin() :
+    time_last_frame_(boost::posix_time::min_date_time),
     publish_socket_(ZMQ_PUB),
-    is_bound_(false),
-    time_last_frame_(boost::posix_time::min_date_time)
+    is_bound_(false)
 {
     logger_ = Logger::getLogger("FP.LiveViewPlugin");
     LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");
@@ -148,7 +148,7 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void LiveViewPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };
@@ -400,8 +400,8 @@ void LiveViewPlugin::set_dataset_name_config(std::string value)
 
     // loop to log datasets
     this->dataset_names_ = "";
-    for (int i = 0; i < this->dataset_names_.size(); i++) {
-        this->dataset_names_ += dataset_names[i] + ":";
+    for (const auto& dataset_name : dataset_names) {
+        this->dataset_names_ += dataset_name + ":";
     }
     LOG4CXX_INFO(logger_, "Setting the datasets allowed to: " << this->dataset_names_);
 }

--- a/cpp/frameProcessor/src/LiveViewPlugin.cpp
+++ b/cpp/frameProcessor/src/LiveViewPlugin.cpp
@@ -28,9 +28,9 @@ const std::string LiveViewPlugin::CONFIG_TAGGED_FILTER_NAME = "filter_tagged";
  * Constructor for this class. Sets up ZMQ pub socket and other default values for the config
  */
 LiveViewPlugin::LiveViewPlugin() :
+    time_last_frame_(boost::posix_time::min_date_time),
     publish_socket_(ZMQ_PUB),
-    is_bound_(false),
-    time_last_frame_(boost::posix_time::min_date_time)
+    is_bound_(false)
 {
     logger_ = Logger::getLogger("FP.LiveViewPlugin");
     LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");
@@ -79,7 +79,7 @@ void LiveViewPlugin::process_frame(boost::shared_ptr<Frame> frame)
             bool tag_filter_active = !tags_.empty();
             bool is_tagged = false;
             if (tag_filter_active) {
-                for (int i = 0; i < tags_.size(); i++) {
+                for (uint32_t i = 0; i < tags_.size(); i++) {
                     if (frame->get_meta_data().has_parameter(tags_[i])) {
                         is_tagged = true;
                         break;
@@ -243,7 +243,7 @@ void LiveViewPlugin::pass_live_frame(boost::shared_ptr<Frame> frame)
     rapidjson::Value keyTags("tags", document.GetAllocator());
     rapidjson::Value valueTags(rapidjson::kArrayType);
     if (!tags_.empty()) {
-        for (int i = 0; i < tags_.size(); i++) {
+        for (uint32_t i = 0; i < tags_.size(); i++) {
             if (meta_data.has_parameter(tags_[i])) {
                 rapidjson::Value tagStringVal(tags_[i].c_str(), document.GetAllocator());
                 valueTags.PushBack(tagStringVal, document.GetAllocator());
@@ -400,7 +400,7 @@ void LiveViewPlugin::set_dataset_name_config(std::string value)
 
     // loop to log datasets
     this->dataset_names_ = "";
-    for (int i = 0; i < this->dataset_names_.size(); i++) {
+    for (uint32_t i = 0; i < this->dataset_names_.size(); i++) {
         this->dataset_names_ += dataset_names[i] + ":";
     }
     LOG4CXX_INFO(logger_, "Setting the datasets allowed to: " << this->dataset_names_);
@@ -414,7 +414,7 @@ void LiveViewPlugin::set_tagged_filter_config(std::string value)
         boost::split(tags_, value, boost::is_any_of(delim));
     }
     std::string tags_string = "";
-    for (int i = 0; i < tags_.size(); i++) {
+    for (uint32_t i = 0; i < tags_.size(); i++) {
         boost::trim(tags_[i]);
         tags_string += tags_[i] + ", ";
     }

--- a/cpp/frameProcessor/src/MetaMessagePublisher.cpp
+++ b/cpp/frameProcessor/src/MetaMessagePublisher.cpp
@@ -16,9 +16,7 @@ MetaMessagePublisher::MetaMessagePublisher() :
 {
 }
 
-MetaMessagePublisher::~MetaMessagePublisher()
-{
-}
+MetaMessagePublisher::~MetaMessagePublisher() = default;
 
 void MetaMessagePublisher::connect_meta_channel()
 {

--- a/cpp/frameProcessor/src/OffsetAdjustmentPlugin.cpp
+++ b/cpp/frameProcessor/src/OffsetAdjustmentPlugin.cpp
@@ -51,7 +51,7 @@ void OffsetAdjustmentPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void OffsetAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void OffsetAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         // Check if we are setting the offset adjustment

--- a/cpp/frameProcessor/src/ParameterAdjustmentPlugin.cpp
+++ b/cpp/frameProcessor/src/ParameterAdjustmentPlugin.cpp
@@ -93,33 +93,35 @@ void ParameterAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData
             add_config_param_metadata(PARAMETER_NAME_CONFIG, PMDD::STRINGARR_T, PMDA::READ_WRITE);
 
             if (parameter_names.size() != 0) {
-                for (auto iter = parameter_names.begin(); iter != parameter_names.end(); ++iter) {
-                    OdinData::IpcMessage paramConfig(parameter_config.get_param<const rapidjson::Value&>(*iter));
+                for (auto& parameter_name : parameter_names) {
+                    OdinData::IpcMessage paramConfig(parameter_config.get_param<const rapidjson::Value&>(parameter_name)
+                    );
                     LOG4CXX_INFO(
                         logger_,
                         "Setting adjustment for parameter "
-                            << *iter << " to " << (int64_t)paramConfig.get_param<int64_t>(PARAMETER_ADJUSTMENT_CONFIG)
+                            << parameter_name << " to "
+                            << (int64_t)paramConfig.get_param<int64_t>(PARAMETER_ADJUSTMENT_CONFIG)
                     );
-                    parameter_adjustments_[*iter]
+                    parameter_adjustments_[parameter_name]
                         = (int64_t)paramConfig.get_param<int64_t>(PARAMETER_ADJUSTMENT_CONFIG);
                     add_config_param_metadata(
-                        PARAMETER_NAME_CONFIG + '/' + *iter + '/' + PARAMETER_ADJUSTMENT_CONFIG, PMDD::INT_T,
+                        PARAMETER_NAME_CONFIG + '/' + parameter_name + '/' + PARAMETER_ADJUSTMENT_CONFIG, PMDD::INT_T,
                         PMDA::READ_WRITE
                     );
 
                     if (paramConfig.has_param(PARAMETER_INPUT_CONFIG)) {
                         LOG4CXX_INFO(
                             logger_,
-                            "Setting input for parameter " << *iter << " to "
+                            "Setting input for parameter " << parameter_name << " to "
                                                            << paramConfig.get_param<std::string>(PARAMETER_INPUT_CONFIG)
                         );
-                        parameter_inputs_[*iter] = paramConfig.get_param<std::string>(PARAMETER_INPUT_CONFIG);
+                        parameter_inputs_[parameter_name] = paramConfig.get_param<std::string>(PARAMETER_INPUT_CONFIG);
                         add_config_param_metadata(
-                            PARAMETER_NAME_CONFIG + '/' + *iter + '/' + PARAMETER_INPUT_CONFIG, PMDD::STRING_T,
+                            PARAMETER_NAME_CONFIG + '/' + parameter_name + '/' + PARAMETER_INPUT_CONFIG, PMDD::STRING_T,
                             PMDA::READ_WRITE
                         );
                     } else {
-                        parameter_inputs_[*iter] = "";
+                        parameter_inputs_[parameter_name] = "";
                     }
                 }
             } else {

--- a/cpp/frameProcessor/src/ParameterAdjustmentPlugin.cpp
+++ b/cpp/frameProcessor/src/ParameterAdjustmentPlugin.cpp
@@ -82,7 +82,7 @@ void ParameterAdjustmentPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void ParameterAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void ParameterAdjustmentPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> guard { mutex_ };

--- a/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
+++ b/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
@@ -94,7 +94,7 @@ void ParameterPublishPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * \param[in] config - IpcMessage containing configuration data.
  * \param[out] reply - Response IpcMessage.
  */
-void ParameterPublishPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void ParameterPublishPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     try {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
+++ b/cpp/frameProcessor/src/ParameterPublishPlugin.cpp
@@ -16,8 +16,8 @@ const std::string ParameterPublishPlugin::DATA_PARAMETERS = "parameters";
  * The constructor sets up logging used within the class.
  */
 ParameterPublishPlugin::ParameterPublishPlugin() :
-    publish_channel_(ZMQ_PUB),
-    channel_endpoint_("")
+    channel_endpoint_(""),
+    publish_channel_(ZMQ_PUB)
 {
     // Setup logging for the class
     logger_ = Logger::getLogger("FP.ParameterPublishPlugin");

--- a/cpp/frameProcessor/src/RawFileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/RawFileWriterPlugin.cpp
@@ -68,7 +68,7 @@ void RawFileWriterPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * @param config
  * @param reply
  */
-void RawFileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+void RawFileWriterPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& /* reply */)
 {
     // Protect this method
     std::lock_guard<std::mutex> lock { mutex_ };

--- a/cpp/frameProcessor/src/RawFileWriterPlugin.cpp
+++ b/cpp/frameProcessor/src/RawFileWriterPlugin.cpp
@@ -16,9 +16,9 @@ const std::string RawFileWriterPlugin::CONFIG_ENABLED = "writing_enabled";
 const std::string RawFileWriterPlugin::STATUS_DROPPED_FRAMES = "dropped_frames";
 
 RawFileWriterPlugin::RawFileWriterPlugin() :
+    enabled_ { false },
     file_path_ { "" },
-    dropped_frames_ { 0 },
-    enabled_ { false }
+    dropped_frames_ { 0 }
 {
     // Setup logging for the class
     logger_ = Logger::getLogger("FP.RawFileWriterPlugin");

--- a/cpp/frameProcessor/src/SharedMemoryController.cpp
+++ b/cpp/frameProcessor/src/SharedMemoryController.cpp
@@ -55,7 +55,7 @@ SharedMemoryController::SharedMemoryController(
     }
 
     // Add the Frame Ready channel to the reactor
-    reactor_->register_channel(rxChannel_, boost::bind(&SharedMemoryController::handleRxChannel, this));
+    reactor_->register_channel(rxChannel_, [this] { handleRxChannel(); });
 
     // Now connect the frame release response channel
     try {
@@ -132,7 +132,7 @@ void SharedMemoryController::requestSharedBufferConfig(const bool deferred)
 {
     if (deferred) {
         LOG4CXX_DEBUG_LEVEL(1, logger_, "Registering timer for deferred shared buffer configuration request");
-        reactor_->register_timer(1000, 1, boost::bind(&SharedMemoryController::requestSharedBufferConfig, this, false));
+        reactor_->register_timer(1000, 1, [this] { requestSharedBufferConfig(false); });
         sharedBufferConfigRequestDeferred_ = true;
     } else {
         // If this is being called by a deferred request timer but the shared buffer has been configured in the

--- a/cpp/frameProcessor/src/WatchdogTimer.cpp
+++ b/cpp/frameProcessor/src/WatchdogTimer.cpp
@@ -15,12 +15,12 @@
 namespace FrameProcessor {
 
 WatchdogTimer::WatchdogTimer(const boost::function<void(const std::string&)>& timeout_callback) :
-    worker_thread_running_(false),
     worker_thread_(boost::bind(&WatchdogTimer::run, this)),
-    timeout_callback_(timeout_callback),
+    worker_thread_running_(false),
     timer_id_(0),
     is_valid_id_(false),
-    ticks_(0)
+    ticks_(0),
+    timeout_callback_(timeout_callback)
 {
     this->logger_ = Logger::getLogger("FP.WatchdogTimer");
 

--- a/cpp/frameProcessor/src/WatchdogTimer.cpp
+++ b/cpp/frameProcessor/src/WatchdogTimer.cpp
@@ -15,7 +15,7 @@
 namespace FrameProcessor {
 
 WatchdogTimer::WatchdogTimer(const boost::function<void(const std::string&)>& timeout_callback) :
-    worker_thread_(boost::bind(&WatchdogTimer::run, this)),
+    worker_thread_([this] { run(); }),
     worker_thread_running_(false),
     timer_id_(0),
     is_valid_id_(false),
@@ -58,7 +58,7 @@ void WatchdogTimer::start_timer(const std::string& function_name, unsigned int w
         timer_id_ = reactor_.register_timer(
             watchdog_timeout_ms, 1,
             // Bind member function to this instance with function_name argument
-            boost::bind(&WatchdogTimer::call_timeout_callback, this, function_name)
+            [this, function_name] { call_timeout_callback(function_name); }
         );
         is_valid_id_ = true;
     }
@@ -106,7 +106,7 @@ void WatchdogTimer::run()
     worker_thread_running_ = true;
 
     // Register a repeating timer to keep the reactor alive and check for shutdown every millisecond
-    reactor_.register_timer(1, 0, boost::bind(&WatchdogTimer::heartbeat, this));
+    reactor_.register_timer(1, 0, [this] { heartbeat(); });
     reactor_.run();
 }
 

--- a/cpp/frameProcessor/test/DummyUDPProcessPluginTest.cpp
+++ b/cpp/frameProcessor/test/DummyUDPProcessPluginTest.cpp
@@ -23,9 +23,7 @@ public:
         dummy_plugin.set_name("dummy");
     }
 
-    ~DummyUDPProcessPluginTestFixture()
-    {
-    }
+    ~DummyUDPProcessPluginTestFixture() = default;
 
     FrameProcessor::DummyUDPProcessPlugin dummy_plugin;
 };

--- a/cpp/frameProcessor/test/Fixtures.h
+++ b/cpp/frameProcessor/test/Fixtures.h
@@ -33,10 +33,7 @@ public:
         set_debug_level(3);
         metaRxChannel_.bind("inproc://meta_rx");
     }
-    ~GlobalConfig() {
-        // std::cout << "GlobalConfig constructor" << std::endl;
-        // delete consoleAppender;
-    };
+    ~GlobalConfig() = default;
 
 private:
     ConsoleAppender* consoleAppender;
@@ -93,11 +90,9 @@ public:
         hdf5_error_definition.write_duration = 1;
         hdf5_error_definition.flush_duration = 2;
         hdf5_error_definition.close_duration = 3;
-        hdf5_error_definition.callback = boost::bind(&dummy_callback, _1);
+        hdf5_error_definition.callback = [](const std::string& message) { dummy_callback(message); };
     }
-    ~FileWriterPluginTestFixture()
-    {
-    }
+    ~FileWriterPluginTestFixture() = default;
     boost::shared_ptr<FrameProcessor::DataBlockFrame> frame;
     std::vector<boost::shared_ptr<FrameProcessor::DataBlockFrame>> frames;
     FrameProcessor::HDF5ErrorDefinition_t hdf5_error_definition;

--- a/cpp/frameProcessor/test/Fixtures.h
+++ b/cpp/frameProcessor/test/Fixtures.h
@@ -43,7 +43,7 @@ private:
     OdinData::IpcChannel metaRxChannel_;
 };
 
-void dummy_callback(const std::string& msg)
+void dummy_callback(const std::string& /* msg */)
 {
 }
 

--- a/cpp/frameProcessor/test/GapFillPluginTest.cpp
+++ b/cpp/frameProcessor/test/GapFillPluginTest.cpp
@@ -52,9 +52,7 @@ public:
         );
     }
 
-    ~GapFillPluginTestFixture()
-    {
-    }
+    ~GapFillPluginTestFixture() = default;
 
     boost::shared_ptr<FrameProcessor::Frame> frame;
     boost::shared_ptr<FrameProcessor::Frame> frame_2;

--- a/cpp/frameProcessor/test/GapFillPluginTest.cpp
+++ b/cpp/frameProcessor/test/GapFillPluginTest.cpp
@@ -138,8 +138,8 @@ BOOST_AUTO_TEST_CASE(GapFillPlugin_process_frame)
     BOOST_CHECK_EQUAL(gap_frame->get_meta_data().get_dimensions()[0], 9);
     BOOST_CHECK_EQUAL(gap_frame->get_meta_data().get_dimensions()[1], 13);
     int index = 0;
-    for (int y = 0; y < gap_frame->get_meta_data().get_dimensions()[0]; y++) {
-        for (int x = 0; x < gap_frame->get_meta_data().get_dimensions()[1]; x++) {
+    for (uint32_t y = 0; y < gap_frame->get_meta_data().get_dimensions()[0]; y++) {
+        for (uint32_t x = 0; x < gap_frame->get_meta_data().get_dimensions()[1]; x++) {
             BOOST_CHECK_EQUAL(ptr[index], gap_img[index]);
             index++;
         }
@@ -172,8 +172,8 @@ BOOST_AUTO_TEST_CASE(GapFillPlugin_process_frame)
     BOOST_CHECK_EQUAL(gap_frame_2->get_meta_data().get_dimensions()[0], 7);
     BOOST_CHECK_EQUAL(gap_frame_2->get_meta_data().get_dimensions()[1], 7);
     index = 0;
-    for (int y = 0; y < gap_frame_2->get_meta_data().get_dimensions()[0]; y++) {
-        for (int x = 0; x < gap_frame_2->get_meta_data().get_dimensions()[1]; x++) {
+    for (uint32_t y = 0; y < gap_frame_2->get_meta_data().get_dimensions()[0]; y++) {
+        for (uint32_t x = 0; x < gap_frame_2->get_meta_data().get_dimensions()[1]; x++) {
             BOOST_CHECK_EQUAL(ptr[index], gap_img_2[index]);
             index++;
         }

--- a/cpp/frameProcessor/test/LiveViewPluginTest.cpp
+++ b/cpp/frameProcessor/test/LiveViewPluginTest.cpp
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(LiveViewDownscaleTest)
     BOOST_CHECK_NO_THROW(cfg.set_param(FrameProcessor::LiveViewPlugin::CONFIG_FRAME_FREQ, 2));
     BOOST_CHECK_NO_THROW(plugin.configure(cfg, reply));
     // process all frames. with a downscale factor of 2, this should return all the even numbered frames.
-    for (int i = 0; i < frames.size(); i++) {
+    for (uint32_t i = 0; i < frames.size(); i++) {
         BOOST_REQUIRE_NO_THROW(plugin.process_frame(frames[i]));
     }
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(LiveViewDatasetFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv()); // clear any extra data from the above while loop
     }
 
-    for (int i = 0; i < frames.size(); i++) {
+    for (uint32_t i = 0; i < frames.size(); i++) {
         BOOST_CHECK_NO_THROW(plugin.process_frame(frames[i]));
     }
 
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(LiveViewDatasetFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv_raw(pbuf)
         ); // we dont need the data for this test but still need to read from the socket to clear it from the queue
     }
-    for (int i = 0; i < dataset_processed_frames.size(); i++) {
+    for (uint32_t i = 0; i < dataset_processed_frames.size(); i++) {
         BOOST_REQUIRE_NO_THROW(doc.Parse(dataset_processed_frames[i].c_str()));
         BOOST_CHECK_EQUAL(
             doc["dataset"].GetString(), "data"
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(LiveViewTagFilterTest)
         recv_socket.recv(); // clear any extra data from the above while loop
     }
 
-    for (int i = 0; i < frames.size(); i++) {
+    for (uint32_t i = 0; i < frames.size(); i++) {
         BOOST_CHECK_NO_THROW(plugin.process_frame(frames[i]));
     }
 
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(LiveViewTagFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv_raw(pbuf)
         ); // we dont need the data for this test but still need to read from the socket to clear it from the queue
     }
-    for (int i = 0; i < tagged_processed_frames.size(); i++) {
+    for (uint32_t i = 0; i < tagged_processed_frames.size(); i++) {
         BOOST_CHECK_NO_THROW(doc.Parse(tagged_processed_frames[i].c_str()));
         BOOST_CHECK_EQUAL(
             doc["tags"][0].GetString(), "test_tag"

--- a/cpp/frameProcessor/test/LiveViewPluginTest.cpp
+++ b/cpp/frameProcessor/test/LiveViewPluginTest.cpp
@@ -231,8 +231,8 @@ BOOST_AUTO_TEST_CASE(LiveViewDownscaleTest)
     BOOST_CHECK_NO_THROW(cfg.set_param(FrameProcessor::LiveViewPlugin::CONFIG_FRAME_FREQ, 2));
     BOOST_CHECK_NO_THROW(plugin.configure(cfg, reply));
     // process all frames. with a downscale factor of 2, this should return all the even numbered frames.
-    for (uint32_t i = 0; i < frames.size(); i++) {
-        BOOST_REQUIRE_NO_THROW(plugin.process_frame(frames[i]));
+    for (const auto& frame : frames) {
+        BOOST_REQUIRE_NO_THROW(plugin.process_frame(frame));
     }
 
     std::vector<std::string> processed_frames;
@@ -261,8 +261,8 @@ BOOST_AUTO_TEST_CASE(LiveViewDatasetFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv()); // clear any extra data from the above while loop
     }
 
-    for (uint32_t i = 0; i < frames.size(); i++) {
-        BOOST_CHECK_NO_THROW(plugin.process_frame(frames[i]));
+    for (const auto& frame : frames) {
+        BOOST_CHECK_NO_THROW(plugin.process_frame(frame));
     }
 
     std::vector<std::string> dataset_processed_frames;
@@ -273,8 +273,8 @@ BOOST_AUTO_TEST_CASE(LiveViewDatasetFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv_raw(pbuf)
         ); // we dont need the data for this test but still need to read from the socket to clear it from the queue
     }
-    for (uint32_t i = 0; i < dataset_processed_frames.size(); i++) {
-        BOOST_REQUIRE_NO_THROW(doc.Parse(dataset_processed_frames[i].c_str()));
+    for (const auto& dataset_processed_frame : dataset_processed_frames) {
+        BOOST_REQUIRE_NO_THROW(doc.Parse(dataset_processed_frame.c_str()));
         BOOST_CHECK_EQUAL(
             doc["dataset"].GetString(), "data"
         ); // check to make sure only "data" frames were passed through
@@ -335,8 +335,8 @@ BOOST_AUTO_TEST_CASE(LiveViewTagFilterTest)
         recv_socket.recv(); // clear any extra data from the above while loop
     }
 
-    for (uint32_t i = 0; i < frames.size(); i++) {
-        BOOST_CHECK_NO_THROW(plugin.process_frame(frames[i]));
+    for (const auto& frame : frames) {
+        BOOST_CHECK_NO_THROW(plugin.process_frame(frame));
     }
 
     std::vector<std::string> tagged_processed_frames;
@@ -347,8 +347,8 @@ BOOST_AUTO_TEST_CASE(LiveViewTagFilterTest)
         BOOST_CHECK_NO_THROW(recv_socket.recv_raw(pbuf)
         ); // we dont need the data for this test but still need to read from the socket to clear it from the queue
     }
-    for (uint32_t i = 0; i < tagged_processed_frames.size(); i++) {
-        BOOST_CHECK_NO_THROW(doc.Parse(tagged_processed_frames[i].c_str()));
+    for (const auto& tagged_processed_frame : tagged_processed_frames) {
+        BOOST_CHECK_NO_THROW(doc.Parse(tagged_processed_frame.c_str()));
         BOOST_CHECK_EQUAL(
             doc["tags"][0].GetString(), "test_tag"
         ); // check to make sure only tagged frames were passed through

--- a/cpp/frameProcessor/test/ParameterPublishPluginTest.cpp
+++ b/cpp/frameProcessor/test/ParameterPublishPluginTest.cpp
@@ -26,8 +26,8 @@ public:
         FrameProcessor::FrameMetaData frame_meta(
             1, "raw", FrameProcessor::raw_64bit, "test", { 3, 4 }, FrameProcessor::no_compression
         );
-        for (size_t i = 0; i < parameters.size(); ++i) {
-            frame_meta.set_parameter<uint64_t>(parameters[i].param, parameters[i].val);
+        for (auto parameter : parameters) {
+            frame_meta.set_parameter<uint64_t>(parameter.param, parameter.val);
         }
         frame = boost::make_shared<FrameProcessor::DataBlockFrame>(frame_meta, static_cast<void*>(img), 24);
         set_debug_level(3);
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_CASE(ParameterPublishPlugin_Publish)
     constexpr const char* inproc_endpoint = "inproc://testcase1";
     listen_ch.subscribe("");
     listen_ch.connect(inproc_endpoint);
-    for (size_t i = 0; i < parameters.size(); ++i) {
-        BOOST_CHECK_NO_THROW(cfg.set_param(FPPP::CONFIG_ADD_PARAMETER, std::string(PPPT::parameters[i].param)));
+    for (auto parameter : parameters) {
+        BOOST_CHECK_NO_THROW(cfg.set_param(FPPP::CONFIG_ADD_PARAMETER, std::string(parameter.param)));
         BOOST_CHECK_NO_THROW(plugin.configure(cfg, reply));
     }
     BOOST_CHECK_NO_THROW(cfg.set_param(FPPP::CONFIG_ENDPOINT, std::string(inproc_endpoint)));
@@ -71,11 +71,9 @@ BOOST_AUTO_TEST_CASE(ParameterPublishPlugin_Publish)
     BOOST_CHECK(d.HasMember(FPPP::DATA_PARAMETERS.c_str()) && d[FPPP::DATA_PARAMETERS.c_str()].IsString());
     rapidjson::Document nested_params;
     BOOST_REQUIRE_NO_THROW(nested_params.Parse(d[FPPP::DATA_PARAMETERS.c_str()].GetString()));
-    for (size_t i = 0; i < parameters.size(); ++i) {
-        BOOST_CHECK(
-            nested_params.HasMember(PPPT::parameters[i].param) && nested_params[PPPT::parameters[i].param].IsInt()
-        );
-        BOOST_CHECK_EQUAL(nested_params[PPPT::parameters[i].param].GetInt(), PPPT::parameters[i].val);
+    for (auto parameter : parameters) {
+        BOOST_CHECK(nested_params.HasMember(parameter.param) && nested_params[parameter.param].IsInt());
+        BOOST_CHECK_EQUAL(nested_params[parameter.param].GetInt(), parameter.val);
     }
 }
 

--- a/cpp/frameProcessor/test/ParameterPublishPluginTest.cpp
+++ b/cpp/frameProcessor/test/ParameterPublishPluginTest.cpp
@@ -50,7 +50,6 @@ BOOST_FIXTURE_TEST_SUITE(ParameterPublishPluginUnitTest, ParameterPublishPluginT
 BOOST_AUTO_TEST_CASE(ParameterPublishPlugin_Publish)
 {
     using FPPP = FrameProcessor::ParameterPublishPlugin;
-    using PPPT = ParameterPublishPluginTestFixture;
     // Configure thresholds
     OdinData::IpcMessage reply;
     OdinData::IpcMessage cfg;

--- a/cpp/frameProcessor/test/RawFileWriterPluginTest.cpp
+++ b/cpp/frameProcessor/test/RawFileWriterPluginTest.cpp
@@ -27,7 +27,7 @@ public:
         rfw_plugin.set_name("rfwplugin");
     }
 
-    static bool is_not_critical(const std::runtime_error& er)
+    static bool is_not_critical(const std::runtime_error& /* er */)
     {
         return true;
     }

--- a/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
@@ -21,28 +21,28 @@ namespace DummyTcpFrameDecoderDefaults {
 class DummyTCPFrameDecoder : public FrameDecoderTCP {
 public:
     DummyTCPFrameDecoder();
-    ~DummyTCPFrameDecoder();
+    ~DummyTCPFrameDecoder() override;
 
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
-    void monitor_buffers(void);
-    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);
+    void monitor_buffers(void) override;
+    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) override;
 
-    void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
-    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
+    void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg) override;
+    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply) override;
 
-    void* get_next_message_buffer(void);
-    size_t get_next_message_size(void) const;
-    FrameDecoder::FrameReceiveState process_message(size_t bytes_received);
+    void* get_next_message_buffer(void) override;
+    size_t get_next_message_size(void) const override;
+    FrameDecoder::FrameReceiveState process_message(size_t bytes_received) override;
 
-    size_t get_frame_buffer_size(void) const;
-    size_t get_frame_header_size(void) const;
+    size_t get_frame_buffer_size(void) const override;
+    size_t get_frame_header_size(void) const override;
 
-    void reset_statistics(void);
+    void reset_statistics(void) override;
 
     void* get_packet_header_buffer(void);
 
@@ -55,7 +55,7 @@ private:
     size_t frames_sent_;
     size_t read_so_far_;
     int current_frame_number_;
-    uint32_t current_frame_buffer_id_;
+    int current_frame_buffer_id_;
     size_t buffer_size_;
     size_t header_size_;
     size_t frame_size_;

--- a/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
@@ -55,7 +55,7 @@ private:
     size_t frames_sent_;
     size_t read_so_far_;
     int current_frame_number_;
-    int current_frame_buffer_id_;
+    uint32_t current_frame_buffer_id_;
     size_t buffer_size_;
     size_t header_size_;
     size_t frame_size_;

--- a/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyTCPFrameDecoder.h
@@ -36,11 +36,11 @@ public:
     void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
 
     void* get_next_message_buffer(void);
-    const size_t get_next_message_size(void) const;
+    size_t get_next_message_size(void) const;
     FrameDecoder::FrameReceiveState process_message(size_t bytes_received);
 
-    const size_t get_frame_buffer_size(void) const;
-    const size_t get_frame_header_size(void) const;
+    size_t get_frame_buffer_size(void) const;
+    size_t get_frame_header_size(void) const;
 
     void reset_statistics(void);
 

--- a/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -40,14 +40,14 @@ public:
     void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
     void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
 
-    const size_t get_frame_buffer_size(void) const;
-    const size_t get_frame_header_size(void) const;
+    size_t get_frame_buffer_size(void) const;
+    size_t get_frame_header_size(void) const;
 
-    inline const bool requires_header_peek(void) const
+    inline bool requires_header_peek(void) const
     {
         return true;
     };
-    const size_t get_packet_header_size(void) const;
+    size_t get_packet_header_size(void) const;
     void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr);
 
     inline const bool trailer_mode(void) const

--- a/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -29,41 +29,42 @@ namespace DummyUdpFrameDecoderDefaults {
 class DummyUDPFrameDecoder : public FrameDecoderUDP {
 public:
     DummyUDPFrameDecoder();
-    ~DummyUDPFrameDecoder();
+    ~DummyUDPFrameDecoder() override;
 
-    int get_version_major();
-    int get_version_minor();
-    int get_version_patch();
-    std::string get_version_short();
-    std::string get_version_long();
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
-    void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
-    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
+    void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg) override;
+    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply) override;
 
-    size_t get_frame_buffer_size(void) const;
-    size_t get_frame_header_size(void) const;
+    size_t get_frame_buffer_size(void) const override;
+    size_t get_frame_header_size(void) const override;
 
-    inline bool requires_header_peek(void) const
+    inline bool requires_header_peek(void) const override
     {
         return true;
     };
-    size_t get_packet_header_size(void) const;
-    void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr);
+    size_t get_packet_header_size(void) const override;
+    void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr) override;
 
     inline bool trailer_mode(void) const
     {
         return false;
     };
 
-    void* get_next_payload_buffer(void) const;
-    size_t get_next_payload_size(void) const;
-    FrameDecoder::FrameReceiveState process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr);
+    void* get_next_payload_buffer(void) const override;
+    size_t get_next_payload_size(void) const override;
+    FrameDecoder::FrameReceiveState
+    process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr) override;
 
-    void monitor_buffers(void);
-    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);
-    void reset_statistics(void);
+    void monitor_buffers(void) override;
+    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) override;
+    void reset_statistics(void) override;
 
-    void* get_packet_header_buffer(void);
+    void* get_packet_header_buffer(void) override;
 
     uint32_t get_frame_number(void) const;
     uint32_t get_packet_number(void) const;
@@ -79,7 +80,7 @@ private:
     boost::shared_ptr<void> current_packet_header_;
     boost::shared_ptr<void> dropped_frame_buffer_;
 
-    uint32_t current_frame_seen_;
+    int current_frame_seen_;
     int current_frame_buffer_id_;
     void* current_frame_buffer_;
     DummyUDP::FrameHeader* current_frame_header_;

--- a/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -50,7 +50,7 @@ public:
     size_t get_packet_header_size(void) const;
     void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr);
 
-    inline const bool trailer_mode(void) const
+    inline bool trailer_mode(void) const
     {
         return false;
     };

--- a/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
+++ b/cpp/frameReceiver/include/DummyUDPFrameDecoder.h
@@ -79,7 +79,7 @@ private:
     boost::shared_ptr<void> current_packet_header_;
     boost::shared_ptr<void> dropped_frame_buffer_;
 
-    int current_frame_seen_;
+    uint32_t current_frame_seen_;
     int current_frame_buffer_id_;
     void* current_frame_buffer_;
     DummyUDP::FrameHeader* current_frame_header_;

--- a/cpp/frameReceiver/include/FrameDecoder.h
+++ b/cpp/frameReceiver/include/FrameDecoder.h
@@ -62,18 +62,18 @@ public:
     virtual void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
     virtual std::vector<std::string> request_commands();
     virtual void execute(const std::string& command, OdinData::IpcMessage& reply);
-    virtual const size_t get_frame_buffer_size(void) const = 0;
-    virtual const size_t get_frame_header_size(void) const = 0;
+    virtual size_t get_frame_buffer_size(void) const = 0;
+    virtual size_t get_frame_header_size(void) const = 0;
 
     void register_buffer_manager(OdinData::SharedBufferManagerPtr buffer_manager);
     void register_frame_ready_callback(FrameReadyCallback callback);
     void push_empty_buffer(int buffer_id);
-    const size_t get_num_empty_buffers(void) const;
-    const size_t get_num_mapped_buffers(void) const;
+    size_t get_num_empty_buffers(void) const;
+    size_t get_num_mapped_buffers(void) const;
     void drop_all_buffers(void);
-    const unsigned int get_frame_timeout_ms(void) const;
-    const unsigned int get_num_frames_timedout(void) const;
-    const unsigned int get_num_frames_dropped(void) const;
+    unsigned int get_frame_timeout_ms(void) const;
+    unsigned int get_num_frames_timedout(void) const;
+    unsigned int get_num_frames_dropped(void) const;
     virtual void monitor_buffers(void) = 0;
     virtual void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg) = 0;
     void version(const std::string param_prefix, OdinData::IpcMessage& status);

--- a/cpp/frameReceiver/include/FrameDecoder.h
+++ b/cpp/frameReceiver/include/FrameDecoder.h
@@ -39,9 +39,9 @@ public:
         OdinData::OdinDataException(what) { };
 };
 
-typedef boost::function<void(int, int)> FrameReadyCallback;
-typedef std::queue<int> EmptyBufferQueue;
-typedef std::map<int, int> FrameBufferMap;
+using FrameReadyCallback = boost::function<void(int, int)>;
+using EmptyBufferQueue = std::queue<int>;
+using FrameBufferMap = std::map<int, int>;
 
 class FrameDecoder : public OdinData::IVersionedObject {
 public:
@@ -55,7 +55,7 @@ public:
 
     FrameDecoder();
 
-    virtual ~FrameDecoder() = 0;
+    ~FrameDecoder() override = 0;
 
     virtual void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
     virtual void init(OdinData::IpcMessage& config_msg);
@@ -96,9 +96,9 @@ protected:
     unsigned int frames_dropped_; //!< Number of frames dropped due to lack of buffers
 };
 
-inline FrameDecoder::~FrameDecoder() { };
+inline FrameDecoder::~FrameDecoder() = default;
 
-typedef boost::shared_ptr<FrameDecoder> FrameDecoderPtr;
+using FrameDecoderPtr = boost::shared_ptr<FrameDecoder>;
 
 } // namespace FrameReceiver
 #endif /* INCLUDE_FRAMEDECODER_H_ */

--- a/cpp/frameReceiver/include/FrameDecoderTCP.h
+++ b/cpp/frameReceiver/include/FrameDecoderTCP.h
@@ -31,7 +31,7 @@ public:
     FrameDecoderTCP() :
         FrameDecoder() { };
 
-    virtual ~FrameDecoderTCP() = 0;
+    ~FrameDecoderTCP() override = 0;
 
     virtual void* get_next_message_buffer(void) = 0;
     virtual size_t get_next_message_size(void) const = 0;
@@ -41,9 +41,9 @@ public:
     void* current_raw_buffer_;
 };
 
-inline FrameDecoderTCP::~FrameDecoderTCP() { };
+inline FrameDecoderTCP::~FrameDecoderTCP() = default;
 
-typedef boost::shared_ptr<FrameDecoderTCP> FrameDecoderTCPPtr;
+using FrameDecoderTCPPtr = boost::shared_ptr<FrameDecoderTCP>;
 
 } // namespace FrameReceiver
 #endif /* INCLUDE_FRAMEDECODER_TCP_H_ */

--- a/cpp/frameReceiver/include/FrameDecoderTCP.h
+++ b/cpp/frameReceiver/include/FrameDecoderTCP.h
@@ -34,7 +34,7 @@ public:
     virtual ~FrameDecoderTCP() = 0;
 
     virtual void* get_next_message_buffer(void) = 0;
-    virtual const size_t get_next_message_size(void) const = 0;
+    virtual size_t get_next_message_size(void) const = 0;
 
     virtual FrameReceiveState process_message(size_t bytes_received) = 0;
 

--- a/cpp/frameReceiver/include/FrameDecoderUDP.h
+++ b/cpp/frameReceiver/include/FrameDecoderUDP.h
@@ -33,9 +33,9 @@ public:
 
     virtual ~FrameDecoderUDP() = 0;
 
-    virtual const bool requires_header_peek(void) const = 0;
+    virtual bool requires_header_peek(void) const = 0;
 
-    virtual const size_t get_packet_header_size(void) const = 0;
+    virtual size_t get_packet_header_size(void) const = 0;
     virtual void* get_packet_header_buffer(void) = 0;
     virtual void process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr) = 0;
 

--- a/cpp/frameReceiver/include/FrameDecoderUDP.h
+++ b/cpp/frameReceiver/include/FrameDecoderUDP.h
@@ -31,7 +31,7 @@ public:
     FrameDecoderUDP() :
         FrameDecoder() { };
 
-    virtual ~FrameDecoderUDP() = 0;
+    ~FrameDecoderUDP() override = 0;
 
     virtual bool requires_header_peek(void) const = 0;
 
@@ -44,9 +44,9 @@ public:
     virtual FrameReceiveState process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr) = 0;
 };
 
-inline FrameDecoderUDP::~FrameDecoderUDP() { };
+inline FrameDecoderUDP::~FrameDecoderUDP() = default;
 
-typedef boost::shared_ptr<FrameDecoderUDP> FrameDecoderUDPPtr;
+using FrameDecoderUDPPtr = boost::shared_ptr<FrameDecoderUDP>;
 
 } // namespace FrameReceiver
 #endif /* INCLUDE_FRAMEDECODER_UDP_H_ */

--- a/cpp/frameReceiver/include/FrameDecoderZMQ.h
+++ b/cpp/frameReceiver/include/FrameDecoderZMQ.h
@@ -31,16 +31,16 @@ public:
     FrameDecoderZMQ() :
         FrameDecoder() { };
 
-    virtual ~FrameDecoderZMQ() = 0;
+    ~FrameDecoderZMQ() override = 0;
 
     virtual void* get_next_message_buffer(void) = 0;
     virtual FrameReceiveState process_message(size_t bytes_received) = 0;
     virtual void frame_meta_data(int meta) = 0;
 };
 
-inline FrameDecoderZMQ::~FrameDecoderZMQ() { };
+inline FrameDecoderZMQ::~FrameDecoderZMQ() = default;
 
-typedef boost::shared_ptr<FrameDecoderZMQ> FrameDecoderZMQPtr;
+using FrameDecoderZMQPtr = boost::shared_ptr<FrameDecoderZMQ>;
 
 } // namespace FrameReceiver
 #endif /* INCLUDE_FRAMEDECODER_ZMQ_H_ */

--- a/cpp/frameReceiver/include/FrameReceiverConfig.h
+++ b/cpp/frameReceiver/include/FrameReceiverConfig.h
@@ -82,7 +82,7 @@ public:
                 = port_list_str.substr(start, (end == std::string::npos) ? std::string::npos : end - start).c_str();
             start = ((end > (std::string::npos - delimiter.size())) ? std::string::npos : end + delimiter.size());
 
-            uint16_t port = static_cast<uint16_t>(strtol(port_str, NULL, 0));
+            uint16_t port = static_cast<uint16_t>(strtol(port_str, nullptr, 0));
             if (port != 0) {
                 port_list.push_back(port);
             }

--- a/cpp/frameReceiver/include/FrameReceiverController.h
+++ b/cpp/frameReceiver/include/FrameReceiverController.h
@@ -98,8 +98,8 @@ private:
 
     bool need_ipc_reconfig_; //!< Flag to signal reconfiguration of IPC channels
     bool need_decoder_reconfig_; //!< Flag to signal reconfiguration of frame decoder
-    bool need_rx_thread_reconfig_; //!< Flag to signal reconfiguration of RX thread
     bool need_buffer_manager_reconfig_; //!< Flag to signal reconfiguration of buffer manager
+    bool need_rx_thread_reconfig_; //!< Flag to signal reconfiguration of RX thread
 
     bool ipc_configured_; //!< Indicates that IPC channels are configured
     bool decoder_configured_; //!< Indicates that the frame decoder is configured

--- a/cpp/frameReceiver/include/FrameReceiverException.h
+++ b/cpp/frameReceiver/include/FrameReceiverException.h
@@ -17,21 +17,21 @@ namespace FrameReceiver {
 class FrameReceiverException : public std::exception {
 public:
     //! Create FrameReceiverException with no message
-    FrameReceiverException(void) throw() :
+    FrameReceiverException(void) noexcept :
         what_("") { };
 
     //! Creates FrameReceiverExcetpion with informational message
-    FrameReceiverException(const std::string what) throw() :
+    FrameReceiverException(const std::string what) noexcept :
         what_(what) { };
 
     //! Returns the content of the informational message
-    virtual const char* what(void) const throw()
+    const char* what(void) const noexcept override
     {
         return what_.c_str();
     };
 
     //! Destructor
-    ~FrameReceiverException(void) throw() { };
+    ~FrameReceiverException(void) noexcept override = default;
 
 private:
     // Member variables

--- a/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
@@ -40,7 +40,7 @@ private:
     void run_specific_service(void) override;
     void cleanup_specific_service(void) override;
 
-    void handle_receive_socket(int socket_fd);
+    void handle_receive_socket(int socket_fd, int recv_port);
 
     LoggerPtr logger_;
     FrameDecoderTCPPtr frame_decoder_;

--- a/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
@@ -40,7 +40,7 @@ private:
     void run_specific_service(void) override;
     void cleanup_specific_service(void) override;
 
-    void handle_receive_socket(int socket_fd, int recv_port);
+    void handle_receive_socket(int socket_fd);
 
     LoggerPtr logger_;
     FrameDecoderTCPPtr frame_decoder_;

--- a/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
@@ -40,7 +40,7 @@ private:
     void run_specific_service(void);
     void cleanup_specific_service(void);
 
-    void handle_receive_socket(int socket_fd, int recv_port);
+    void handle_receive_socket(int socket_fd);
 
     LoggerPtr logger_;
     FrameDecoderTCPPtr frame_decoder_;

--- a/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverTCPRxThread.h
@@ -34,11 +34,11 @@ public:
         FrameDecoderPtr frame_decoder,
         unsigned int tick_period_ms = 100
     );
-    virtual ~FrameReceiverTCPRxThread();
+    ~FrameReceiverTCPRxThread() override;
 
 private:
-    void run_specific_service(void);
-    void cleanup_specific_service(void);
+    void run_specific_service(void) override;
+    void cleanup_specific_service(void) override;
 
     void handle_receive_socket(int socket_fd);
 

--- a/cpp/frameReceiver/include/FrameReceiverUDPRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverUDPRxThread.h
@@ -36,11 +36,11 @@ public:
         FrameDecoderPtr frame_decoder,
         unsigned int tick_period_ms = 100
     );
-    virtual ~FrameReceiverUDPRxThread();
+    ~FrameReceiverUDPRxThread() override;
 
 private:
-    void run_specific_service(void);
-    void cleanup_specific_service(void);
+    void run_specific_service(void) override;
+    void cleanup_specific_service(void) override;
 
     void handle_receive_socket(int socket_fd, int recv_port);
 

--- a/cpp/frameReceiver/include/FrameReceiverZMQRxThread.h
+++ b/cpp/frameReceiver/include/FrameReceiverZMQRxThread.h
@@ -36,11 +36,11 @@ public:
         FrameDecoderPtr frame_decoder,
         unsigned int tick_period_ms = 100
     );
-    virtual ~FrameReceiverZMQRxThread();
+    ~FrameReceiverZMQRxThread() override;
 
 private:
-    void run_specific_service(void);
-    void cleanup_specific_service(void);
+    void run_specific_service(void) override;
+    void cleanup_specific_service(void) override;
 
     void handle_receive_socket();
 

--- a/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
@@ -9,8 +9,8 @@
 #include <algorithm>
 #include <bitset>
 #include <boost/algorithm/string.hpp>
+#include <cstring>
 #include <sstream>
-#include <string.h>
 #include <unistd.h>
 
 using namespace FrameReceiver;
@@ -35,9 +35,7 @@ DummyTCPFrameDecoder::DummyTCPFrameDecoder() :
 }
 
 //! Destructor for DummyTCPFrameDecoder
-DummyTCPFrameDecoder::~DummyTCPFrameDecoder()
-{
-}
+DummyTCPFrameDecoder::~DummyTCPFrameDecoder() = default;
 
 /**
  * Initialises the frame decoder

--- a/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
@@ -102,7 +102,7 @@ void* DummyTCPFrameDecoder::get_next_message_buffer(void)
 //!
 //! \return size of frame buffer in bytes
 //!
-const size_t DummyTCPFrameDecoder::get_frame_buffer_size(void) const
+size_t DummyTCPFrameDecoder::get_frame_buffer_size(void) const
 {
     return buffer_size_;
 }
@@ -112,7 +112,7 @@ const size_t DummyTCPFrameDecoder::get_frame_buffer_size(void) const
 //! This method returns the size of the frame header used by the decoder.
 //!
 //! \return size of the frame header in bytes
-const size_t DummyTCPFrameDecoder::get_frame_header_size(void) const
+size_t DummyTCPFrameDecoder::get_frame_header_size(void) const
 {
     return header_size_;
 }
@@ -138,7 +138,7 @@ FrameDecoder::FrameReceiveState DummyTCPFrameDecoder::process_message(size_t byt
         throw "Not Implemented: Can not handle case when too many bytes received";
 }
 
-const size_t DummyTCPFrameDecoder::get_next_message_size(void) const
+size_t DummyTCPFrameDecoder::get_next_message_size(void) const
 {
     return frame_size_ - read_so_far_;
 }

--- a/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
@@ -84,7 +84,7 @@ void* DummyTCPFrameDecoder::get_next_message_buffer(void)
     // only increment buffer when frame is complete
     if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
         // get id in buffer circularly
-        if (current_frame_buffer_id_ + 1 >= num_buffers_)
+        if (static_cast<unsigned int>(current_frame_buffer_id_ + 1) >= num_buffers_)
             current_frame_buffer_id_ = 0;
         else
             current_frame_buffer_id_++;

--- a/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
@@ -45,7 +45,7 @@ DummyTCPFrameDecoder::~DummyTCPFrameDecoder()
  * \param[in] logger The logger
  * \param[in] config_msg The config parameters to initialise with
  */
-void DummyTCPFrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& config_msg)
+void DummyTCPFrameDecoder::init(LoggerPtr& /* logger */, OdinData::IpcMessage& /* config_msg */)
 {
 }
 

--- a/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyTCPFrameDecoder.cpp
@@ -17,14 +17,14 @@ using namespace FrameReceiver;
 
 DummyTCPFrameDecoder::DummyTCPFrameDecoder() :
     FrameDecoderTCP(),
+    frames_dropped_(0),
+    frames_sent_(0),
+    read_so_far_(0),
     current_frame_number_(DummyTcpFrameDecoderDefaults::frame_number),
     current_frame_buffer_id_(DummyTcpFrameDecoderDefaults::buffer_id),
     header_size_(DummyTcpFrameDecoderDefaults::header_size),
     frame_size_(DummyTcpFrameDecoderDefaults::max_size),
     num_buffers_(DummyTcpFrameDecoderDefaults::num_buffers),
-    frames_dropped_(0),
-    frames_sent_(0),
-    read_so_far_(0),
     receive_state_(FrameDecoder::FrameReceiveStateEmpty)
 {
     this->logger_ = Logger::getLogger("FR.DummyTCPFrameDecoder");

--- a/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -212,7 +212,7 @@ void DummyUDPFrameDecoder::process_packet_header(size_t /* bytes_received */, in
     uint32_t frame_number = get_frame_number();
     uint32_t packet_number = get_packet_number();
 
-    if (frame_number != current_frame_seen_) {
+    if (current_frame_seen_ < 0 || frame_number != static_cast<uint32_t>(current_frame_seen_)) {
         current_frame_seen_ = frame_number;
 
         if (frame_buffer_map_.count(current_frame_seen_) == 0) {

--- a/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -154,7 +154,7 @@ void DummyUDPFrameDecoder::request_configuration(const std::string param_prefix,
 //!
 //! \return size of frame buffer in bytes
 //!
-const size_t DummyUDPFrameDecoder::get_frame_buffer_size(void) const
+size_t DummyUDPFrameDecoder::get_frame_buffer_size(void) const
 {
     size_t frame_buffer_size = get_frame_header_size() + (udp_packets_per_frame_ * udp_packet_size_);
     return frame_buffer_size;
@@ -166,7 +166,7 @@ const size_t DummyUDPFrameDecoder::get_frame_buffer_size(void) const
 //! DummyUDP frame header.
 //!
 //! \return size of the frame header in bytes
-const size_t DummyUDPFrameDecoder::get_frame_header_size(void) const
+size_t DummyUDPFrameDecoder::get_frame_header_size(void) const
 {
     return sizeof(DummyUDP::FrameHeader);
 }
@@ -178,7 +178,7 @@ const size_t DummyUDPFrameDecoder::get_frame_header_size(void) const
 //!
 //! \return size of the packet header in bytes.
 //!
-const size_t DummyUDPFrameDecoder::get_packet_header_size(void) const
+size_t DummyUDPFrameDecoder::get_packet_header_size(void) const
 {
     return sizeof(DummyUDP::PacketHeader);
 }

--- a/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -28,8 +28,8 @@ DummyUDPFrameDecoder::DummyUDPFrameDecoder() :
     status_get_count_(0),
     current_frame_seen_(DummyUDP::default_frame_number),
     current_frame_buffer_id_(DummyUDP::default_frame_number),
-    current_frame_buffer_(0),
-    current_frame_header_(0),
+    current_frame_buffer_(nullptr),
+    current_frame_header_(nullptr),
     num_active_fems_(0),
     dropping_frame_data_(false),
     packets_received_(0),
@@ -46,9 +46,7 @@ DummyUDPFrameDecoder::DummyUDPFrameDecoder() :
 }
 
 //! Destructor for DummyDUPFrameDecoder
-DummyUDPFrameDecoder::~DummyUDPFrameDecoder()
-{
-}
+DummyUDPFrameDecoder::~DummyUDPFrameDecoder() = default;
 
 int DummyUDPFrameDecoder::get_version_major()
 {

--- a/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -88,9 +88,9 @@ void DummyUDPFrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& config_
 {
 
     // Pass the configuration message to the base class decoder
-    FrameDecoderUDP::init(logger_, config_msg);
+    FrameDecoderUDP::init(logger, config_msg);
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Got decoder config message: " << config_msg.encode());
+    LOG4CXX_DEBUG_LEVEL(2, logger, "Got decoder config message: " << config_msg.encode());
 
     // Determine the number of UDP packets per frame if present in the config message, checking that
     // it doesn't exceed the maximum permitted
@@ -207,7 +207,12 @@ void* DummyUDPFrameDecoder::get_packet_header_buffer(void)
 //! \param[in] port - UDP port packet header was received on
 //! \param[in] from_addr - socket address structure with details of source packet
 //!
-void DummyUDPFrameDecoder::process_packet_header(size_t bytes_received, int port, struct sockaddr_in* from_addr)
+void DummyUDPFrameDecoder::process_packet_header
+(
+    size_t /* bytes_received */, 
+    int /* port */, 
+    struct sockaddr_in* /* from_addr */
+)
 {
 
     // Extract fields from the packet header
@@ -339,7 +344,7 @@ size_t DummyUDPFrameDecoder::get_next_payload_size(void) const
 //! \return current frame receive state
 //!
 FrameDecoder::FrameReceiveState
-DummyUDPFrameDecoder::process_packet(size_t bytes_received, int port, struct sockaddr_in* from_addr)
+DummyUDPFrameDecoder::process_packet(size_t /*bytes_received*/, int /* port */, struct sockaddr_in* /* from_addr */)
 {
     FrameDecoder::FrameReceiveState frame_state = FrameDecoder::FrameReceiveStateIncomplete;
 

--- a/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
+++ b/cpp/frameReceiver/src/DummyUDPFrameDecoder.cpp
@@ -207,12 +207,7 @@ void* DummyUDPFrameDecoder::get_packet_header_buffer(void)
 //! \param[in] port - UDP port packet header was received on
 //! \param[in] from_addr - socket address structure with details of source packet
 //!
-void DummyUDPFrameDecoder::process_packet_header
-(
-    size_t /* bytes_received */, 
-    int /* port */, 
-    struct sockaddr_in* /* from_addr */
-)
+void DummyUDPFrameDecoder::process_packet_header(size_t /* bytes_received */, int /* port */, struct sockaddr_in* /* from_addr */)
 {
 
     // Extract fields from the packet header

--- a/cpp/frameReceiver/src/FrameDecoder.cpp
+++ b/cpp/frameReceiver/src/FrameDecoder.cpp
@@ -23,7 +23,7 @@ FrameDecoder::FrameDecoder() :
     frames_dropped_(0) { };
 
 //! This overload is scheduled for deletion; logger is unused.
-void FrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& config_msg)
+void FrameDecoder::init(LoggerPtr& /* logger */, OdinData::IpcMessage& config_msg)
 {
     init(config_msg);
 }

--- a/cpp/frameReceiver/src/FrameDecoder.cpp
+++ b/cpp/frameReceiver/src/FrameDecoder.cpp
@@ -137,7 +137,7 @@ void FrameDecoder::push_empty_buffer(int buffer_id)
 //!
 //! \return number of empty buffers queued
 //!
-const size_t FrameDecoder::get_num_empty_buffers(void) const
+size_t FrameDecoder::get_num_empty_buffers(void) const
 {
     return empty_buffer_queue_.size();
 }
@@ -149,7 +149,7 @@ const size_t FrameDecoder::get_num_empty_buffers(void) const
 //!
 //! \return - number of buffers currently mapped for incoming frames
 //!
-const size_t FrameDecoder::get_num_mapped_buffers(void) const
+size_t FrameDecoder::get_num_mapped_buffers(void) const
 {
     return frame_buffer_map_.size();
 }
@@ -160,7 +160,7 @@ const size_t FrameDecoder::get_num_mapped_buffers(void) const
 //!
 //! \return - current frame timeout in milliseconds
 //!
-const unsigned int FrameDecoder::get_frame_timeout_ms(void) const
+unsigned int FrameDecoder::get_frame_timeout_ms(void) const
 {
     return frame_timeout_ms_;
 }
@@ -173,7 +173,7 @@ const unsigned int FrameDecoder::get_frame_timeout_ms(void) const
 //!
 //! \return - number of frames timed out
 //!
-const unsigned int FrameDecoder::get_num_frames_timedout(void) const
+unsigned int FrameDecoder::get_num_frames_timedout(void) const
 {
     return frames_timedout_;
 }
@@ -185,7 +185,7 @@ const unsigned int FrameDecoder::get_num_frames_timedout(void) const
 //!
 //! \return - number of frames dropped
 //!
-const unsigned int FrameDecoder::get_num_frames_dropped(void) const
+unsigned int FrameDecoder::get_num_frames_dropped(void) const
 {
     return frames_dropped_;
 }

--- a/cpp/frameReceiver/src/FrameReceiverApp.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverApp.cpp
@@ -272,7 +272,7 @@ void FrameReceiverApp::stop(void)
 
 //! Interrupt signal handler
 
-void intHandler(int sig)
+void intHandler(int)
 {
     FrameReceiver::FrameReceiverApp::stop();
 }

--- a/cpp/frameReceiver/src/FrameReceiverApp.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverApp.cpp
@@ -5,9 +5,9 @@
  *      Author: Tim Nicholls, STFC Application Engineering Group
  */
 
+#include <csignal>
 #include <fstream>
 #include <iostream>
-#include <signal.h>
 #include <streambuf>
 #include <string>
 using namespace std;

--- a/cpp/frameReceiver/src/FrameReceiverController.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverController.cpp
@@ -165,7 +165,7 @@ void FrameReceiverController::run(void)
 void FrameReceiverController::stop(const bool deferred)
 {
     if (deferred) {
-        reactor_.register_timer(deferred_action_delay_ms, 1, boost::bind(&FrameReceiverController::stop, this, false));
+        reactor_.register_timer(deferred_action_delay_ms, 1, [this] { stop(false); });
     } else {
         LOG4CXX_TRACE(logger_, "FrameReceiverController::stop()");
         terminate_controller_ = true;
@@ -265,7 +265,7 @@ void FrameReceiverController::setup_control_channel(const std::string& endpoint)
     }
 
     // Add channel to the reactor
-    reactor_.register_channel(ctrl_channel_, boost::bind(&FrameReceiverController::handle_ctrl_channel, this));
+    reactor_.register_channel(ctrl_channel_, [this] { handle_ctrl_channel(); });
 }
 
 //! Set up the receiver thread channel.
@@ -288,7 +288,7 @@ void FrameReceiverController::setup_rx_channel(const std::string& endpoint)
     }
 
     // Add channel to the reactor
-    reactor_.register_channel(rx_channel_, boost::bind(&FrameReceiverController::handle_rx_channel, this));
+    reactor_.register_channel(rx_channel_, [this] { handle_rx_channel(); });
 }
 
 //! Set up the frame ready notification channel.
@@ -334,9 +334,7 @@ void FrameReceiverController::setup_frame_release_channel(const std::string& end
     frame_release_channel_.subscribe("");
 
     // Add channel to the reactor
-    reactor_.register_channel(
-        frame_release_channel_, boost::bind(&FrameReceiverController::handle_frame_release_channel, this)
-    );
+    reactor_.register_channel(frame_release_channel_, [this] { handle_frame_release_channel(); });
 }
 
 //! Unbind an IpcChannel from an endpoint.
@@ -957,9 +955,7 @@ void FrameReceiverController::notify_buffer_config(const bool deferred)
     // buffer configuration.
 
     if (deferred) {
-        reactor_.register_timer(
-            deferred_action_delay_ms, 1, boost::bind(&FrameReceiverController::notify_buffer_config, this, false)
-        );
+        reactor_.register_timer(deferred_action_delay_ms, 1, [this] { notify_buffer_config(false); });
     } else {
         LOG4CXX_DEBUG_LEVEL(1, logger_, "Notifying downstream processes of shared buffer configuration");
 

--- a/cpp/frameReceiver/src/FrameReceiverController.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverController.cpp
@@ -189,7 +189,6 @@ void FrameReceiverController::configure_ipc_channels(OdinData::IpcMessage& confi
     static bool ctrl_channel_configured = false;
     static bool rx_channel_configured = false;
     static bool ready_channel_configured = false;
-    static bool release_channel_configured = false;
 
     // Clear the IPC config status until successful completion
     ipc_configured_ = false;
@@ -237,7 +236,6 @@ void FrameReceiverController::configure_ipc_channels(OdinData::IpcMessage& confi
             this->unbind_channel(&frame_release_channel_, config_.frame_release_endpoint_, false);
             this->setup_frame_release_channel(frame_release_endpoint);
             config_.frame_release_endpoint_ = frame_release_endpoint;
-            release_channel_configured = true;
         }
     }
 

--- a/cpp/frameReceiver/src/FrameReceiverController.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverController.cpp
@@ -701,7 +701,6 @@ void FrameReceiverController::handle_ctrl_channel(void)
 
     // Construct a default reply
     IpcMessage ctrl_reply;
-    IpcMessage::MsgVal ctrl_reply_val = IpcMessage::MsgValIllegal;
 
     bool request_ok = true;
     std::ostringstream error_ss;

--- a/cpp/frameReceiver/src/FrameReceiverController.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverController.cpp
@@ -351,10 +351,9 @@ void FrameReceiverController::unbind_channel(OdinData::IpcChannel* channel, std:
 {
     if (channel->has_bound_endpoint(endpoint)) {
         if (deferred) {
-            reactor_.register_timer(
-                deferred_action_delay_ms, 1,
-                boost::bind(&FrameReceiverController::unbind_channel, this, channel, endpoint, false)
-            );
+            reactor_.register_timer(deferred_action_delay_ms, 1, [this, channel, endpoint]() mutable {
+                unbind_channel(channel, endpoint, false);
+            });
         } else {
             LOG4CXX_DEBUG_LEVEL(1, logger_, "Unbinding channel endpoint " << endpoint);
             channel->unbind(endpoint);

--- a/cpp/frameReceiver/src/FrameReceiverRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverRxThread.cpp
@@ -55,8 +55,7 @@ bool FrameReceiverRxThread::start()
 
     bool init_ok = true;
 
-    rx_thread_
-        = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&FrameReceiverRxThread::run_service, this)));
+    rx_thread_ = boost::shared_ptr<boost::thread>(new boost::thread([this] { run_service(); }));
 
     // Wait for the thread service to initialise and be running properly, logging an error
     // an returning false if the thread fails to start within a reasonable time. Also
@@ -127,22 +126,22 @@ void FrameReceiverRxThread::run_service(void)
     }
 
     // Add the RX channel to the reactor
-    reactor_.register_channel(rx_channel_, boost::bind(&FrameReceiverRxThread::handle_rx_channel, this));
+    reactor_.register_channel(rx_channel_, [this] { handle_rx_channel(); });
 
     // Run the specific service setup implemented in subclass
     run_specific_service();
 
     // Add the tick timer to the reactor
-    int tick_timer_id
-        = reactor_.register_timer(tick_period_ms_, 0, boost::bind(&FrameReceiverRxThread::tick_timer, this));
+    int tick_timer_id = reactor_.register_timer(tick_period_ms_, 0, [this] { tick_timer(); });
 
     // Add the buffer monitor timer to the reactor
-    int buffer_monitor_timer_id = reactor_.register_timer(
-        frame_decoder_->get_frame_timeout_ms(), 0, boost::bind(&FrameReceiverRxThread::buffer_monitor_timer, this)
-    );
+    int buffer_monitor_timer_id
+        = reactor_.register_timer(frame_decoder_->get_frame_timeout_ms(), 0, [this] { buffer_monitor_timer(); });
 
     // Register the frame release callback with the decoder
-    frame_decoder_->register_frame_ready_callback(boost::bind(&FrameReceiverRxThread::frame_ready, this, _1, _2));
+    frame_decoder_->register_frame_ready_callback([this](int buffer_id, int frame_number) {
+        frame_ready(buffer_id, frame_number);
+    });
 
     // If there was any prior error setting the thread up, return
     if (thread_init_error_) {
@@ -168,10 +167,9 @@ void FrameReceiverRxThread::run_service(void)
     reactor_.remove_timer(tick_timer_id);
     reactor_.remove_timer(buffer_monitor_timer_id);
 
-    for (std::vector<int>::iterator recv_sock_it = recv_sockets_.begin(); recv_sock_it != recv_sockets_.end();
-         recv_sock_it++) {
-        reactor_.remove_socket(*recv_sock_it);
-        close(*recv_sock_it);
+    for (int& recv_socket : recv_sockets_) {
+        reactor_.remove_socket(recv_socket);
+        close(recv_socket);
     }
     recv_sockets_.clear();
     rx_channel_.close();

--- a/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
@@ -92,7 +92,7 @@ void FrameReceiverTCPRxThread::run_specific_service(void)
         // Register this socket
         this->register_socket(
             recv_socket_,
-            boost::bind(&FrameReceiverTCPRxThread::handle_receive_socket, this, recv_socket_, (int)rx_port)
+            boost::bind(&FrameReceiverTCPRxThread::handle_receive_socket, this, recv_socket_)
         );
     }
 }
@@ -106,7 +106,7 @@ void FrameReceiverTCPRxThread::cleanup_specific_service(void)
     close(recv_socket_);
 }
 
-void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_, int recv_port)
+void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_)
 {
     // Receive a message from the main thread channel and place it directly into
     // the provided memory buffer

--- a/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
@@ -87,9 +87,7 @@ void FrameReceiverTCPRxThread::run_specific_service(void)
         }
 
         // Register this socket
-        this->register_socket(recv_socket_, [this, recv_socket_, recv_port = static_cast<int>(rx_port)] {
-            handle_receive_socket(recv_socket_, recv_port);
-        });
+        this->register_socket(recv_socket_, [this, recv_socket_] { handle_receive_socket(recv_socket_); });
     }
 }
 
@@ -102,7 +100,7 @@ void FrameReceiverTCPRxThread::cleanup_specific_service(void)
     close(recv_socket_);
 }
 
-void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_, int recv_port)
+void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_)
 {
     // Receive a message from the main thread channel and place it directly into
     // the provided memory buffer

--- a/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverTCPRxThread.cpp
@@ -34,10 +34,7 @@ void FrameReceiverTCPRxThread::run_specific_service(void)
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Running TCP RX thread service");
 
-    for (std::vector<uint16_t>::iterator rx_port_itr = config_.rx_ports_.begin();
-         rx_port_itr != config_.rx_ports_.end(); rx_port_itr++) {
-
-        uint16_t rx_port = *rx_port_itr;
+    for (unsigned short rx_port : config_.rx_ports_) {
 
         // Create the receive socket
         int recv_socket_ = socket(AF_INET, SOCK_STREAM, 0);
@@ -90,10 +87,9 @@ void FrameReceiverTCPRxThread::run_specific_service(void)
         }
 
         // Register this socket
-        this->register_socket(
-            recv_socket_,
-            boost::bind(&FrameReceiverTCPRxThread::handle_receive_socket, this, recv_socket_)
-        );
+        this->register_socket(recv_socket_, [this, recv_socket_, recv_port = static_cast<int>(rx_port)] {
+            handle_receive_socket(recv_socket_, recv_port);
+        });
     }
 }
 
@@ -106,7 +102,7 @@ void FrameReceiverTCPRxThread::cleanup_specific_service(void)
     close(recv_socket_);
 }
 
-void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_)
+void FrameReceiverTCPRxThread::handle_receive_socket(int recv_socket_, int recv_port)
 {
     // Receive a message from the main thread channel and place it directly into
     // the provided memory buffer

--- a/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
@@ -116,6 +116,7 @@ void FrameReceiverUDPRxThread::handle_receive_socket(int recv_socket, int recv_p
         void* header_buffer = frame_decoder_->get_packet_header_buffer();
         socklen_t from_len = sizeof(from_addr);
         size_t bytes_received
+        //BUG??: recvfrom is ssize_t but bytes_recieved is size_t
             = recvfrom(recv_socket, header_buffer, header_size, MSG_PEEK, (struct sockaddr*)&from_addr, &from_len);
         LOG4CXX_DEBUG_LEVEL(3, logger_, "RX thread received " << bytes_received << " header bytes on recv socket");
         frame_decoder_->process_packet_header(bytes_received, recv_port, &from_addr);

--- a/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
@@ -35,10 +35,7 @@ void FrameReceiverUDPRxThread::run_specific_service(void)
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Running UDP RX thread service");
 
-    for (std::vector<uint16_t>::iterator rx_port_itr = config_.rx_ports_.begin();
-         rx_port_itr != config_.rx_ports_.end(); rx_port_itr++) {
-
-        uint16_t rx_port = *rx_port_itr;
+    for (unsigned short rx_port : config_.rx_ports_) {
 
         // Create the receive socket
         int recv_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -93,9 +90,9 @@ void FrameReceiverUDPRxThread::run_specific_service(void)
         }
 
         // Register this socket
-        this->register_socket(
-            recv_socket, boost::bind(&FrameReceiverUDPRxThread::handle_receive_socket, this, recv_socket, (int)rx_port)
-        );
+        this->register_socket(recv_socket, [this, recv_socket, recv_port = static_cast<int>(rx_port)] {
+            handle_receive_socket(recv_socket, recv_port);
+        });
     }
 }
 

--- a/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
@@ -145,6 +145,4 @@ void FrameReceiverUDPRxThread::handle_receive_socket(int recv_socket, int recv_p
                               << frame_decoder_->get_next_payload_buffer()
     );
 
-    FrameDecoder::FrameReceiveState frame_receive_state
-        = frame_decoder_->process_packet(bytes_received, recv_port, &from_addr);
 }

--- a/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverUDPRxThread.cpp
@@ -145,4 +145,6 @@ void FrameReceiverUDPRxThread::handle_receive_socket(int recv_socket, int recv_p
                               << frame_decoder_->get_next_payload_buffer()
     );
 
+    frame_decoder_->process_packet(bytes_received, recv_port, &from_addr);
+
 }

--- a/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
@@ -72,8 +72,6 @@ void FrameReceiverZMQRxThread::handle_receive_socket()
                               << nextMessageBuffer
     );
 
-    FrameDecoder::FrameReceiveState frame_receive_state = frame_decoder_->process_message(msg_len);
-
     // Now check for end of messsage
     if (skt_channel_.eom()) {
         // Message complete, notify the decoder

--- a/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
@@ -72,6 +72,8 @@ void FrameReceiverZMQRxThread::handle_receive_socket()
                               << nextMessageBuffer
     );
 
+    frame_decoder_->process_message(msg_len);
+
     // Now check for end of messsage
     if (skt_channel_.eom()) {
         // Message complete, notify the decoder

--- a/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
+++ b/cpp/frameReceiver/src/FrameReceiverZMQRxThread.cpp
@@ -34,16 +34,13 @@ void FrameReceiverZMQRxThread::run_specific_service(void)
 {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Running ZMQ RX thread service");
 
-    for (std::vector<uint16_t>::iterator rx_port_itr = config_.rx_ports_.begin();
-         rx_port_itr != config_.rx_ports_.end(); rx_port_itr++) {
-        uint16_t rx_port = *rx_port_itr;
-
+    for (unsigned short rx_port : config_.rx_ports_) {
         std::stringstream ss;
         ss << "tcp://" << config_.rx_address_ << ":" << rx_port;
         skt_channel_.connect(ss.str().c_str());
 
         // Register the IPC channel with the reactor
-        reactor_.register_channel(skt_channel_, boost::bind(&FrameReceiverZMQRxThread::handle_receive_socket, this));
+        reactor_.register_channel(skt_channel_, [this] { handle_receive_socket(); });
     }
 }
 

--- a/cpp/frameReceiver/test/FrameReceiverConfigUnitTest.cpp
+++ b/cpp/frameReceiver/test/FrameReceiverConfigUnitTest.cpp
@@ -28,7 +28,7 @@ public:
         std::vector<uint16_t> port_list;
         mConfig.tokenize_port_list(port_list, FrameReceiver::Defaults::default_rx_port_list);
         BOOST_CHECK_EQUAL(mConfig.rx_ports_.size(), port_list.size());
-        for (int i = 0; i < mConfig.rx_ports_.size(); i++) {
+        for (uint32_t i = 0; i < mConfig.rx_ports_.size(); i++) {
             BOOST_CHECK_EQUAL(mConfig.rx_ports_[i], port_list[i]);
         }
         BOOST_CHECK_EQUAL(mConfig.rx_address_, FrameReceiver::Defaults::default_rx_address);

--- a/cpp/frameReceiver/test/IpcChannelUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcChannelUnitTest.cpp
@@ -15,9 +15,9 @@
 
 struct TestFixture {
     TestFixture() :
+        dealer_channel_id("dealer_chan"),
         send_channel(ZMQ_PAIR),
         recv_channel(ZMQ_PAIR),
-        dealer_channel_id("dealer_chan"),
         dealer_channel(ZMQ_DEALER, dealer_channel_id),
         router_channel(ZMQ_ROUTER)
 

--- a/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
@@ -347,7 +347,6 @@ BOOST_AUTO_TEST_CASE(TestIpcMessageCreationSpeed)
     BOOST_CHECK_NO_THROW(for (int i = 0; i < numLoops; i++) {
         OdinData::IpcMessage simpleMessage(OdinData::IpcMessage::MsgTypeCmd, OdinData::IpcMessage::MsgValCmdStatus);
         simpleMessage.set_param<int>("loopParam", i);
-        const char* encodedMsg = simpleMessage.encode();
     });
 
     gettime(&end);

--- a/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcMessageUnitTest.cpp
@@ -10,8 +10,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <ctime>
 #include <exception>
-#include <time.h>
 
 #include "IpcMessage.h"
 #include "gettime.h"

--- a/cpp/frameReceiver/test/IpcReactorUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcReactorUnitTest.cpp
@@ -73,7 +73,8 @@ BOOST_AUTO_TEST_CASE(ReactorTimerTest)
 {
 
     int max_count = 10;
-    int timer_id = reactor.register_timer(10, max_count, boost::bind(&ReactorTestFixture::timer_handler, this));
+    reactor.register_timer(10, max_count, boost::bind(&ReactorTestFixture::timer_handler, this));
+
     reactor.run();
     BOOST_CHECK_EQUAL(timer_count, max_count);
 }
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE(ReactorChannelTest)
 BOOST_AUTO_TEST_CASE(ReactorSendFromTimerTest)
 {
     reactor.register_channel(recv_channel, boost::bind(&ReactorTestFixture::recv_handler, this));
-    int timer_id = reactor.register_timer(10, 1, boost::bind(&ReactorTestFixture::timed_send_handler, this));
+    reactor.register_timer(10, 1, boost::bind(&ReactorTestFixture::timed_send_handler, this));
     reactor.run();
 
     BOOST_CHECK_EQUAL(test_message, received_message);

--- a/cpp/frameReceiver/test/IpcReactorUnitTest.cpp
+++ b/cpp/frameReceiver/test/IpcReactorUnitTest.cpp
@@ -73,8 +73,7 @@ BOOST_AUTO_TEST_CASE(ReactorTimerTest)
 {
 
     int max_count = 10;
-    reactor.register_timer(10, max_count, boost::bind(&ReactorTestFixture::timer_handler, this));
-
+    reactor.register_timer(10, max_count, [this] { timer_handler(); });
     reactor.run();
     BOOST_CHECK_EQUAL(timer_count, max_count);
 }
@@ -82,7 +81,7 @@ BOOST_AUTO_TEST_CASE(ReactorTimerTest)
 BOOST_AUTO_TEST_CASE(ReactorChannelTest)
 {
 
-    reactor.register_channel(recv_channel, boost::bind(&ReactorTestFixture::recv_handler, this));
+    reactor.register_channel(recv_channel, [this] { recv_handler(); });
 
     send_channel.send(test_message);
     reactor.run();
@@ -92,8 +91,8 @@ BOOST_AUTO_TEST_CASE(ReactorChannelTest)
 
 BOOST_AUTO_TEST_CASE(ReactorSendFromTimerTest)
 {
-    reactor.register_channel(recv_channel, boost::bind(&ReactorTestFixture::recv_handler, this));
-    reactor.register_timer(10, 1, boost::bind(&ReactorTestFixture::timed_send_handler, this));
+    reactor.register_channel(recv_channel, [this] { recv_handler(); });
+    reactor.register_timer(10, 1, [this] { timed_send_handler(); });
     reactor.run();
 
     BOOST_CHECK_EQUAL(test_message, received_message);

--- a/cpp/frameReceiver/test/SharedBufferManagerUnitTest.cpp
+++ b/cpp/frameReceiver/test/SharedBufferManagerUnitTest.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(SharedWithChildProcessTest)
     // Initialise the contents of first buffer to incrementing byte values
     char* buf_address = reinterpret_cast<char*>(shared_buffer_manager.get_buffer_address(0));
     size_t buffer_size = shared_buffer_manager.get_buffer_size();
-    for (int i = 0; i < buffer_size; i++) {
+    for (uint32_t i = 0; i < buffer_size; i++) {
         buf_address[i] = i % 256;
     }
 
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(SharedWithChildProcessTest)
 
         // Check the first buffer has been initialised with incrementing byte values
         int buffer_values_mismatched = 0;
-        for (int i = 0; i < child_buffer_size; i++) {
+        for (uint32_t i = 0; i < child_buffer_size; i++) {
             if (buf_address[i] != i % 256) {
                 buffer_values_mismatched++;
             }
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(SharedWithChildProcessTest)
         char* child_max_buffer_address
             = reinterpret_cast<char*>(child_manager.get_buffer_address(child_num_buffers - 1));
         int max_buffer_values_mismatched = 0;
-        for (int i = 0; i < child_buffer_size; i++) {
+        for (uint32_t i = 0; i < child_buffer_size; i++) {
             if (child_max_buffer_address[i] != max_buffer_value) {
                 max_buffer_values_mismatched++;
             }

--- a/cpp/frameReceiver/test/SharedBufferManagerUnitTest.cpp
+++ b/cpp/frameReceiver/test/SharedBufferManagerUnitTest.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(BasicSharedBufferTest)
 {
 
     void* buf_address = shared_buffer_manager.get_buffer_address(0);
-    BOOST_CHECK_NE(buf_address, (void*)0);
+    BOOST_CHECK_NE(buf_address, (void*)nullptr);
     BOOST_CHECK_EQUAL(buffer_size, shared_buffer_manager.get_buffer_size());
     BOOST_CHECK_EQUAL(num_buffers, shared_buffer_manager.get_num_buffers());
 }
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(SharedWithChildProcessTest)
 
         // Check child has non-zero buffer address
         char* child_buf_address = reinterpret_cast<char*>(child_manager.get_buffer_address(0));
-        BOOST_CHECK_NE(child_buf_address, (char*)0);
+        BOOST_CHECK_NE(child_buf_address, (char*)nullptr);
 
         // Check child buffer size matches parent
         size_t child_buffer_size = child_manager.get_buffer_size();

--- a/cpp/frameSimulator/include/DummyUDPFrameSimulatorPlugin.h
+++ b/cpp/frameSimulator/include/DummyUDPFrameSimulatorPlugin.h
@@ -49,7 +49,7 @@ private:
 
     int image_width_;
     int image_height_;
-    int packet_len_;
+    uint32_t packet_len_;
 };
 
 }

--- a/cpp/frameSimulator/include/DummyUDPFrameSimulatorPlugin.h
+++ b/cpp/frameSimulator/include/DummyUDPFrameSimulatorPlugin.h
@@ -30,18 +30,18 @@ class DummyUDPFrameSimulatorPlugin : public FrameSimulatorPluginUDP {
 public:
     DummyUDPFrameSimulatorPlugin();
 
-    virtual void populate_options(po::options_description& config);
-    virtual bool setup(const po::variables_map& vm);
+    void populate_options(po::options_description& config) override;
+    bool setup(const po::variables_map& vm) override;
 
-    virtual int get_version_major();
-    virtual int get_version_minor();
-    virtual int get_version_patch();
-    virtual std::string get_version_short();
-    virtual std::string get_version_long();
+    int get_version_major() override;
+    int get_version_minor() override;
+    int get_version_patch() override;
+    std::string get_version_short() override;
+    std::string get_version_long() override;
 
 protected:
-    virtual void extract_frames(const u_char* data, const int& size);
-    virtual void create_frames(const int& num_frames);
+    void extract_frames(const u_char* data, const int& size) override;
+    void create_frames(const int& num_frames) override;
 
 private:
     /** Pointer to logger **/

--- a/cpp/frameSimulator/include/FrameSimulatorOption.h
+++ b/cpp/frameSimulator/include/FrameSimulatorOption.h
@@ -84,9 +84,9 @@ public:
     }
 
 private:
-    const boost::optional<T> defaultval;
     const std::string argstring;
     const std::string description;
+    const boost::optional<T> defaultval;
 };
 
 }

--- a/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
+++ b/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
@@ -80,7 +80,7 @@ private:
     int m_socket;
 
     // Used by send_packet to send each frame to the correct port
-    mutable int curr_port_index;
+    mutable uint64_t curr_port_index;
     mutable int curr_frame;
 
     pcap_t* m_handle;

--- a/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
+++ b/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
@@ -36,12 +36,12 @@ class FrameSimulatorPluginUDP : public FrameSimulatorPlugin {
 
 public:
     FrameSimulatorPluginUDP();
-    ~FrameSimulatorPluginUDP();
+    ~FrameSimulatorPluginUDP() override;
 
-    virtual void populate_options(po::options_description& config);
+    void populate_options(po::options_description& config) override;
 
-    virtual bool setup(const po::variables_map& vm);
-    virtual void simulate();
+    bool setup(const po::variables_map& vm) override;
+    void simulate() override;
 
 protected:
     static void pkt_callback(u_char* user, const pcap_pkthdr* hdr, const u_char* buffer);

--- a/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
+++ b/cpp/frameSimulator/include/FrameSimulatorPluginUDP.h
@@ -23,7 +23,7 @@ using namespace log4cxx::helpers;
 
 namespace FrameSimulator {
 
-typedef std::vector<UDPFrame> UDPFrames;
+using UDPFrames = std::vector<UDPFrame>;
 
 /** FrameSimulatorPluginUDP
  *

--- a/cpp/frameSimulator/include/UDPFrame.h
+++ b/cpp/frameSimulator/include/UDPFrame.h
@@ -7,7 +7,7 @@
 
 namespace FrameSimulator {
 
-typedef std::vector<boost::shared_ptr<Packet>> PacketList;
+using PacketList = std::vector<boost::shared_ptr<Packet>>;
 
 /** UDPFrame class
  *

--- a/cpp/frameSimulator/src/DummyUDPFrameSimulatorPlugin.cpp
+++ b/cpp/frameSimulator/src/DummyUDPFrameSimulatorPlugin.cpp
@@ -8,8 +8,8 @@
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <cstdlib>
+#include <ctime>
 #include <iostream>
-#include <time.h>
 
 #include "version.h"
 

--- a/cpp/frameSimulator/src/FrameSimulatorPluginUDP.cpp
+++ b/cpp/frameSimulator/src/FrameSimulatorPluginUDP.cpp
@@ -1,7 +1,7 @@
 #include "FrameSimulatorPluginUDP.h"
 
+#include <cstring>
 #include <functional>
-#include <string.h>
 #include <unistd.h>
 
 #include <net/ethernet.h>
@@ -93,7 +93,7 @@ bool FrameSimulatorPluginUDP::setup(const po::variables_map& vm)
         // Open a handle to the pcap file
         m_handle = pcap_open_offline(opt_pcapfile.get_val(vm).c_str(), errbuf);
 
-        if (m_handle == NULL) {
+        if (m_handle == nullptr) {
             LOG4CXX_ERROR(logger_, "pcap open failed: " << errbuf);
             return false;
         }
@@ -213,7 +213,7 @@ void FrameSimulatorPluginUDP::replay_frames()
                 struct timespec wait_spec;
                 wait_spec.tv_sec = (int)wait_time_s;
                 wait_spec.tv_nsec = (long)((wait_time_s - (float)wait_spec.tv_sec) * 1000000000L);
-                nanosleep(&wait_spec, NULL);
+                nanosleep(&wait_spec, nullptr);
             }
         }
 

--- a/cpp/frameSimulator/src/FrameSimulatorPluginUDP.cpp
+++ b/cpp/frameSimulator/src/FrameSimulatorPluginUDP.cpp
@@ -118,10 +118,8 @@ void FrameSimulatorPluginUDP::prepare_packets(const struct pcap_pkthdr* header, 
 
     LOG4CXX_DEBUG(logger_, "Preparing packet(s)");
 
-    int size = header->len;
     struct iphdr* iph = (struct iphdr*)(buffer + sizeof(struct ethhdr));
     struct udphdr* udph = (struct udphdr*)(buffer + iph->ihl * 4 + sizeof(struct ethhdr));
-    const u_char* d = &buffer[sizeof(struct ethhdr) + iph->ihl * 4 + sizeof udph];
 
     int header_size = sizeof(struct ethhdr) + iph->ihl * 4 + sizeof(udph);
 

--- a/cpp/test/integrationTest/src/ControlUtility.cpp
+++ b/cpp/test/integrationTest/src/ControlUtility.cpp
@@ -66,18 +66,19 @@ void ControlUtility::run_process(const bool& wait_child)
         LOG4CXX_DEBUG(
             logger_, "Launching " + process_path_ + "(" + boost::lexical_cast<std::string>(process_pid_) + ")"
         );
+        int status;
         if (wait_child) {
-            wait(NULL);
+            wait(nullptr);
         }
     }
 
     if (process_pid_ == 0) {
 
         std::vector<char*> args;
-        for (uint32_t s = 0; s < process_args_.size(); s++) {
-            args.push_back((char*)process_args_.at(s).data());
+        for (auto& process_arg : process_args_) {
+            args.push_back((char*)process_arg.data());
         }
-        args.push_back(NULL);
+        args.push_back(nullptr);
 
         execv(process_path_.c_str(), args.data());
     }
@@ -92,11 +93,11 @@ void ControlUtility::run_command()
     std::string command = process_path_;
 
     command += " ";
-    for (uint32_t s = 0; s < command_args_.size(); s++) {
-        if (command_args_[s].find("--") != std::string::npos)
-            command += command_args_[s] + "=";
+    for (const auto& command_arg : command_args_) {
+        if (command_arg.find("--") != std::string::npos)
+            command += command_arg + "=";
         else
-            command += command_args_[s] + " ";
+            command += command_arg + " ";
     }
 
     int status = std::system((command).c_str());

--- a/cpp/test/integrationTest/src/ControlUtility.cpp
+++ b/cpp/test/integrationTest/src/ControlUtility.cpp
@@ -66,7 +66,6 @@ void ControlUtility::run_process(const bool& wait_child)
         LOG4CXX_DEBUG(
             logger_, "Launching " + process_path_ + "(" + boost::lexical_cast<std::string>(process_pid_) + ")"
         );
-        int status;
         if (wait_child) {
             wait(NULL);
         }
@@ -75,7 +74,7 @@ void ControlUtility::run_process(const bool& wait_child)
     if (process_pid_ == 0) {
 
         std::vector<char*> args;
-        for (int s = 0; s < process_args_.size(); s++) {
+        for (uint32_t s = 0; s < process_args_.size(); s++) {
             args.push_back((char*)process_args_.at(s).data());
         }
         args.push_back(NULL);
@@ -93,7 +92,7 @@ void ControlUtility::run_command()
     std::string command = process_path_;
 
     command += " ";
-    for (int s = 0; s < command_args_.size(); s++) {
+    for (uint32_t s = 0; s < command_args_.size(); s++) {
         if (command_args_[s].find("--") != std::string::npos)
             command += command_args_[s] + "=";
         else

--- a/cpp/test/integrationTest/src/ControlUtility.cpp
+++ b/cpp/test/integrationTest/src/ControlUtility.cpp
@@ -66,7 +66,6 @@ void ControlUtility::run_process(const bool& wait_child)
         LOG4CXX_DEBUG(
             logger_, "Launching " + process_path_ + "(" + boost::lexical_cast<std::string>(process_pid_) + ")"
         );
-        int status;
         if (wait_child) {
             wait(nullptr);
         }

--- a/cpp/test/integrationTest/src/FrameTestApp.cpp
+++ b/cpp/test/integrationTest/src/FrameTestApp.cpp
@@ -35,16 +35,6 @@ namespace po = boost::program_options;
 #include "DebugLevelLogger.h"
 #include "logging.h"
 
-/** Check that str contains suffix
- * /param[in] str - string to test
- * /param[in] suffix - test suffix
- * /return true if suffix found; else false
- */
-static bool has_suffix(const std::string& str, const std::string& suffix)
-{
-    return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 /** Parse command line arguments
  * /param[in] argc - argument count; number of arguments to parse
  * /param[in] argv - one-dimensional string array of command line arguments

--- a/cpp/test/integrationTest/src/FrameTestApp.cpp
+++ b/cpp/test/integrationTest/src/FrameTestApp.cpp
@@ -35,16 +35,6 @@ namespace po = boost::program_options;
 #include "DebugLevelLogger.h"
 #include "logging.h"
 
-/** Check that str contains suffix
- * /param[in] str - string to test
- * /param[in] suffix - test suffix
- * /return true if suffix found; else false
- */
-static bool has_suffix(const std::string& str, const std::string& suffix)
-{
-    return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 /** Parse command line arguments
  * /param[in] argc - argument count; number of arguments to parse
  * /param[in] argv - one-dimensional string array of command line arguments
@@ -149,11 +139,11 @@ int main(int argc, char* argv[])
             sleep(sleeptime);
         }
 
-        for (int i = 0; i < processes.size(); i++) {
+        for (uint32_t i = 0; i < processes.size(); i++) {
             processes[i]->end();
         }
 
-        for (int j = 0; j < utilities.size(); j++) {
+        for (uint32_t j = 0; j < utilities.size(); j++) {
             int status = utilities[j]->exit_status();
             if (status != 0)
                 return status;

--- a/cpp/test/integrationTest/src/FrameTestApp.cpp
+++ b/cpp/test/integrationTest/src/FrameTestApp.cpp
@@ -1,6 +1,6 @@
+#include <csignal>
 #include <iostream>
 #include <map>
-#include <signal.h>
 #include <string>
 #include <utility>
 #include <vector>
@@ -34,6 +34,16 @@ namespace po = boost::program_options;
 
 #include "DebugLevelLogger.h"
 #include "logging.h"
+
+/** Check that str contains suffix
+ * /param[in] str - string to test
+ * /param[in] suffix - test suffix
+ * /return true if suffix found; else false
+ */
+static bool has_suffix(const std::string& str, const std::string& suffix)
+{
+    return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
 
 /** Parse command line arguments
  * /param[in] argc - argument count; number of arguments to parse
@@ -139,12 +149,12 @@ int main(int argc, char* argv[])
             sleep(sleeptime);
         }
 
-        for (uint32_t i = 0; i < processes.size(); i++) {
-            processes[i]->end();
+        for (auto& process : processes) {
+            process->end();
         }
 
-        for (uint32_t j = 0; j < utilities.size(); j++) {
-            int status = utilities[j]->exit_status();
+        for (auto& utility : utilities) {
+            int status = utility->exit_status();
             if (status != 0)
                 return status;
         }

--- a/cpp/test/integrationTest/src/HDF5FrameTest.cpp
+++ b/cpp/test/integrationTest/src/HDF5FrameTest.cpp
@@ -98,8 +98,7 @@ BOOST_AUTO_TEST_CASE(HDF5Frame_size)
     const int ndims = H5Sget_simple_extent_ndims(space);
 
     hsize_t dims[ndims];
-    int ndms = H5Sget_simple_extent_dims(space, dims, NULL);
-
+    H5Sget_simple_extent_dims(space, dims, NULL);
     int frames = dims[0];
 
     if (boost::optional<int> t_dims = ptree.get_optional<int>("Test.dimensions"))

--- a/cpp/test/integrationTest/src/HDF5FrameTest.cpp
+++ b/cpp/test/integrationTest/src/HDF5FrameTest.cpp
@@ -66,8 +66,8 @@ public:
 
         const int ndims = H5Sget_simple_extent_ndims(space);
 
-        hsize_t dims[ndims];
-        int ndms = H5Sget_simple_extent_dims(space, dims, NULL);
+        std::vector<hsize_t> dims(ndims);
+        int ndms = H5Sget_simple_extent_dims(space, dims.data(), NULL);
 
         int num_pts = dims[0];
 
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(HDF5Frame_size)
 
     const int ndims = H5Sget_simple_extent_ndims(space);
 
-    hsize_t dims[ndims];
-    H5Sget_simple_extent_dims(space, dims, NULL);
+    std::vector<hsize_t> dims(ndims);
+    H5Sget_simple_extent_dims(space, dims.data(), NULL);
     int frames = dims[0];
 
     if (boost::optional<int> t_dims = ptree.get_optional<int>("Test.dimensions"))

--- a/cpp/test/integrationTest/src/HDF5FrameTest.cpp
+++ b/cpp/test/integrationTest/src/HDF5FrameTest.cpp
@@ -80,7 +80,7 @@ public:
 
         BOOST_FOREACH (boost::property_tree::ptree::value_type& vc, ptree.get_child("Test.data"))
             BOOST_CHECK_EQUAL(data_out[std::atoi(vc.first.c_str())], ptree.get<T>("Test.data." + vc.first));
-    };
+    }
 
     ~HDF5FrameTest() = default;
 

--- a/cpp/test/integrationTest/src/HDF5FrameTest.cpp
+++ b/cpp/test/integrationTest/src/HDF5FrameTest.cpp
@@ -80,7 +80,7 @@ public:
 
         BOOST_FOREACH (boost::property_tree::ptree::value_type& vc, ptree.get_child("Test.data"))
             BOOST_CHECK_EQUAL(data_out[std::atoi(vc.first.c_str())], ptree.get<T>("Test.data." + vc.first));
-    };
+    }
 
     ~HDF5FrameTest()
     {

--- a/cpp/test/integrationTest/src/HDF5FrameTest.cpp
+++ b/cpp/test/integrationTest/src/HDF5FrameTest.cpp
@@ -67,7 +67,7 @@ public:
         const int ndims = H5Sget_simple_extent_ndims(space);
 
         std::vector<hsize_t> dims(ndims);
-        int ndms = H5Sget_simple_extent_dims(space, dims.data(), NULL);
+        int ndms = H5Sget_simple_extent_dims(space, dims.data(), nullptr);
 
         int num_pts = dims[0];
 
@@ -80,11 +80,9 @@ public:
 
         BOOST_FOREACH (boost::property_tree::ptree::value_type& vc, ptree.get_child("Test.data"))
             BOOST_CHECK_EQUAL(data_out[std::atoi(vc.first.c_str())], ptree.get<T>("Test.data." + vc.first));
-    }
+    };
 
-    ~HDF5FrameTest()
-    {
-    }
+    ~HDF5FrameTest() = default;
 
     hid_t file_id, dataset, filetype, space;
     boost::property_tree::ptree ptree;
@@ -98,7 +96,8 @@ BOOST_AUTO_TEST_CASE(HDF5Frame_size)
     const int ndims = H5Sget_simple_extent_ndims(space);
 
     std::vector<hsize_t> dims(ndims);
-    H5Sget_simple_extent_dims(space, dims.data(), NULL);
+    H5Sget_simple_extent_dims(space, dims.data(), nullptr);
+
     int frames = dims[0];
 
     if (boost::optional<int> t_dims = ptree.get_optional<int>("Test.dimensions"))

--- a/cpp/test/test_rewind.cpp
+++ b/cpp/test/test_rewind.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <vector>
 
-int main(int argc, char* argv[])
+int main()
 {
     hsize_t CHUNK_NX = 704;
     hsize_t CHUNK_NY = 1484;

--- a/cpp/test/test_rewind.cpp
+++ b/cpp/test/test_rewind.cpp
@@ -5,8 +5,8 @@
 
 int main()
 {
-    hsize_t CHUNK_NX = 704;
-    hsize_t CHUNK_NY = 1484;
+    constexpr hsize_t CHUNK_NX = 704;
+    constexpr hsize_t CHUNK_NY = 1484;
     size_t buf_size = CHUNK_NX * CHUNK_NY * sizeof(int16_t);
     int16_t data_buf[CHUNK_NY][CHUNK_NX];
     int16_t one_buf[CHUNK_NY][CHUNK_NX];

--- a/cpp/test/test_rewind.cpp
+++ b/cpp/test/test_rewind.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
     hid_t dset_id = H5Dcreate2(file, "data", dtype, dataspace, H5P_DEFAULT, prop, dapl);
 
     /* Initialize data for one chunk */
-    int i, n, j;
+    uint32_t i, n, j;
     for (i = n = 0; i < CHUNK_NY; i++) {
         for (j = 0; j < CHUNK_NX; j++) {
             data_buf[i][j] = n++;

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -29,7 +29,7 @@ checks="${CLANG_TIDY_CHECKS:-${default_checks}}"
 jobs="${CLANG_TIDY_JOBS:-4}"
 apply_fixes=0
 quiet=1
-warnings_as_errors=""
+warnings_as_errors="*"
 source_paths=()
 
 report()
@@ -57,7 +57,8 @@ Options:
   -j, --jobs N                 Parallel clang-tidy processes (default: 4)
       --checks LIST            Override the curated clang-tidy checks
       --warnings-as-errors LIST
-                               Upgrade matching checks to errors
+                               Override which checks are upgraded to errors
+                               (default: all enabled checks)
       --fix                    Apply clang-tidy fix-its to source files
       --verbose                Show run-clang-tidy progress output
   -h, --help                   Show this help
@@ -249,6 +250,11 @@ command=(
     "-checks=${checks}"
     -header-filter "^${escaped_cpp_dir}/"
     -exclude-header-filter "^${escaped_common_include_dir}/(rapidjson|zmq)/"
+    # RapidJSON 1.1 contains an invalid assignment operator in an unused
+    # template. Clang 20 diagnoses its body before the header filter can
+    # discard external diagnostics. Delay template parsing so unused vendored
+    # template bodies are ignored while instantiated code is still analysed.
+    -extra-arg=-fdelayed-template-parsing
 )
 
 if [[ ${quiet} -eq 1 ]]; then
@@ -269,6 +275,27 @@ if [[ ${apply_fixes} -eq 1 ]]; then
     report "Applying clang-tidy fix-its"
 else
     report "Report-only mode; no source files will be changed"
+fi
+
+if [[ ${quiet} -eq 1 ]]; then
+    # Clang reports the number of diagnostics it considered before the header
+    # filters suppress external-code warnings. Those totals are not actionable
+    # findings, so hide only the exact bookkeeping lines in normal output.
+    set +e
+    "${command[@]}" 2>&1 \
+        | sed -u -E '/^[[:space:]]*[0-9]+ warnings? generated\.[[:space:]]*$/d'
+    command_statuses=("${PIPESTATUS[@]}")
+    set -e
+
+    if [[ ${command_statuses[0]} -ne 0 ]]; then
+        exit "${command_statuses[0]}"
+    fi
+    if [[ ${command_statuses[1]} -ne 0 ]]; then
+        exit "${command_statuses[1]}"
+    fi
+
+    report "clang-tidy completed successfully"
+    exit 0
 fi
 
 exec "${command[@]}"

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run a curated set of clang-tidy C++ modernisation checks over translation
+# units in a CMake compilation database. Header diagnostics are limited to
+# Odin-owned C++ code; vendored RapidJSON and ZeroMQ headers are excluded.
+
+script_name=$(basename "$0")
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd -- "${script_dir}/.." && pwd)
+
+default_checks="-*,\
+modernize-avoid-bind,\
+modernize-deprecated-headers,\
+modernize-loop-convert,\
+modernize-make-shared,\
+modernize-make-unique,\
+modernize-replace-auto-ptr,\
+modernize-use-equals-default,\
+modernize-use-equals-delete,\
+modernize-use-noexcept,\
+modernize-use-nullptr,\
+modernize-use-override,\
+modernize-use-using"
+
+build_dir="${CLANG_TIDY_BUILD_DIR:-${repo_dir}/vscode_build}"
+checks="${CLANG_TIDY_CHECKS:-${default_checks}}"
+jobs="${CLANG_TIDY_JOBS:-4}"
+apply_fixes=0
+quiet=1
+warnings_as_errors=""
+source_paths=()
+
+report()
+{
+    printf '[%s] %s\n' "${script_name}" "$*"
+}
+
+report_error()
+{
+    printf '[%s] Error: %s\n' "${script_name}" "$*" >&2
+}
+
+usage()
+{
+    cat <<EOF
+Usage: ${script_name} [options] [source-file-or-directory ...]
+
+Run clang-tidy against translation units in a CMake compile_commands.json.
+Paths are resolved relative to the repository root. With no paths, all C++
+translation units under cpp/ are checked. Headers are analysed when included
+by a translation unit; vendored RapidJSON and ZeroMQ headers are excluded.
+
+Options:
+  -p, --build-dir DIR          CMake build directory (default: vscode_build)
+  -j, --jobs N                 Parallel clang-tidy processes (default: 4)
+      --checks LIST            Override the curated clang-tidy checks
+      --warnings-as-errors LIST
+                               Upgrade matching checks to errors
+      --fix                    Apply clang-tidy fix-its to source files
+      --verbose                Show run-clang-tidy progress output
+  -h, --help                   Show this help
+
+Environment overrides:
+  CLANG_TIDY_BUILD_DIR, CLANG_TIDY_CHECKS, CLANG_TIDY_JOBS
+
+Examples:
+  scripts/${script_name}
+  scripts/${script_name} cpp/frameProcessor/src/FileWriterPlugin.cpp
+  scripts/${script_name} --jobs 8 cpp/common cpp/frameReceiver
+  scripts/${script_name} --checks='-*,modernize-use-nullptr' cpp/common
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--build-dir)
+            [[ $# -ge 2 ]] || { report_error "$1 requires a directory"; exit 2; }
+            build_dir=$2
+            shift 2
+            ;;
+        --build-dir=*)
+            build_dir=${1#*=}
+            [[ -n "${build_dir}" ]] || { report_error "--build-dir requires a directory"; exit 2; }
+            shift
+            ;;
+        -j|--jobs)
+            [[ $# -ge 2 ]] || { report_error "$1 requires a positive integer"; exit 2; }
+            jobs=$2
+            shift 2
+            ;;
+        --jobs=*)
+            jobs=${1#*=}
+            [[ -n "${jobs}" ]] || { report_error "--jobs requires a positive integer"; exit 2; }
+            shift
+            ;;
+        --checks)
+            [[ $# -ge 2 ]] || { report_error "$1 requires a checks list"; exit 2; }
+            checks=$2
+            shift 2
+            ;;
+        --checks=*)
+            checks=${1#*=}
+            [[ -n "${checks}" ]] || { report_error "--checks requires a checks list"; exit 2; }
+            shift
+            ;;
+        --warnings-as-errors)
+            [[ $# -ge 2 ]] || { report_error "$1 requires a checks list"; exit 2; }
+            warnings_as_errors=$2
+            shift 2
+            ;;
+        --warnings-as-errors=*)
+            warnings_as_errors=${1#*=}
+            [[ -n "${warnings_as_errors}" ]] || { report_error "--warnings-as-errors requires a checks list"; exit 2; }
+            shift
+            ;;
+        --fix)
+            apply_fixes=1
+            shift
+            ;;
+        --verbose)
+            quiet=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            source_paths+=("$@")
+            break
+            ;;
+        -*)
+            report_error "Unknown option: $1"
+            usage >&2
+            exit 2
+            ;;
+        *)
+            source_paths+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ! "${jobs}" =~ ^[1-9][0-9]*$ ]]; then
+    report_error "Job count must be a positive integer: ${jobs}"
+    exit 2
+fi
+
+if [[ "${build_dir}" != /* ]]; then
+    build_dir="${repo_dir}/${build_dir}"
+fi
+
+compile_commands="${build_dir}/compile_commands.json"
+if [[ ! -f "${compile_commands}" ]]; then
+    report_error "Compilation database not found: ${compile_commands}"
+    report_error "Configure it with: cmake -S ${repo_dir}/cpp -B ${build_dir} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    exit 2
+fi
+
+clang_tidy=""
+for candidate in clang-tidy-20 clang-tidy; do
+    if command -v "${candidate}" >/dev/null 2>&1; then
+        candidate_path=$(command -v "${candidate}")
+        candidate_major=$("${candidate_path}" --version \
+            | sed -nE 's/.*version ([0-9]+).*/\1/p' \
+            | head -n 1)
+        if [[ -n "${candidate_major}" && "${candidate_major}" -ge 20 ]]; then
+            clang_tidy=${candidate_path}
+            break
+        fi
+    fi
+done
+
+if [[ -z "${clang_tidy}" ]]; then
+    report_error "clang-tidy version 20 or newer was not found"
+    exit 3
+fi
+
+run_clang_tidy=""
+for candidate in run-clang-tidy-20 run-clang-tidy; do
+    if command -v "${candidate}" >/dev/null 2>&1; then
+        run_clang_tidy=$(command -v "${candidate}")
+        break
+    fi
+done
+
+if [[ -z "${run_clang_tidy}" ]]; then
+    report_error "run-clang-tidy was not found"
+    exit 3
+fi
+
+if [[ ${#source_paths[@]} -eq 0 ]]; then
+    source_paths=("cpp")
+fi
+
+regex_escape()
+{
+    sed 's/[][\\.^$*+?{}()|]/\\&/g' <<<"$1"
+}
+
+source_patterns=()
+for source_path in "${source_paths[@]}"; do
+    if [[ "${source_path}" == /* ]]; then
+        absolute_path=${source_path}
+    else
+        absolute_path="${repo_dir}/${source_path}"
+    fi
+
+    if [[ ! -e "${absolute_path}" ]]; then
+        report_error "Source path does not exist: ${source_path}"
+        exit 2
+    fi
+
+    absolute_path=$(cd -- "$(dirname -- "${absolute_path}")" && pwd)/$(basename -- "${absolute_path}")
+    case "${absolute_path}" in
+        "${repo_dir}"|"${repo_dir}"/*) ;;
+        *)
+            report_error "Source path is outside the repository: ${source_path}"
+            exit 2
+            ;;
+    esac
+
+    escaped_path=$(regex_escape "${absolute_path}")
+    if [[ -d "${absolute_path}" ]]; then
+        source_patterns+=("^${escaped_path}/.*\\.(c|cc|cpp|cxx)$")
+    else
+        case "${absolute_path}" in
+            *.c|*.cc|*.cpp|*.cxx) ;;
+            *)
+                report_error "Expected a C/C++ source file or directory: ${source_path}"
+                exit 2
+                ;;
+        esac
+        source_patterns+=("^${escaped_path}$")
+    fi
+done
+
+escaped_cpp_dir=$(regex_escape "${repo_dir}/cpp")
+escaped_common_include_dir=$(regex_escape "${repo_dir}/cpp/common/include")
+
+command=(
+    "${run_clang_tidy}"
+    -clang-tidy-binary "${clang_tidy}"
+    -p "${build_dir}"
+    -j "${jobs}"
+    "-checks=${checks}"
+    -header-filter "^${escaped_cpp_dir}/"
+    -exclude-header-filter "^${escaped_common_include_dir}/(rapidjson|zmq)/"
+)
+
+if [[ ${quiet} -eq 1 ]]; then
+    command+=(-quiet)
+fi
+if [[ ${apply_fixes} -eq 1 ]]; then
+    command+=(-fix)
+fi
+if [[ -n "${warnings_as_errors}" ]]; then
+    command+=("-warnings-as-errors=${warnings_as_errors}")
+fi
+command+=("${source_patterns[@]}")
+
+report "Using $("${clang_tidy}" --version | head -n 1)"
+report "Compilation database: ${compile_commands}"
+report "Parallel jobs: ${jobs}"
+if [[ ${apply_fixes} -eq 1 ]]; then
+    report "Applying clang-tidy fix-its"
+else
+    report "Report-only mode; no source files will be changed"
+fi
+
+exec "${command[@]}"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd -- "${script_dir}/.." && pwd)"
+build_dir="${BUILD_DIR:-${repo_dir}/vscode_build}"
+bin_dir="${TEST_BIN_DIR:-${build_dir}/bin}"
+lib_dir="${TEST_LIB_DIR:-${build_dir}/lib}"
+config_source_dir="${INTEGRATION_CONFIG_DIR:-${repo_dir}/cpp/test/integrationTest/config}"
+test_timeout_seconds="${TEST_TIMEOUT_SECONDS:-120}"
+
+if [[ ! "${test_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "TEST_TIMEOUT_SECONDS must be a positive integer: ${test_timeout_seconds}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${bin_dir}" ]]; then
+  echo "Test binary directory does not exist: ${bin_dir}" >&2
+  exit 1
+fi
+
+receiver_tests=()
+while IFS= read -r test_path; do
+  receiver_tests+=("${test_path}")
+done < <(find "${bin_dir}" -maxdepth 1 -type f -perm -111 -name 'unit_fr_*' | sort)
+
+processor_tests=()
+while IFS= read -r test_path; do
+  processor_tests+=("${test_path}")
+done < <(find "${bin_dir}" -maxdepth 1 -type f -perm -111 -name 'unit_fp_*' | sort)
+
+if [[ ${#receiver_tests[@]} -eq 0 ]]; then
+  echo "No frame-receiver unit tests were found in ${bin_dir}" >&2
+  exit 1
+fi
+
+if [[ ${#processor_tests[@]} -eq 0 ]]; then
+  echo "No frame-processor unit tests were found in ${bin_dir}" >&2
+  exit 1
+fi
+
+log_dir="$(mktemp -d "${TMPDIR:-/tmp}/odin-tests.XXXXXX")"
+trap 'rm -rf "${log_dir}"' EXIT
+
+failed_tests=()
+failed_statuses=()
+failed_logs=()
+test_count=0
+
+run_test()
+{
+  local test_name="$1"
+  shift
+
+  local test_log="${log_dir}/${test_name}.log"
+  local test_status
+
+  test_count=$((test_count + 1))
+  echo "==> Running ${test_name}"
+
+  if timeout --kill-after=5s "${test_timeout_seconds}s" "$@" 2>&1 | tee "${test_log}"; then
+    echo "    PASS"
+  else
+    test_status=$?
+    failed_tests+=("${test_name}")
+    failed_statuses+=("${test_status}")
+    failed_logs+=("${test_log}")
+    if [[ ${test_status} -eq 124 ]]; then
+      echo "    TIMEOUT after ${test_timeout_seconds}s"
+    else
+      echo "    FAIL (exit ${test_status})"
+    fi
+  fi
+}
+
+echo "Frame receiver unit tests"
+for test_path in "${receiver_tests[@]}"; do
+  run_test "$(basename "${test_path}")" "${test_path}" --log_level=test_suite
+done
+
+echo
+echo "Frame processor unit tests"
+for test_path in "${processor_tests[@]}"; do
+  run_test "$(basename "${test_path}")" "${test_path}" --log_level=test_suite
+done
+
+echo
+echo "Odin-data frame integration test"
+
+required_integration_files=(
+  "${bin_dir}/odinDataTest"
+  "${bin_dir}/frameReceiver"
+  "${bin_dir}/frameProcessor"
+  "${bin_dir}/frameSimulator"
+  "${bin_dir}/frameTests"
+  "${config_source_dir}/dummyUDP.json"
+  "${config_source_dir}/dummyUDP-fr.json"
+  "${config_source_dir}/dummyUDP-fp.json"
+  "${config_source_dir}/testUDP.json"
+)
+
+for required_file in "${required_integration_files[@]}"; do
+  if [[ ! -e "${required_file}" ]]; then
+    echo "Required integration-test file does not exist: ${required_file}" >&2
+    exit 1
+  fi
+done
+
+# Replace the install-prefix placeholder in temporary config copies so every
+# process uses the binaries and libraries from vscode_build.
+runtime_dir="${log_dir}/runtime"
+mkdir -p "${runtime_dir}/test_config"
+ln -s "${bin_dir}" "${runtime_dir}/bin"
+ln -s "${lib_dir}" "${runtime_dir}/lib"
+
+for config_name in dummyUDP.json dummyUDP-fr.json dummyUDP-fp.json testUDP.json; do
+  sed "s|\\\${CMAKE_INSTALL_PREFIX}|${runtime_dir}|g" \
+    "${config_source_dir}/${config_name}" >"${runtime_dir}/test_config/${config_name}"
+done
+
+run_test \
+  "odinDataTest" \
+  "${bin_dir}/odinDataTest" \
+  "--json=${runtime_dir}/test_config/dummyUDP.json"
+
+if [[ ${#failed_tests[@]} -ne 0 ]]; then
+  echo
+  echo "${#failed_tests[@]} of ${test_count} test executables failed:"
+
+  for ((index = 0; index < ${#failed_tests[@]}; index++)); do
+    echo
+    echo "===== ${failed_tests[index]} (exit ${failed_statuses[index]}) ====="
+    cat "${failed_logs[index]}"
+  done
+
+  exit 1
+fi
+
+echo
+echo "All ${test_count} test executables passed."


### PR DESCRIPTION
This PR modernises the codebase somewhat. Some parts of this PR are somewhat modernising for modernising's sake (more on this in a sec) while other parts actually get benefits/compiler optimisation due to using more modern syntax/constructs. There were some (potentially unnecessary) modernising changes that were done to pass the full clang-tidy gate. The benefit of this is that going forward, it should hopefully reduce the surface area of bugs. Clang-tidy combined with warnings from CMake.

Blocked by #544 
Fixes #557 
