### PR TITLE
Add CMake Target to Build and Run All Tests

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.22)
 # Project name
 project(OdinData)
 
+include(CTest)
+
 include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
 setup_coverage()
 
@@ -183,3 +185,14 @@ add_subdirectory(${TEST_DIR})
 
 # Add the config subdirectory (config files used for integration testing)
 add_subdirectory(config)
+
+if (BUILD_TESTING)
+  get_property(ODINDATA_TEST_TARGETS GLOBAL PROPERTY ODINDATA_TEST_TARGETS)
+  add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --no-tests=error
+    DEPENDS ${ODINDATA_TEST_TARGETS}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    USES_TERMINAL
+    COMMENT "Running unit and integration tests"
+  )
+endif()

--- a/cpp/frameProcessor/test/CMakeLists.txt
+++ b/cpp/frameProcessor/test/CMakeLists.txt
@@ -7,6 +7,12 @@ function(add_unit_test _target)
   set(_target "unit_fp_${_target}")
   add_executable(${_target} ${_source})
 
+  if (BUILD_TESTING)
+    add_test(NAME ${_target} COMMAND ${_target} --log_level=test_suite)
+    set_tests_properties(${_target} PROPERTIES LABELS "unit;frameProcessor" TIMEOUT 120)
+    set_property(GLOBAL APPEND PROPERTY ODINDATA_TEST_TARGETS ${_target})
+  endif()
+
   target_link_libraries(${_target}
     ${LIB_PROCESSOR}
     DummyUDPProcessPlugin

--- a/cpp/frameReceiver/test/CMakeLists.txt
+++ b/cpp/frameReceiver/test/CMakeLists.txt
@@ -18,6 +18,12 @@ function(add_unit_test _target)
 
   add_executable(${_target} ${_source} ${RECEIVER_SRCS})
 
+  if (BUILD_TESTING)
+    add_test(NAME ${_target} COMMAND ${_target} --log_level=test_suite)
+    set_tests_properties(${_target} PROPERTIES LABELS "unit;frameReceiver" TIMEOUT 120)
+    set_property(GLOBAL APPEND PROPERTY ODINDATA_TEST_TARGETS ${_target})
+  endif()
+
   target_link_libraries(${_target}
     ${LIB_RECEIVER}
     DummyTCPFrameDecoder

--- a/cpp/test/integrationTest/config/CMakeLists.txt
+++ b/cpp/test/integrationTest/config/CMakeLists.txt
@@ -1,9 +1,29 @@
-# Copy files to build and substitute macros
-configure_file(dummyUDP.json .)
-configure_file(dummyUDP-fp.json .)
-configure_file(dummyUDP-fr.json .)
-configure_file(testUDP.json .)
+set(INTEGRATION_CONFIG_FILES
+  dummyUDP.json
+  dummyUDP-fp.json
+  dummyUDP-fr.json
+  testUDP.json
+)
 
-# Install files generated in build by above commands, *not* directly from source
-file(GLOB CONFIG_FILES ${CMAKE_CURRENT_BINARY_DIR}/*json)
-install(FILES ${CONFIG_FILES} DESTINATION test_config)
+function(configure_integration_test_file source output prefix)
+  set(CMAKE_INSTALL_PREFIX "${prefix}")
+  configure_file("${source}" "${output}")
+endfunction()
+
+# Generate one set for tests run from the build tree and one for installation.
+set(INSTALL_CONFIG_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/install")
+foreach(config_file IN LISTS INTEGRATION_CONFIG_FILES)
+  configure_integration_test_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${config_file}"
+    "${CMAKE_CONFIG_OUTPUT_DIRECTORY}/${config_file}"
+    "${CMAKE_BINARY_DIR}"
+  )
+  configure_integration_test_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${config_file}"
+    "${INSTALL_CONFIG_OUTPUT_DIRECTORY}/${config_file}"
+    "${CMAKE_INSTALL_PREFIX}"
+  )
+  list(APPEND INSTALL_CONFIG_FILES "${INSTALL_CONFIG_OUTPUT_DIRECTORY}/${config_file}")
+endforeach()
+
+install(FILES ${INSTALL_CONFIG_FILES} DESTINATION test_config)

--- a/cpp/test/integrationTest/src/CMakeLists.txt
+++ b/cpp/test/integrationTest/src/CMakeLists.txt
@@ -27,5 +27,24 @@ add_executable(frameTests ${FRAMETEST_SOURCES})
 target_link_libraries(odinDataTest ${Boost_LIBRARIES} ${HDF5_LIBRARIES} ${LOG4CXX_LIBRARIES} ${COMMON_LIBRARY})
 target_link_libraries(frameTests ${Boost_LIBRARIES} ${HDF5_LIBRARIES} ${LOG4CXX_LIBRARIES} ${COMMON_LIBRARY})
 
+if (BUILD_TESTING)
+  add_test(
+    NAME integration_dummy_udp
+    COMMAND odinDataTest --json=${CMAKE_CONFIG_OUTPUT_DIRECTORY}/dummyUDP.json
+  )
+  set_tests_properties(integration_dummy_udp PROPERTIES LABELS "integration" RUN_SERIAL TRUE TIMEOUT 120)
+  set_property(GLOBAL APPEND PROPERTY ODINDATA_TEST_TARGETS
+    odinDataTest
+    frameTests
+    frameReceiver
+    frameProcessor
+    frameSimulator
+    DummyUDPFrameDecoder
+    DummyUDPFrameSimulatorPlugin
+    DummyUDPProcessPlugin
+    Hdf5Plugin
+  )
+endif()
+
 install(TARGETS odinDataTest RUNTIME DESTINATION bin)
 install(TARGETS frameTests RUNTIME DESTINATION bin)


### PR DESCRIPTION
Add `CMake` target to build and run unit tests.

Fixes #488 